### PR TITLE
#123 Fix NPE when running in Tests module

### DIFF
--- a/foundation/foundation-mda/src/main/resources/templates/deployment/argocd/v2/sealed.secret.yaml.vm
+++ b/foundation/foundation-mda/src/main/resources/templates/deployment/argocd/v2/sealed.secret.yaml.vm
@@ -1,6 +1,6 @@
 # Convert this to a SealedSecret using kubeseal and replace it here
-# See our guide for using SealedSecret's in your project to learn more:
-# TODO: LINK-TO-GUIDE-HERE
+### See our guide for using SealedSecret's in your project to learn more:
+## TODO: LINK-TO-GUIDE-HERE
 
 apiVersion: v1
 kind: Secret

--- a/foundation/foundation-upgrade/src/test/java/com/boozallen/aissemble/upgrade/migration/v1_7_0/SparkAppExecMigrationSteps.java
+++ b/foundation/foundation-upgrade/src/test/java/com/boozallen/aissemble/upgrade/migration/v1_7_0/SparkAppExecMigrationSteps.java
@@ -19,12 +19,18 @@ import org.apache.commons.io.FileUtils;
 import java.io.File;
 import java.io.IOException;
 
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 public class SparkAppExecMigrationSteps extends AbstractMigrationTest  {
     @Given("a pipeline pom file with one or more helm template commands using the aissemble-spark-application chart")
     public void aPipelinePomFileWithOneOrMoreHelmTemplateCommandsUsingTheAissembleSparkApplicationChart() {
         testFile = getTestFile("v1_7_0/SparkAppExecMigration/migration/pom.xml");
+    }
+
+    @Given("a tests module POM with no build section")
+    public void aTestsModulePOMWithNoBuildSection() {
+        testFile = getTestFile("v1_7_0/SparkAppExecMigration/migration/tests-pom.xml");
     }
 
     @When("the 1.7.0 spark app exec migration executes")
@@ -41,5 +47,10 @@ public class SparkAppExecMigrationSteps extends AbstractMigrationTest  {
 
         assertTrue("Migrated file does not match expected output",
                 FileUtils.contentEqualsIgnoreEOL(migratedFile, validationFile, null));
+    }
+
+    @Then("the tests module POM is not updated")
+    public void theTestsModulePOMIsNotUpdated() {
+        assertFalse("File migration was incorrectly executed", shouldExecute);
     }
 }

--- a/foundation/foundation-upgrade/src/test/resources/specifications/v1_7_0/spark-application-exec-migration.feature
+++ b/foundation/foundation-upgrade/src/test/resources/specifications/v1_7_0/spark-application-exec-migration.feature
@@ -5,3 +5,8 @@ Feature: Spark App Exec Migration
     Given a pipeline pom file with one or more helm template commands using the aissemble-spark-application chart
     When the 1.7.0 spark app exec migration executes
     Then the pom is updated to use the aissemble-spark-application-chart from the fully qualified URL
+
+  Scenario: Tests module POM is skipped
+    Given a tests module POM with no build section
+    When the 1.7.0 spark app exec migration executes
+    Then the tests module POM is not updated

--- a/foundation/foundation-upgrade/src/test/resources/test-files/v1_7_0/SparkAppExecMigration/migration/tests-pom.xml
+++ b/foundation/foundation-upgrade/src/test/resources/test-files/v1_7_0/SparkAppExecMigration/migration/tests-pom.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  aiSSEMBLE::Foundation::Upgrade
+  %%
+  Copyright (C) 2021 Booz Allen
+  %%
+  This software package is licensed under the Booz Allen Public License. All Rights Reserved.
+  #L%
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.test</groupId>
+        <artifactId>test</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>test-tests</artifactId>
+    <name>Test::Tests</name>
+    <description>Integration tests for Test</description>
+
+    <packaging>pom</packaging>
+
+    <properties>
+        <!-- Kubernetes Java Client version -->
+        <kubernetes.client.version>6.0.0</kubernetes.client.version>
+    </properties>
+
+    <modules>
+        <module>test-tests-java</module>
+        <module>test-tests-docker</module>
+        <module>test-tests-helm</module>
+    </modules>
+</project>


### PR DESCRIPTION
~Now that downstream projects have the build cache enabled by default, our archetype test isn't always catching and testing new changes to the underlying dependencies. In this case, the baton migrations were cached and so were skipped, giving the impression that the new migration was functioning correctly when it just hadn't been tested. To fix this, the test script has been updated to disable the build cache for the final build of the archetype test.~