### PR TITLE
Resolve SageMaker CVEs

### DIFF
--- a/extensions/aissemble-extensions-model-training-api-sagemaker/pyproject.toml
+++ b/extensions/aissemble-extensions-model-training-api-sagemaker/pyproject.toml
@@ -16,7 +16,7 @@ pydantic = ">=1.8.0,<2.0.0"
 kubernetes = ">=26.1.0"
 urllib3 = "^1.26.18"
 krausening = ">=19"
-sagemaker = ">2.173.0, <=2.182.0"
+sagemaker = ">=2.218.0"
 mlflow = "^2.3.1"
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
Resolves CVE-2024-34072 and CVE-2024-34073 by upgrading SageMaker to >= 2.218.0.  There was previously an upper cap on the version that was ostensibly for Python 3.11.4 compatibility, but it looks like 2.218 supports Python 3.11.4.