### PR TITLE
 #154 Initial Baton migration for Orphedomos to Fabric8 docker-maven-…

### DIFF
--- a/DRAFT_RELEASE_NOTES.md
+++ b/DRAFT_RELEASE_NOTES.md
@@ -51,6 +51,7 @@ To reduce burden of upgrading aiSSEMBLE, the Baton project is used to automate t
 | upgrade-v2-chart-files-aissemble-version-migration         | Updates the helm chart dependencies within your project's deployment resources (<YOUR_PROJECT>-deploy/src/main/resources/apps/) to use the latest version of the aiSSEMBLE                                                                             |
 | upgrade-v1-chart-files-aissemble-version-migration         | Updates the docker image tags within your project's deployment resources (<YOUR_PROJECT>-deploy/src/main/resources/apps/) to use the latest version of the aiSSEMBLE                                                                                   |
 | python-linting-migration                              | Updates Habushu configuration in root pom.xml to disable build failures when linting issues are detected |
+| orphedomos-to-fabric8-migration | Updates `orphedomos-maven-plugin` usages to leverage fabric8's `docker-maven-plugin`|
 
 To deactivate any of these migrations, add the following configuration to the `baton-maven-plugin` within your root `pom.xml`:
 

--- a/foundation/foundation-upgrade/src/main/java/com/boozallen/aissemble/upgrade/migration/v1_8_0/OrphedomosToFabric8Migration.java
+++ b/foundation/foundation-upgrade/src/main/java/com/boozallen/aissemble/upgrade/migration/v1_8_0/OrphedomosToFabric8Migration.java
@@ -1,0 +1,288 @@
+package com.boozallen.aissemble.upgrade.migration.v1_8_0;
+
+/*-
+ * #%L
+ * aiSSEMBLE::Foundation::Upgrade
+ * %%
+ * Copyright (C) 2021 Booz Allen
+ * %%
+ * This software package is licensed under the Booz Allen Public License. All Rights Reserved.
+ * #L%
+ */
+import com.boozallen.aissemble.upgrade.migration.AbstractAissembleMigration;
+import com.boozallen.aissemble.upgrade.util.pom.LocationAwareMavenReader;
+import org.apache.maven.model.Build;
+import org.technologybrewery.baton.util.FileUtils;
+import com.boozallen.aissemble.upgrade.util.pom.PomHelper;
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.maven.model.InputLocation;
+import org.apache.maven.model.Model;
+import org.apache.maven.model.Plugin;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import com.boozallen.aissemble.upgrade.util.pom.PomModifications;
+import org.codehaus.plexus.util.xml.Xpp3Dom;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.technologybrewery.baton.BatonException;
+
+import static com.boozallen.aissemble.upgrade.util.pom.PomHelper.getLocationAnnotatedModel;
+import static com.boozallen.aissemble.upgrade.util.pom.PomHelper.writeModifications;
+
+import static org.technologybrewery.baton.util.FileUtils.getRegExCaptureGroups;
+
+/**
+ * This migration is responsible for migrating pom files using Orphedomos to use the Fabric8 docker-maven-plugin.
+ */
+
+public class OrphedomosToFabric8Migration extends AbstractAissembleMigration{
+    private static final Logger logger = LoggerFactory.getLogger(OrphedomosToFabric8Migration.class);
+    private static final String ORPHEDOMOS_GROUP_ID = "org.technologybrewery.orphedomos";
+    private static final String ORPHEDOMOS_ARTIFACT_ID = "orphedomos-maven-plugin";
+    private static final String FABRIC8_GROUP_ID = "io.fabric8";
+    private static final String FABRIC8_ARTIFACT_ID = "docker-maven-plugin";
+    private static final String EXTRACT_PACKAGING_REGEX = "(<packaging>)orphedomos(<\\/packaging>)";
+    private static final String SECOND_REGEX_GROUPING = "$2";
+    private static final String ROOT_ARTIFACT_ID = "build-parent";
+    private static final String ROOT_GROUP_ID = "com.boozallen.aissemble";
+    private static final String TESTS_DOCKER_PARENT_ARTIFACT_ID = "-tests";
+    private static final String TESTS_DOCKER_ARTIFACT_ID = "-tests-docker";
+    private static final String GROUP_ID = "groupId";
+    private static final String ARTIFACT_ID = "artifactId";
+    private static final String VERSION = "version";
+    private static final String CONFIGURATION = "configuration";
+    private static final String IMAGE_NAME = "imageName";
+    private static final String IMAGE_VERSION = "imageVersion";
+    private static String imageName;
+    private static String imageVersion;
+
+    /**
+     * Function that returns instance of Plugin class with name equal to the pluginName provided
+     * @param model the model to check
+     * @param pluginName the name of the plugin
+     * @return Plugin with the plugin name specified
+     */
+    private Plugin getPlugin(Model model, String pluginName) {
+        Build build = model.getBuild();
+        if (build != null) {
+            List<Plugin> plugins = build.getPlugins();
+            for (Plugin plugin : plugins) {
+                if ((pluginName).equalsIgnoreCase(plugin.getArtifactId())) {
+                    return plugin;
+                }
+            }
+        }
+        return null;
+    }
+
+    private boolean isRootProjectPom(Model model) {
+        return ROOT_GROUP_ID.equals(model.getParent().getGroupId()) && ROOT_ARTIFACT_ID.equals(model.getParent().getArtifactId());
+    }
+    private boolean isTestDockerPom(Model model){
+        return model.getParent().getArtifactId().endsWith(TESTS_DOCKER_PARENT_ARTIFACT_ID) && model.getArtifactId().endsWith(TESTS_DOCKER_ARTIFACT_ID);
+    }
+
+    private Xpp3Dom getConfiguration(Plugin plugin) {
+        Object pluginConfiguration = plugin.getConfiguration();
+        return (Xpp3Dom) pluginConfiguration;
+    }
+
+    private static boolean hasConfigurationItem(Xpp3Dom configuration, String configurationItem){
+        return configuration.getChildren(configurationItem).length > 0;
+    }
+
+    /**
+     * Function to validate whether migration should be performed or not.
+     * @param file file to validate
+     * @return true if migration should be performed
+     */
+    @Override
+    protected boolean shouldExecuteOnFile(File file) {
+        boolean shouldExecute = false;
+        boolean migrateConfiguration = false;
+        boolean migratePackaging = false;
+
+        Model model = getLocationAnnotatedModel(file);
+        if (isRootProjectPom(model) || isTestDockerPom(model)){
+            shouldExecute = false;
+        } else {
+            Plugin orphedomosPlugin = getPlugin(model, ORPHEDOMOS_ARTIFACT_ID);
+            if (orphedomosPlugin != null){
+                migrateConfiguration = true;
+            }
+            if(containsOrphedomosPackaging(file)){
+                migratePackaging = true;
+            }
+            shouldExecute = migrateConfiguration || migratePackaging;
+        }
+
+        return shouldExecute;
+    }
+
+    /**
+     * Performs the migration if the shouldExecuteOnFile() returns true
+     * @param file file to migrate
+     * @return isSuccessful - whether file was migrated successfully or not
+     */
+    @Override
+    protected boolean performMigration(File file) {
+        Model model = getLocationAnnotatedModel(file);
+        Plugin plugin = getPlugin(model, ORPHEDOMOS_ARTIFACT_ID);
+        boolean replacedConfig = false;
+        boolean replacedPackaging = false;
+        boolean isSuccessful = false;
+
+        Xpp3Dom config;
+
+        if (plugin != null){
+            config = getConfiguration(plugin);
+        } else {
+            config = null;
+            logger.info("Orphedomos plugin configuration not found. Skipping configuration migration.");
+        }
+
+        // check if pom file has orphedomos-maven-plugin configuration
+        if (config != null){
+            // grab the old imageVersion and imageName
+            imageVersion = getImageVersion(config);
+            imageName = getImageName(config);
+
+            // Replace groupID and artifactID
+            PomModifications modifyPlugin = new PomModifications();
+            InputLocation startGroupId = plugin.getLocation(GROUP_ID);
+            InputLocation endGroupId = PomHelper.incrementColumn(startGroupId, ORPHEDOMOS_GROUP_ID.length());
+
+            InputLocation startArtifactId = plugin.getLocation(ARTIFACT_ID);
+            InputLocation endArtifactId = PomHelper.incrementColumn(startArtifactId, ORPHEDOMOS_ARTIFACT_ID.length());
+
+            modifyPlugin.add(new PomModifications.Replacement(startGroupId, endGroupId, FABRIC8_GROUP_ID));
+            modifyPlugin.add(new PomModifications.Replacement(startArtifactId, endArtifactId, FABRIC8_ARTIFACT_ID));
+
+            writeModifications(file, modifyPlugin.finalizeMods());
+
+            Model updatedModel = getLocationAnnotatedModel(file);
+            Plugin updatedPlugin = getPlugin(updatedModel, FABRIC8_ARTIFACT_ID);
+
+            if (imageVersion != null && imageName != null) {
+                PomModifications modifyImages = new PomModifications();
+                // add new configuration code
+                int indent = 4;
+                int startConfigCodeRow = updatedPlugin.getLocation(ARTIFACT_ID).getLineNumber();
+                InputLocation startConfigCode = new InputLocation(startConfigCodeRow + 1, updatedPlugin.getLocation(ARTIFACT_ID).getColumnNumber());
+                modifyImages.add(new PomModifications.Insertion(startConfigCode, indent, OrphedomosToFabric8Migration::getConfigCode));
+
+                replacedConfig = writeModifications(file, modifyImages.finalizeMods());
+
+            }
+
+            Model fabric8Model = getLocationAnnotatedModel(file);
+            Plugin fabric8Plugin = getPlugin(fabric8Model, FABRIC8_ARTIFACT_ID);
+            PomModifications removeOldConfig = new PomModifications();
+
+            // delete single line version tag if it exists
+            String version = fabric8Plugin.getVersion();
+            if (version != null) {
+                InputLocation startVersionLocation = fabric8Plugin.getLocation(VERSION + LocationAwareMavenReader.START);
+                InputLocation endVersionLocation = fabric8Plugin.getLocation(VERSION + LocationAwareMavenReader.END);
+
+                PomModifications.Deletion pomDeletePreviousVersion = new PomModifications.Deletion(startVersionLocation, endVersionLocation);
+                removeOldConfig.add(pomDeletePreviousVersion);
+            }
+
+            // delete old orphedomos configuration
+            InputLocation startConfigLocation = fabric8Plugin.getLocation(CONFIGURATION + LocationAwareMavenReader.START);
+            InputLocation endConfigLocation = fabric8Plugin.getLocation(CONFIGURATION + LocationAwareMavenReader.END);
+            PomModifications.Deletion pomDeletePreviousConfig = new PomModifications.Deletion(startConfigLocation, endConfigLocation);
+            removeOldConfig.add(pomDeletePreviousConfig);
+
+            writeModifications(file, removeOldConfig.finalizeMods());
+        }
+
+        // check if pom file has <packaging>orphedomos</packaging> and replace
+        if (containsOrphedomosPackaging(file)){
+            replacedPackaging = executePackagingMigration(file);
+        }
+
+        isSuccessful = replacedConfig || replacedPackaging;
+
+        return isSuccessful;
+    }
+
+
+    private String getImageName(Xpp3Dom configuration){
+        String imageName;
+        if (hasConfigurationItem(configuration, IMAGE_NAME)) {
+            imageName = configuration.getChild(IMAGE_NAME).getValue();
+        } else {
+            imageName = null;
+        }
+        return imageName;
+    }
+
+    private String getImageVersion(Xpp3Dom configuration){
+        String imageVersion;
+        if (hasConfigurationItem(configuration, IMAGE_VERSION)) {
+            imageVersion = configuration.getChild(IMAGE_VERSION).getValue();
+        } else {
+            imageVersion = null;
+        }
+        return imageVersion;
+    }
+
+    /**
+     * Function that creates the new Fabric8 docker-maven-plugin configuration code.
+     */
+    private static String getConfigCode(String indent){
+        return StringUtils.repeat(indent, 4) + "<executions>\n" +
+                StringUtils.repeat(indent, 5) + "<execution>\n" +
+                StringUtils.repeat(indent, 6) + "<id>default-build</id>\n" +
+                StringUtils.repeat(indent, 6) + "<configuration>\n" +
+                StringUtils.repeat(indent, 7) + "<images>\n" +
+                StringUtils.repeat(indent, 8) + "<image>\n" +
+                StringUtils.repeat(indent, 9) + "<name>" + imageName + ":" + imageVersion + "</name>\n" +
+                StringUtils.repeat(indent, 8) + "</image>\n" +
+                StringUtils.repeat(indent, 7) + "</images>\n" +
+                StringUtils.repeat(indent, 6) + "</configuration>\n" +
+                StringUtils.repeat(indent, 5) + "</execution>\n" +
+                StringUtils.repeat(indent, 4) + "</executions>\n";
+    }
+
+    /**
+     * Function to check whether a given pom file has its packaging type set to Orphedomos
+     */
+    private boolean containsOrphedomosPackaging(File file){
+        boolean shouldExecute = false;
+        try {
+            List<String> orphedomosPackaging = getRegExCaptureGroups(EXTRACT_PACKAGING_REGEX, file);
+            shouldExecute = CollectionUtils.isNotEmpty(orphedomosPackaging);
+        } catch (IOException e){
+            throw new BatonException("Unable to determine if Orphedomos packaging migration must be executed", e);
+        }
+        return shouldExecute;
+    }
+
+    /**
+     * Function that performs the migration on the pom file's packaging type.
+     */
+    private boolean executePackagingMigration(File file){
+        boolean performedSuccessfully = false;
+        String replacementText = FIRST_REGEX_GROUPING + "docker-build" + SECOND_REGEX_GROUPING;
+        try {
+            performedSuccessfully = FileUtils.replaceInFile(
+                    file,
+                    EXTRACT_PACKAGING_REGEX,
+                    replacementText
+            );
+        } catch (Exception e) {
+            logger.error("Unable to perform packaging type migration due to exception", e);
+        }
+
+        return performedSuccessfully;
+    }
+
+}

