### PR TITLE
#51 update kafka base image to bitnami

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,6 +68,7 @@ extensions/extensions-helm/aissemble-airflow-chart/values.yaml
 extensions/extensions-helm/aissemble-spark-operator-chart/values.yaml
 extensions/extensions-helm/aissemble-jenkins-chart/values.yaml
 extensions/extensions-helm/aissemble-mlflow-chart/values.yaml
+extensions/extensions-helm/aissemble-kafka-chart/values.yaml
 
 # The test project should test that we generate files that compile and have the expected structure for model options
 # there should not be any no custom logic added and we should clean up the project properly before each build

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -32,7 +32,6 @@
         <version.python>3.11.4</version.python>
         <version.help.plugin>3.2.0</version.help.plugin>
         <version.krausening>19</version.krausening>
-        <version.license.plugin>2.4.0</version.license.plugin>
         <version.plexus.archiver>3.6.0</version.plexus.archiver>
         <version.plugin.plugin>3.9.0</version.plugin.plugin>
         <version.quarkus>2.8.3.Final</version.quarkus>
@@ -880,7 +879,6 @@ To suppress enforce-helm-version rule, you must add following plugin to the root
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>license-maven-plugin</artifactId>
-                <version>${version.license.plugin}</version>
             </plugin>
 
             <!-- Set properties containing the scm revision -->

--- a/extensions/extensions-docker/aissemble-kafka/src/main/resources/docker/Dockerfile
+++ b/extensions/extensions-docker/aissemble-kafka/src/main/resources/docker/Dockerfile
@@ -1,33 +1,25 @@
 #Script for creating base Kafka Docker image
-FROM wurstmeister/kafka:2.13-2.7.2
+FROM bitnami/kafka:3.5
 
 LABEL org.opencontainers.image.source = "https://github.com/boozallen/aissemble"
 
