### PR TITLE
 #84 Set Helm publishing repo for downstream projects

### DIFF
--- a/DRAFT_RELEASE_NOTES.md
+++ b/DRAFT_RELEASE_NOTES.md
@@ -70,6 +70,7 @@ Note instructions for adapting to these changes are outlined in the upgrade inst
 * The maven property `version.clean.plugin` was changed to `version.maven.clean.plugin` causing the `*-deploy/pom.xml` 
   to be invalid
 * The specification of private PyPI repositories has been changed from prior releases.
+* The specification of Helm publishing repositories has been changed from prior releases.
 * The Kafka home directory in the **aissemble-kafka** image has changed from _/opt/kafka_ to _/opt/bitnami/kafka_
 
 # Known Issues
@@ -188,6 +189,49 @@ in this example - adjust for your project, as appropriate):
   </build>
 
 ```
+### Add the Helm Publishing Repository Configuration
+Add the following `property` into your project's root `pom.xml` file with the appropriate Helm repository URL and name you wish to publish your charts to (Nexus is used in this example - adjust for your project, as appropriate):
+
+```xml
+  <properties>
+    ...
+    <helm.publishing.repository.url>https://nexus.mydomain.com/repository</helm.publishing.repository.url>
+    <helm.publishing.repository.name>my-helm-charts</helm.publishing.repository.name>
+</properties>
+
+```
+Update the following `plugin` within your project's `-deploy/pom.xml` file. Adjust for your project as appropriate:
+```xml
+<plugin>
+    <groupId>${group.helm.plugin}</groupId>
+    <artifactId>helm-maven-plugin</artifactId>
+    <executions>
+        ...
+        <execution>
+            <id>deploy</id>
+            <phase>deploy</phase>
+            <goals>
+                <goal>push</goal>
+            </goals>
+        </execution>
+    </executions>
+    <configuration>
+        ...
+        <uploadRepoStable>
+            <name>${helm.publishing.repository.name}</name>
+            <url>${helm.publishing.repository.url}</url>
+        </uploadRepoStable>
+        <uploadRepoSnapshot>
+            <name>${helm.publishing.repository.name}</name>
+            <url>${helm.publishing.repository.url}</url>
+        </uploadRepoSnapshot>
+        ...
+    </configuration>
+</plugin>
+
+```
+For further configurations that can be set for your specific Helm repository needs, please see the [helm-maven-plugin documentation](https://github.com/kokuwaio/helm-maven-plugin?tab=readme-ov-file)
+
 
 ## Conditional Steps
 

--- a/docs/modules/ROOT/pages/archetype.adoc
+++ b/docs/modules/ROOT/pages/archetype.adoc
@@ -180,6 +180,34 @@ If not specified, this will default to `https://pypi-PLACEHOLDER/repository/` an
 * `https://pypi.org`
 
 | No
+| `helmPublishingRepositoryUrl`
+| The URL of the Helm repository you plan to publish your Helm charts to for this project.
+| Should be used if you intend to publish your project's Helm charts to a private repository,
+such as Nexus or ghcr.io.
+
+Please see https://github.com/kokuwaio/helm-maven-plugin?tab=readme-ov-file#helm-maven-plugin[helm-maven-plugin documentation,role=external,window=_blank], to view further configurations that can be set for your Helm repository specifications.
+
+If not specified, this will default to `https://helm-PLACEHOLDER/repository` and will need to be updated in your root
+`pom.xml` file prior to pushing your Helm charts to a repository.
+|
+* `https://nexus.mydomain.com/repository`
+* `https://ghcr.io/mydomain/repository`
+
+| No
+| `helmPublishingRepositoryName`
+| The name of the Helm repository you plan to publish your Helm charts to for this project.
+| Should be used if you intend to publish your project's Helm charts to a private repository,
+such as Nexus or ghcr.io.
+
+Please see https://github.com/kokuwaio/helm-maven-plugin?tab=readme-ov-file#helm-maven-plugin[helm-maven-plugin documentation,role=external,window=_blank], to view further configurations that can be set for your Helm repository specifications..
+
+If not specified, this will default to `PLACEHOLDER-helm` and will need to be updated in your root
+`pom.xml` file prior to pushing your Helm charts to a repository.
+|
+*`my-helm-charts`*
+
+| No
+
 
 |===
 

--- a/foundation/foundation-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/foundation/foundation-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -45,6 +45,12 @@
 		<requiredProperty key="pypiProjectRepositoryUrl">
 			<defaultValue>https://pypi-PLACEHOLDER/repository/</defaultValue>
 		</requiredProperty>
+		<requiredProperty key="helmPublishingRepositoryUrl">
+			<defaultValue>https://helm-PLACEHOLDER/repository</defaultValue>
+		</requiredProperty>
+		<requiredProperty key="helmPublishingRepositoryName">
+			<defaultValue>PLACEHOLDER-helm</defaultValue>
+		</requiredProperty>
 	</requiredProperties>
 
 	<fileSets>

--- a/foundation/foundation-archetype/src/main/resources/archetype-resources/__rootArtifactId__-deploy/pom.xml
+++ b/foundation/foundation-archetype/src/main/resources/archetype-resources/__rootArtifactId__-deploy/pom.xml
@@ -97,9 +97,24 @@
                             <goal>dependency-update</goal>
                         </goals>
                     </execution>
+                    <execution>
+                        <id>deploy</id>
+                        <phase>deploy</phase>
+                        <goals>
+                            <goal>push</goal>
+                        </goals>
+                    </execution>
                 </executions>
                 <configuration>
                     <chartDirectory>${project.basedir}/src/main/resources/apps</chartDirectory>
+                    <uploadRepoStable>
+                        <name>${helm.publishing.repository.name}</name>
+                        <url>${helm.publishing.repository.url}</url>
+                    </uploadRepoStable>
+                    <uploadRepoSnapshot>
+                        <name>${helm.publishing.repository.name}</name>
+                        <url>${helm.publishing.repository.url}</url>
+                    </uploadRepoSnapshot>
                     <helmExtraRepos>
                         <helmRepo>
                             <name>ghcr.io</name>

--- a/foundation/foundation-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/foundation/foundation-archetype/src/main/resources/archetype-resources/pom.xml
@@ -41,6 +41,8 @@
         <maven.snapshot.repo.id>maven-snapshots</maven.snapshot.repo.id>
         <maven.snapshot.repo.url>${mavenSnapshotRepositoryUrl}</maven.snapshot.repo.url>
         <pypi.project.repository.url>${pypiProjectRepositoryUrl}</pypi.project.repository.url>
+        <helm.publishing.repository.url>${helmPublishingRepositoryUrl}</helm.publishing.repository.url>
+        <helm.publishing.repository.name>${helmPublishingRepositoryName}</helm.publishing.repository.name>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
- allow downstream users to set helm publishing repo name and URL during project creation
- update documentation and release notes