--- a/foundation/foundation-upgrade/src/main/resources/migrations.json
+++ b/foundation/foundation-upgrade/src/main/resources/migrations.json
@@ -11,6 +11,15 @@
             "includes": ["pom.xml"]
           }
         ]
+      },
+      {
+        "name": "orphedomos-to-fabric8-migration",
+        "implementation": "com.boozallen.aissemble.upgrade.migration.v1_8_0.OrphedomosToFabric8Migration",
+        "fileSets": [
+          {
+            "includes": ["pom.xml"]
+          }
+        ]
       }
     ]
   },

--- a/foundation/foundation-upgrade/src/test/java/com/boozallen/aissemble/upgrade/migration/v1_8_0/OrphedomosToFabric8MigrationSteps.java
+++ b/foundation/foundation-upgrade/src/test/java/com/boozallen/aissemble/upgrade/migration/v1_8_0/OrphedomosToFabric8MigrationSteps.java
@@ -1,0 +1,88 @@
+package com.boozallen.aissemble.upgrade.migration.v1_8_0;
+
+/*-
+ * #%L
+ * aiSSEMBLE::Foundation::Upgrade
+ * %%
+ * Copyright (C) 2021 Booz Allen
+ * %%
+ * This software package is licensed under the Booz Allen Public License. All Rights Reserved.
+ * #L%
+ */
+
+import com.boozallen.aissemble.upgrade.migration.AbstractMigrationTest;
+import com.boozallen.aissemble.upgrade.util.pom.PomHelper;
+import io.cucumber.java.en.And;
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
+import org.apache.maven.model.Model;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertNotNull;
+
+public class OrphedomosToFabric8MigrationSteps  extends AbstractMigrationTest {
+
+    @Given("A pom with Orphedomos in the plugin management")
+    public void a_pom_with_orphedomos_in_the_plugin_management() {
+        testFile = getTestFile("v1_8_0/OrphedomosToFabric8Migration/migrate-configuration/pom.xml");
+    }
+    @When("The migration executes")
+    public void the_migration_executes() {
+        performMigration(new OrphedomosToFabric8Migration());
+        assertTrue("The migration should execute", shouldExecute);
+    }
+    @Then("The pom is updated to use the Fabric8 docker-maven-plugin")
+    public void the_pom_is_updated_to_use_the_fabric8_docker_maven_plugin() {
+        Model model = PomHelper.getLocationAnnotatedModel(testFile);
+        Object artifactId = model.getBuild().getPlugins().get(1).getArtifactId();
+        assertEquals("docker-maven-plugin", artifactId.toString());
+
+        Object groupId = model.getBuild().getPlugins().get(1).getGroupId();
+        assertEquals("io.fabric8", groupId.toString());
+
+    }
+
+    @And("Fabric8 is configured properly")
+    public void fabric8_is_configured_properly(){
+        Model model = PomHelper.getLocationAnnotatedModel(testFile);
+        Object executions = model.getBuild().getPlugins().get(1).getExecutions();
+        assertNotNull("The executions were not added properly", executions);
+    }
+    @Then("the previous configuration was removed")
+    public void the_previous_configuration_was_removed() {
+        Model model = PomHelper.getLocationAnnotatedModel(testFile);
+        Object configuration = model.getBuild().getPlugins().get(1).getConfiguration();
+        assertNull("The previous configuration was not removed successfully", configuration);
+    }
+
+
+    @Given("A pom with its packaging set to Orphedomos")
+    public void a_pom_with_its_packaging_set_to_orphedomos() {
+        testFile = getTestFile("v1_8_0/OrphedomosToFabric8Migration/migrate-packaging/pom.xml");
+    }
+    @Then("The pom is updated to use packaging type of docker-build")
+    public void the_pom_is_updated_to_use_packaging_type_of_docker_build() {
+        Model model = PomHelper.getLocationAnnotatedModel(testFile);
+        Object packaging = model.getPackaging();
+        assertEquals("docker-build", packaging);
+    }
+
+    @Given("A pom within the tests docker module")
+    public void a_pom_within_the_tests_docker_module() {
+        testFile = getTestFile("v1_8_0/OrphedomosToFabric8Migration/skip-migration/pom.xml");
+    }
+    @When("The migration is executed")
+    public void the_migration_is_executed() {
+        performMigration(new OrphedomosToFabric8Migration());
+
+    }
+    @Then("The pom is not updated to use the Fabric8 docker-maven-plugin")
+    public void the_pom_is_not_updated_to_use_the_fabric8_docker_maven_plugin() {
+        assertFalse("The migration should be skipped", shouldExecute);
+    }
+
+}