+USER root
 RUN apt-get update -y \
     && apt-get install unzip \
     && rm -rf /var/lib/apt/lists/* \
     && apt-get clean
 
-RUN adduser --system --shell /bin/bash --no-create-home --uid 1001 --ingroup root --disabled-login kafka && \
-chown -R kafka:root /opt/kafka && \
-chown -hLR kafka:root /opt/kafka_2.13-2.7.2 && \
-chown -R kafka:root /usr/bin/*.sh
-
+RUN addgroup --gid 1001 kafka && adduser --system --uid 1001 --gid 1001 kafka
 RUN mkdir /opt/connectors && \
-    chown -R kafka:root /opt/connectors
+    chown -R kafka:kafka /opt/connectors && \
+    chown -R kafka:kafka /opt/bitnami/kafka
 
 USER kafka
 # Install kafka-connect-spooldir plugin that can be used with Kafka Connect to read CSV data into topics
-RUN wget https://d1i4a15mxbxib1.cloudfront.net/api/plugins/jcustenborder/kafka-connect-spooldir/versions/2.0.62/jcustenborder-kafka-connect-spooldir-2.0.62.zip \
-    -P /opt/connectors
-RUN unzip /opt/connectors/jcustenborder-kafka-connect-spooldir-2.0.62.zip -d /opt/connectors
+RUN curl -slLO https://d1i4a15mxbxib1.cloudfront.net/api/plugins/jcustenborder/kafka-connect-spooldir/versions/2.0.62/jcustenborder-kafka-connect-spooldir-2.0.62.zip \
+    --output-dir /opt/connectors && \
+    unzip /opt/connectors/jcustenborder-kafka-connect-spooldir-2.0.62.zip -d /opt/connectors && \
+    rm /opt/connectors/jcustenborder-kafka-connect-spooldir-2.0.62.zip
 
 # Copy over configs
-COPY ./src/main/resources/config/ /opt/kafka/config/
-
-# Base image creates a volume mount point at /kafka so any changes to that directory do not persist.
-# Because volumes can only be mounted as root, we can't use that directory for our logs and run the container
-# as a non-root user. In scenarios where persistence is important, this log should be configured to write
-# to an external source or a persistent volume.
-ENV KAFKA_LOG_DIRS=/opt/kafka/logs
-USER kafka
+COPY ./src/main/resources/config/ /opt/bitnami/kafka/config/

--- a/extensions/extensions-helm/aissemble-airflow-chart/pom.xml
+++ b/extensions/extensions-helm/aissemble-airflow-chart/pom.xml
@@ -15,31 +15,9 @@
 
     <build>
         <plugins>
-            <!-- The airflow subchart defaults to setting the image tag to the airflow version -->
-            <!-- We use a template here to ease release maintenance.  -->
             <plugin>
                 <groupId>com.google.code.maven-replacer-plugin</groupId>
                 <artifactId>replacer</artifactId>
-                <version>1.5.3</version>
-                <executions>
-                    <execution>
-                        <phase>process-sources</phase>
-                        <goals>
-                            <goal>replace</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <configuration>
-                    <basedir>${project.basedir}</basedir>
-                    <file>values.template.yaml</file>
-                    <outputFile>values.yaml</outputFile>
-                    <replacements>
-                        <replacement>
-                            <token>@version.aissemble@</token>
-                            <value>${project.version}</value>
-                        </replacement>
-                    </replacements>
-                </configuration>
             </plugin>
             <plugin>
                 <groupId>${group.helm.plugin}</groupId>

--- a/extensions/extensions-helm/aissemble-jenkins-chart/pom.xml
+++ b/extensions/extensions-helm/aissemble-jenkins-chart/pom.xml
@@ -15,31 +15,9 @@
 
     <build>
         <plugins>
-            <!-- The jenkins subchart defaults to setting the image tag to its own version  -->
-            <!-- We use a template here to ease release maintenance.  -->
             <plugin>
                 <groupId>com.google.code.maven-replacer-plugin</groupId>
                 <artifactId>replacer</artifactId>
-                <version>1.5.3</version>
-                <executions>
-                    <execution>
-                        <phase>process-sources</phase>
-                        <goals>
-                            <goal>replace</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <configuration>
-                    <basedir>${project.basedir}</basedir>
-                    <file>values.template.yaml</file>
-                    <outputFile>values.yaml</outputFile>
-                    <replacements>
-                        <replacement>
-                            <token>@version.aissemble@</token>
-                            <value>${project.version}</value>
-                        </replacement>
-                    </replacements>
-                </configuration>
             </plugin>
             <plugin>
                 <groupId>${group.helm.plugin}</groupId>

--- a/extensions/extensions-helm/aissemble-kafka-chart/Chart.yaml
+++ b/extensions/extensions-helm/aissemble-kafka-chart/Chart.yaml
@@ -10,5 +10,5 @@ sources:
   - https://github.com/boozallen/aissemble
 dependencies:
   - name: kafka
-    version: 22.1.2
+    version: 23.0.7
     repository: https://charts.bitnami.com/bitnami

--- a/extensions/extensions-helm/aissemble-kafka-chart/pom.xml
+++ b/extensions/extensions-helm/aissemble-kafka-chart/pom.xml
@@ -16,6 +16,10 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>com.google.code.maven-replacer-plugin</groupId>
+                <artifactId>replacer</artifactId>
+            </plugin>
+            <plugin>
                 <groupId>${group.helm.plugin}</groupId>
                 <artifactId>helm-maven-plugin</artifactId>
             </plugin>

--- a/extensions/extensions-helm/aissemble-kafka-chart/values.template.yaml
+++ b/extensions/extensions-helm/aissemble-kafka-chart/values.template.yaml
@@ -2,6 +2,10 @@
 ## CONFIG | Kafka Configs
 ########################################
 kafka:
+  image:
+    registry: ghcr.io
+    repository: boozallen/aissemble-kafka
+    tag: "@version.aissemble@"
   fullnameOverride: kafka-cluster
   # Container Ports Configuration
   containerPorts:

--- a/extensions/extensions-helm/aissemble-mlflow-chart/pom.xml
+++ b/extensions/extensions-helm/aissemble-mlflow-chart/pom.xml
@@ -15,31 +15,9 @@
 
     <build>
         <plugins>
-            <!-- The mlflow subchart defaults to setting the image tag to bitnami's image tag.  -->
-            <!-- We use a template here to ease release maintenance.  -->
             <plugin>
                 <groupId>com.google.code.maven-replacer-plugin</groupId>
                 <artifactId>replacer</artifactId>
-                <version>1.5.3</version>
-                <executions>
-                    <execution>
-                        <phase>process-sources</phase>
-                        <goals>
-                            <goal>replace</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <configuration>
-                    <basedir>${project.basedir}</basedir>
-                    <file>values.template.yaml</file>
-                    <outputFile>values.yaml</outputFile>
-                    <replacements>
-                        <replacement>
-                            <token>@version.aissemble@</token>
-                            <value>${project.version}</value>
-                        </replacement>
-                    </replacements>
-                </configuration>
             </plugin>
             <plugin>
                 <groupId>${group.helm.plugin}</groupId>

--- a/extensions/extensions-helm/aissemble-spark-operator-chart/pom.xml
+++ b/extensions/extensions-helm/aissemble-spark-operator-chart/pom.xml
@@ -15,31 +15,9 @@
 
     <build>
         <plugins>
-            <!-- The spark-operator subchart defaults to setting the image tag to its appVersion.  -->
-            <!-- We use a template here to ease release maintenance.  -->
             <plugin>
                 <groupId>com.google.code.maven-replacer-plugin</groupId>
                 <artifactId>replacer</artifactId>
-                <version>1.5.3</version>
-                <executions>
-                    <execution>
-                        <phase>process-sources</phase>
-                        <goals>
-                            <goal>replace</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <configuration>
-                    <basedir>${project.basedir}</basedir>
-                    <file>values.template.yaml</file>
-                    <outputFile>values.yaml</outputFile>
-                    <replacements>
-                        <replacement>
-                            <token>@version.aissemble@</token>
-                            <value>${project.version}</value>
-                        </replacement>
-                    </replacements>
-                </configuration>
             </plugin>
             <plugin>
                 <groupId>${group.helm.plugin}</groupId>

--- a/extensions/extensions-helm/pom.xml
+++ b/extensions/extensions-helm/pom.xml
@@ -210,6 +210,31 @@
                         </execution>
                     </executions>
                 </plugin>
+                <!-- Allows us to replace image tags with the aissemble version without manual updates to values.yaml -->
+                <plugin>
+                    <groupId>com.google.code.maven-replacer-plugin</groupId>
+                    <artifactId>replacer</artifactId>
+                    <version>1.5.3</version>
+                    <executions>
+                        <execution>
+                            <phase>process-sources</phase>
+                            <goals>
+                                <goal>replace</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                    <configuration>
+                        <basedir>${project.basedir}</basedir>
+                        <file>values.template.yaml</file>
+                        <outputFile>values.yaml</outputFile>
+                        <replacements>
+                            <replacement>
+                                <token>@version.aissemble@</token>
+                                <value>${project.version}</value>
+                            </replacement>
+                        </replacements>
+                    </configuration>
+                </plugin>
             </plugins>
         </pluginManagement>
         <plugins>

--- a/foundation/foundation-maven-plugins/artifacts-maven-plugin/pom.xml
+++ b/foundation/foundation-maven-plugins/artifacts-maven-plugin/pom.xml
@@ -98,7 +98,6 @@
         <dependency>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-dependency-plugin</artifactId>
-            <version>${version.maven.dependency.plugin}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/foundation/foundation-maven-plugins/mda-maven-plugin/pom.xml
+++ b/foundation/foundation-maven-plugins/mda-maven-plugin/pom.xml
@@ -63,7 +63,6 @@
         <dependency>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-dependency-plugin</artifactId>
-            <version>${version.maven.dependency.plugin}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.boozallen.aissemble</groupId>
         <artifactId>aissemble-parent</artifactId>
-        <version>2</version>
+        <version>3</version>
     </parent>
 
     <artifactId>aissemble-root</artifactId>


### PR DESCRIPTION
Updates the base image for the aissemble-kafka image from wurstmeister kafka to bitnami/kafka:3.5.  The bitnami image was selected because our helm chart, aissemble-kafka-chart, is based on the bitnami kafka chart. The version 3.5 was chosen over the newer 3.7 version image because there was a major refactor to bitnami's chart in chart version 24.0 that would have required a significant refactor and testing to our chart to upgrade beyond. Instead I updated to the last compatible version of the chart, 23.0.7, which was based on the 3.5 image.