### PR TITLE
49-downstream-maven-publishing-repo

### DIFF
--- a/DRAFT_RELEASE_NOTES.md
+++ b/DRAFT_RELEASE_NOTES.md
@@ -150,6 +150,19 @@ plugin in *-deploy/pom.xml. This can be achieved with:
 sed -i'' -e '/version.clean.plugin/d' *-deploy/pom.xml
 ```
 
+### Update Maven Repository Configuration
+Update the following properties in your project's root `pom.xml` file with the appropriate Maven repository IDs and URLs 
+for publishing and retrieving releases and snapshots. Adjust for your project as appropriate:
+```xml
+<properties>
+    ...
+    <maven.repo.id>maven-releases</maven.repo.id>
+    <maven.repo.url>https://release-PLACEHOLDER/repository/maven-releases</maven.repo.url>
+    <maven.snapshot.repo.id>maven-snapshots</maven.snapshot.repo.id>
+    <maven.snapshot.repo.url>https://snapshot-PLACEHOLDER/repository/maven-snapshots</maven.snapshot.repo.url>
+</properties>
+```
+
 ## Conditional Steps
 
 ### Upgrade Steps for Projects Leveraging Data Lineage

--- a/docs/modules/ROOT/pages/archetype.adoc
+++ b/docs/modules/ROOT/pages/archetype.adoc
@@ -81,6 +81,37 @@ General pattern: ``<internet domain name in reverse>.<your area name>``
 
 | Yes
 
+| ``licenseName``
+| The name of the license to use in the project
+| Defaults to Booz Allen's "closed-source-license" but can be updated to a
+https://github.com/boozallen/booz-allen-maven-licenses[Booz Allen license,role=external,window=_blank] or any license
+under mvn license:license-list
+|
+* booz-allen-public-license
+* agpl_v3
+
+| No
+
+| ``mavenRepositoryUrl``
+|  The URL of the Maven repository where the release artifacts of the project will be deployed.
+| Defaults to "https://release-PLACEHOLDER/repository/maven-releases" and can be updated in the `<properties>` section
+of the root `pom.xml`
+|
+* https://nexus.mydomain.com/repository/maven-releases/
+* https://artifactory.mydomain.com/artifactory/libs-release-local
+
+| No
+
+| ``mavenSnapshotRepositoryUrl``
+|  The URL of the Maven repository where the snapshot artifacts of the project will be deployed.
+| Defaults to "https://snapshot-PLACEHOLDER/repository/maven-snapshots" and can be updated in the `<properties>` section
+of the root `pom.xml`
+|
+* https://nexus.mydomain.com/repository/maven-snapshots/
+* https://artifactory.mydomain.com/artifactory/libs-snapshot-local
+
+| No
+
 | ``package``
 | The package name in which JVM-based source code will be placed
 | Defaults to your ``groupId`` value, which is almost always the right decision, so just select enter to accept this
@@ -92,17 +123,6 @@ default
 | General description of your project
 | Default to "Project that contains aiSSEMBLE compliant pipeline(s)"
 |
-| No
-
-| ``licenseName``
-| The name of the license to use in the project
-| Defaults to Booz Allen's "closed-source-license" but can be updated to a
-https://github.com/boozallen/booz-allen-maven-licenses[Booz Allen license,role=external,window=_blank] or any license
-under mvn license:license-list
-|
-* booz-allen-public-license
-* agpl_v3
-
 | No
 
 | ``projectGitUrl``

--- a/foundation/foundation-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/foundation/foundation-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -36,6 +36,12 @@
 		<requiredProperty key="licenseName">
 			<defaultValue>closed-source-license</defaultValue>
 		</requiredProperty>
+		<requiredProperty key="mavenRepositoryUrl">
+			<defaultValue>https://release-PLACEHOLDER/repository/maven-releases</defaultValue>
+		</requiredProperty>
+		<requiredProperty key="mavenSnapshotRepositoryUrl">
+			<defaultValue>https://snapshot-PLACEHOLDER/repository/maven-snapshots</defaultValue>
+		</requiredProperty>
 	</requiredProperties>
 
 	<fileSets>

--- a/foundation/foundation-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/foundation/foundation-archetype/src/main/resources/archetype-resources/pom.xml
@@ -34,6 +34,14 @@
         <module>${artifactId}-shared</module>
     </modules>
 
+    <properties>
+        <!-- Maven Repos -->
+        <maven.repo.id>maven-releases</maven.repo.id>
+        <maven.repo.url>${mavenRepositoryUrl}</maven.repo.url>
+        <maven.snapshot.repo.id>maven-snapshots</maven.snapshot.repo.id>
+        <maven.snapshot.repo.url>${mavenSnapshotRepositoryUrl}</maven.snapshot.repo.url>
+    </properties>
+
     <dependencyManagement>
         <dependencies>
             <dependency>
@@ -59,6 +67,40 @@
         <url>${projectGitUrl}</url>
         <tag>HEAD</tag>
     </scm>
+
+    <distributionManagement>
+        <!-- The repositories that the maven artifacts will be deployed
+		to. The credentials for the repository must be provided in the Maven
+		settings.xml file. The repository/snapshotRepository id below should
+		match the serverId in the settings.xml -->
+        <repository>
+            <id>${maven.repo.id}</id>
+            <url>${maven.repo.url}</url>
+        </repository>
+        <snapshotRepository>
+            <id>${maven.snapshot.repo.id}</id>
+            <url>${maven.snapshot.repo.url}</url>
+        </snapshotRepository>
+    </distributionManagement>
+
+    <repositories>
+        <repository>
+            <id>${maven.repo.id}</id>
+            <url>${maven.repo.url}</url>
+            <releases>
+                <enabled>true</enabled>
+                <checksumPolicy>fail</checksumPolicy>
+            </releases>
+        </repository>
+        <repository>
+            <id>${maven.snapshot.repo.id}</id>
+            <url>${maven.snapshot.repo.url}</url>
+            <snapshots>
+                <enabled>true</enabled>
+                <checksumPolicy>fail</checksumPolicy>
+            </snapshots>
+        </repository>
+    </repositories>
 
     <build>
         <extensions>


### PR DESCRIPTION
Added functionality to set maven publishing repos (releases and snapshots) in downstream projects of aissemble.

- Publishing repo urls were added as `requiredProperties`. They can either be updated in the project creation (by selecting "n" when confirming and overriding the defaults) or by updating them in the `<properties>` section of the root pom in the downstream project.
- Updated docs with `mavenPublishingRepoUrl` and `mavenSnapshotPublishingRepoUrl` fields