--- a/foundation/foundation-upgrade/src/test/resources/specifications/v1_8_0/orphedomos-to-fabric8-migration.feature
+++ b/foundation/foundation-upgrade/src/test/resources/specifications/v1_8_0/orphedomos-to-fabric8-migration.feature
@@ -1,0 +1,18 @@
+Feature: Migrate from using Orphedomos to Fabric8 docker-maven-plugin
+
+  Scenario: Pom file with Orphedomos plugin configuration is migrated to Fabric8 docker-maven-plugin
+    Given A pom with Orphedomos in the plugin management
+    When The migration executes
+    Then The pom is updated to use the Fabric8 docker-maven-plugin
+    And Fabric8 is configured properly
+    And the previous configuration was removed
+
+  Scenario: Pom file with Orphedomos packaging type is migrated to Fabric8 docker-build
+    Given A pom with its packaging set to Orphedomos
+    When The migration executes
+    Then The pom is updated to use packaging type of docker-build
+
+  Scenario: Migration does not run for pom file within <project-name>-tests-docker module
+    Given A pom within the tests docker module
+    When The migration is executed
+    Then The pom is not updated to use the Fabric8 docker-maven-plugin

--- a/foundation/foundation-upgrade/src/test/resources/test-files/v1_8_0/OrphedomosToFabric8Migration/migrate-configuration/pom.xml
+++ b/foundation/foundation-upgrade/src/test/resources/test-files/v1_8_0/OrphedomosToFabric8Migration/migrate-configuration/pom.xml
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  aiSSEMBLE::Foundation::Upgrade
+  %%
+  Copyright (C) 2021 Booz Allen
+  %%
+  This software package is licensed under the Booz Allen Public License. All Rights Reserved.
+  #L%
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.test</groupId>
+        <artifactId>test-project</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>test-project-docker</artifactId>
+
+    <name>test-project::Docker</name>
+    <description>Contains the Docker Build this test-project</description>
+    <packaging>pom</packaging>
+
+    <modules>
+        <!-- TODO: Add docker modules here -->
+        <module>test-project-spark-worker-docker</module>
+        <module>test-project-policy-decision-point-docker</module>
+        <module>test-project-vault-docker</module>
+    </modules>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.technologybrewery.fermenter</groupId>
+                    <artifactId>fermenter-mda</artifactId>
+                    <configuration>
+                        <basePackage>org.test</basePackage>
+                        <!-- Reference models from test-project-pipeline-models. See the following
+                            page for more detailed information: https://fermenter.atlassian.net/wiki/spaces/FER/pages/48955396/Controlling+What+Gets+Generated#ControllingWhatGetsGenerated-UsingmetadataoutsideofyourcurrentMavenmodule -->
+                        <metadataDependencies>
+                            <metadataDependency>test-project-pipeline-models</metadataDependency>
+                        </metadataDependencies>
+                        <targetModelInstances>
+                            <targetModelInstance>test-project-pipeline-models</targetModelInstance>
+                        </targetModelInstances>
+                        <propertyVariables>
+                            <aissembleVersion>${version.aissemble}</aissembleVersion>
+                        </propertyVariables>
+                    </configuration>
+                    <dependencies>
+                        <dependency>
+                            <groupId>${project.groupId}</groupId>
+                            <artifactId>test-project-pipeline-models</artifactId>
+                            <version>${project.version}</version>
+                        </dependency>
+                    </dependencies>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+        <plugins>
+            <plugin>
+                <groupId>org.technologybrewery.fermenter</groupId>
+                <artifactId>fermenter-mda</artifactId>
+                <inherited>false</inherited>
+                <configuration>
+                    <basePackage>org.test</basePackage>
+                    <profile>docker-spark-python-pipelines</profile>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.technologybrewery.orphedomos</groupId>
+                <artifactId>orphedomos-maven-plugin</artifactId>
+                <version>${version.orphedomos.plugin}</version>
+                <configuration>
+                    <skip>true</skip>
+                    <imageVersion>${project.version}</imageVersion>
+                    <imageName>${project.artifactId}</imageName>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>ci</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.technologybrewery.orphedomos</groupId>
+                        <artifactId>orphedomos-maven-plugin</artifactId>
+                        <configuration>
+                            <skip>false</skip>
+                            <imageVersion>${project.version}</imageVersion>
+                            <!-- Add in repoId that corresponds to the serverId in your settings.xml
+                                 that contains the docker login credentials -->
+                            <repoId />
+                            <repoUrl>${docker.project.repository.url}</repoUrl>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+</project>

--- a/foundation/foundation-upgrade/src/test/resources/test-files/v1_8_0/OrphedomosToFabric8Migration/migrate-packaging/pom.xml
+++ b/foundation/foundation-upgrade/src/test/resources/test-files/v1_8_0/OrphedomosToFabric8Migration/migrate-packaging/pom.xml
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  aiSSEMBLE::Foundation::Upgrade
+  %%
+  Copyright (C) 2021 Booz Allen
+  %%
+  This software package is licensed under the Booz Allen Public License. All Rights Reserved.
+  #L%
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <parent>
+        <groupId>org.test</groupId>
+        <artifactId>test-project-docker</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>test-project-spark-worker-docker</artifactId>
+
+    <packaging>orphedomos</packaging>
+
+    <name>test-project::Docker::Spark</name>
+    <description>Build for a Spark Docker container which contains all pipelines</description>
+    <modelVersion>4.0.0</modelVersion>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.technologybrewery.fermenter</groupId>
+                <artifactId>fermenter-mda</artifactId>
+                <configuration>
+                    <basePackage>com.boozallen.aiops.cookbook</basePackage>
+                    <profile>aissemble-spark-worker-docker</profile>
+                </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-resources-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>copy-docker-resources</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${project.build.directory}</outputDirectory>
+                            <resources>
+                                <resource>
+                                    <directory>${project.basedir}/src/main/resources/docker</directory>
+                                    <filtering>false</filtering>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>com.boozallen.aissemble</groupId>
+                <artifactId>mda-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>copy-pipeline-artifacts</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>copy-pipeline-artifacts</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <groupId>${project.groupId}</groupId>
+                    <modelsArtifactId>test-project-pipeline-models</modelsArtifactId>
+                    <pipelinesDirectory>${project.parent.parent.basedir}/test-project-pipelines/</pipelinesDirectory>
+                    <outputDirectory>${project.build.directory}/dockerbuild/</outputDirectory>
+                    <habushuArtifactVersion>${version.habushu.dist.artifact}</habushuArtifactVersion>
+                    <targetPipelineTypes>
+                        <targetPipelineType>data-flow</targetPipelineType>
+                    </targetPipelineTypes>
+                </configuration>
+                <dependencies>
+                    <dependency>
+                        <groupId>${project.groupId}</groupId>
+                        <artifactId>test-project-pipeline-models</artifactId>
+                        <version>${project.version}</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+        </plugins>
+    </build>
+    <dependencies>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>spark-pipeline</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+        </dependency>
+    </dependencies>
+</project>
+

--- a/foundation/foundation-upgrade/src/test/resources/test-files/v1_8_0/OrphedomosToFabric8Migration/skip-migration/pom.xml
+++ b/foundation/foundation-upgrade/src/test/resources/test-files/v1_8_0/OrphedomosToFabric8Migration/skip-migration/pom.xml
@@ -1,0 +1,128 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  aiSSEMBLE::Foundation::Upgrade
+  %%
+  Copyright (C) 2021 Booz Allen
+  %%
+  This software package is licensed under the Booz Allen Public License. All Rights Reserved.
+  #L%
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.boozallen.aissemble.test</groupId>
+        <artifactId>test-project-tests</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>test-project-tests-docker</artifactId>
+    <name>test-project::Tests::Docker</name>
+    <description>Integration test docker image for test-project</description>
+
+    <packaging>orphedomos</packaging>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.technologybrewery.fermenter</groupId>
+                <artifactId>fermenter-mda</artifactId>
+                <inherited>false</inherited>
+                <configuration>
+                    <basePackage>com.boozallen.aissemble.test</basePackage>
+                    <profile>integration-test-docker</profile>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.technologybrewery.orphedomos</groupId>
+                <artifactId>orphedomos-maven-plugin</artifactId>
+                <version>${version.orphedomos.plugin}</version>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.boozallen.aissemble.test</groupId>
+            <artifactId>${project.parent.artifactId}-java</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+
+    <profiles>
+        <profile>
+            <id>integration-test</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.technologybrewery.orphedomos</groupId>
+                        <artifactId>orphedomos-maven-plugin</artifactId>
+                        <version>${version.orphedomos.plugin}</version>
+                        <configuration>
+                            <skip>false</skip>
+                            <imageVersion>latest</imageVersion>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-resources-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>copy-docker-resources</id>
+                                <phase>prepare-package</phase>
+                                <goals>
+                                    <goal>copy-resources</goal>
+                                </goals>
+                                <configuration>
+                                    <outputDirectory>${project.build.directory}/specifications/</outputDirectory>
+                                    <resources>
+                                        <resource>
+                                            <directory>${project.parent.basedir}/${project.parent.artifactId}-java/src/main/resources/specifications/</directory>
+                                            <includes>
+                                                <include>**</include>
+                                            </includes>
+                                            <filtering>false</filtering>
+                                        </resource>
+                                    </resources>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-dependency-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>copy</id>
+                                <phase>prepare-package</phase>
+                                <goals>
+                                    <goal>copy</goal>
+                                </goals>
+                                <configuration>
+                                    <artifactItems>
+                                        <artifactItem>
+                                            <groupId>${project.groupId}</groupId>
+                                            <artifactId>${project.parent.artifactId}-java</artifactId>
+                                            <version>${project.version}</version>
+                                            <type>jar</type>
+                                            <overWrite>true</overWrite>
+                                            <destFileName>${project.artifactId}.jar</destFileName>
+                                            <outputDirectory>${project.build.directory}</outputDirectory>
+                                        </artifactItem>
+                                    </artifactItems>
+                                    <overWriteSnapshots>true</overWriteSnapshots>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+</project>


### PR DESCRIPTION
…plugin

- Migrates Orphedomos plugin configurations for all eligible pom files (all except build-parent and -tests-docker)
- Updates groupId, artifactId, configurations, executions to Fabric8 docker-maven-plugin
- Updates any orphedomos packaging types to docker-build
- Removes previous plugin version, if set
- Removes skip, if set
- Removes any previous Orphedomos plugin configurations