### PR TITLE
#150 use Habushu's `containerize-dependencies` goal

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -28,7 +28,7 @@
         <version.failsafe.plugin>${version.maven.surefire.plugin}</version.failsafe.plugin>
         <version.fermenter>2.10.3</version.fermenter>
         <version.fermenter.legacy.tools>2.8.0</version.fermenter.legacy.tools>
-        <version.habushu.plugin>2.15.0</version.habushu.plugin>
+        <version.habushu.plugin>2.16.0</version.habushu.plugin>
         <version.python>3.11.4</version.python>
         <version.help.plugin>3.2.0</version.help.plugin>
         <version.krausening>19</version.krausening>

--- a/extensions/extensions-docker/aissemble-airflow/src/main/resources/docker/Dockerfile
+++ b/extensions/extensions-docker/aissemble-airflow/src/main/resources/docker/Dockerfile
@@ -1,7 +1,7 @@
 # Script for creating base Airflow Docker image
 FROM apache/airflow:2.7.0-python3.11
 
-LABEL org.opencontainers.image.source = "https://github.com/boozallen/aissemble"
+LABEL org.opencontainers.image.source="https://github.com/boozallen/aissemble"
 
 USER root
 
@@ -37,10 +37,10 @@ USER root
 RUN mkdir -p /tmp/mlruns /tmp/model
 RUN chown airflow:0 -R /tmp/mlruns /tmp/model
 
-ENV JAVA_HOME /usr/lib/jvm/default-java
+ENV JAVA_HOME=/usr/lib/jvm/default-java
 RUN export JAVA_HOME
 
-ENV DEBIAN_FRONTEND noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
 ENV TERM linux
 
 # Airflow UID is 50000

--- a/extensions/extensions-docker/aissemble-configuration-store/src/main/resources/docker/Dockerfile
+++ b/extensions/extensions-docker/aissemble-configuration-store/src/main/resources/docker/Dockerfile
@@ -2,7 +2,7 @@ ARG DOCKER_BASELINE_REPO_ID
 ARG VERSION_AISSEMBLE
 FROM ${DOCKER_BASELINE_REPO_ID}boozallen/aissemble-quarkus:${VERSION_AISSEMBLE}
 
-LABEL org.opencontainers.image.source = "https://github.com/boozallen/aissemble"
+LABEL org.opencontainers.image.source="https://github.com/boozallen/aissemble"
 
 USER root
 RUN useradd --home /home/configstore --user-group --shell /usr/sbin/nologin --uid 1001 configstore

--- a/extensions/extensions-docker/aissemble-data-lineage-http-consumer/src/main/resources/docker/Dockerfile
+++ b/extensions/extensions-docker/aissemble-data-lineage-http-consumer/src/main/resources/docker/Dockerfile
@@ -2,6 +2,6 @@ ARG DOCKER_BASELINE_REPO_ID
 ARG VERSION_AISSEMBLE
 FROM ${DOCKER_BASELINE_REPO_ID}boozallen/aissemble-quarkus:${VERSION_AISSEMBLE}
 
-LABEL org.opencontainers.image.source = "https://github.com/boozallen/aissemble"
+LABEL org.opencontainers.image.source="https://github.com/boozallen/aissemble"
 
 COPY target/quarkus-app/ /deployments/

--- a/extensions/extensions-docker/aissemble-fastapi/src/main/resources/docker/Dockerfile
+++ b/extensions/extensions-docker/aissemble-fastapi/src/main/resources/docker/Dockerfile
@@ -1,8 +1,8 @@
 # Script for creating base FastAPI Docker image
 
-FROM python:3.11
+FROM python:3.11-slim
 
-LABEL org.opencontainers.image.source = "https://github.com/boozallen/aissemble"
+LABEL org.opencontainers.image.source="https://github.com/boozallen/aissemble"
 
 WORKDIR /app
 

--- a/extensions/extensions-docker/aissemble-hive/aissemble-hive-mysql/src/main/resources/docker/Dockerfile
+++ b/extensions/extensions-docker/aissemble-hive/aissemble-hive-mysql/src/main/resources/docker/Dockerfile
@@ -1,6 +1,6 @@
 FROM mysql/mysql-server:8.0.30
 
-LABEL org.opencontainers.image.source = "https://github.com/boozallen/aissemble"
+LABEL org.opencontainers.image.source="https://github.com/boozallen/aissemble"
 
 # MySQL places files into the root directory as a part of the startup process.
 # Since the root directory isn't owned by the mysql user, it has to run as root normally in order to create those files.

--- a/extensions/extensions-docker/aissemble-hive/aissemble-hive-service/src/main/resources/docker/Dockerfile
+++ b/extensions/extensions-docker/aissemble-hive/aissemble-hive-service/src/main/resources/docker/Dockerfile
@@ -3,7 +3,7 @@ FROM apache/hive:${METASTORE_VERSION} as appsource
 
 FROM eclipse-temurin:17-jre as final
 
-LABEL org.opencontainers.image.source = "https://github.com/boozallen/aissemble"
+LABEL org.opencontainers.image.source="https://github.com/boozallen/aissemble"
 
 WORKDIR /opt
 

--- a/extensions/extensions-docker/aissemble-jenkins/aissemble-jenkins-agent/src/main/resources/docker/Dockerfile
+++ b/extensions/extensions-docker/aissemble-jenkins/aissemble-jenkins-agent/src/main/resources/docker/Dockerfile
@@ -1,3 +1,3 @@
 FROM jenkins/ssh-agent:latest-jdk11
 
-LABEL org.opencontainers.image.source = "https://github.com/boozallen/aissemble"
+LABEL org.opencontainers.image.source="https://github.com/boozallen/aissemble"

--- a/extensions/extensions-docker/aissemble-jenkins/aissemble-jenkins-controller/src/main/resources/docker/Dockerfile
+++ b/extensions/extensions-docker/aissemble-jenkins/aissemble-jenkins-controller/src/main/resources/docker/Dockerfile
@@ -1,6 +1,6 @@
 FROM jenkins/jenkins:lts-jdk11
 
-LABEL org.opencontainers.image.source = "https://github.com/boozallen/aissemble"
+LABEL org.opencontainers.image.source="https://github.com/boozallen/aissemble"
 
 USER root
 USER jenkins

--- a/extensions/extensions-docker/aissemble-kafka/src/main/resources/docker/Dockerfile
+++ b/extensions/extensions-docker/aissemble-kafka/src/main/resources/docker/Dockerfile
@@ -1,7 +1,7 @@
 #Script for creating base Kafka Docker image
 FROM bitnami/kafka:3.5
 
-LABEL org.opencontainers.image.source = "https://github.com/boozallen/aissemble"
+LABEL org.opencontainers.image.source="https://github.com/boozallen/aissemble"
 
 USER root
 RUN apt-get update -y \

--- a/extensions/extensions-docker/aissemble-metadata/src/main/resources/docker/Dockerfile
+++ b/extensions/extensions-docker/aissemble-metadata/src/main/resources/docker/Dockerfile
@@ -2,7 +2,7 @@ ARG DOCKER_BASELINE_REPO_ID
 ARG VERSION_AISSEMBLE
 FROM ${DOCKER_BASELINE_REPO_ID}boozallen/aissemble-quarkus:${VERSION_AISSEMBLE}
 
-LABEL org.opencontainers.image.source = "https://github.com/boozallen/aissemble"
+LABEL org.opencontainers.image.source="https://github.com/boozallen/aissemble"
 
 USER root
 RUN useradd --home /home/metadata --user-group --shell /usr/sbin/nologin --uid 1001 metadata

--- a/extensions/extensions-docker/aissemble-mlflow/src/main/resources/docker/Dockerfile
+++ b/extensions/extensions-docker/aissemble-mlflow/src/main/resources/docker/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.11
 
-LABEL org.opencontainers.image.source = "https://github.com/boozallen/aissemble"
+LABEL org.opencontainers.image.source="https://github.com/boozallen/aissemble"
 
 RUN pip install \
     mlflow==2.3.1 \

--- a/extensions/extensions-docker/aissemble-model-training-api-containers/aissemble-model-training-api-sagemaker/pom.xml
+++ b/extensions/extensions-docker/aissemble-model-training-api-containers/aissemble-model-training-api-sagemaker/pom.xml
@@ -14,60 +14,11 @@
 
     <packaging>docker-build</packaging>
 
-    <properties>
-        <wheelOutputDirectory>${project.build.directory}/wheels/</wheelOutputDirectory>
-    </properties>
-
     <build>
         <plugins>
             <plugin>
-                <groupId>org.technologybrewery.orphedomos</groupId>
-                <artifactId>orphedomos-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>retrieve-wheels</id>
-                        <phase>validate</phase>
-                        <goals>
-                            <goal>retrieve-wheels</goal>
-                        </goals>
-                        <configuration>
-                            <wheelDependencies>
-                                <wheelDependency>
-                                    <artifactId>aissemble-extensions-model-training-api-sagemaker</artifactId>
-                                    <targetDirectory>${wheelOutputDirectory}</targetDirectory>
-                                </wheelDependency>																
-                            </wheelDependencies>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>            
-            <plugin>
-                <artifactId>maven-resources-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>copy-docker-resources</id>
-                        <phase>prepare-package</phase>
-                        <goals>
-                            <goal>copy-resources</goal>
-                        </goals>
-                        <configuration>
-                            <outputDirectory>${project.build.directory}</outputDirectory>
-                            <resources>
-                                <resource>
-                                    <directory>${project.basedir}/src/main/resources/docker</directory>
-                                    <filtering>false</filtering>
-                                </resource>
-                                <resource>
-                                    <directory>../../../../extensions/aissemble-extensions-model-training-api-sagemaker/src/model_training_api_sagemaker</directory>
-                                    <includes>
-                                        <include>model_training_api_sagemaker.py</include>
-                                    </includes>
-                                    <filtering>false</filtering>
-                                </resource>
-                            </resources>
-                        </configuration>
-                    </execution>
-                </executions>
+                <groupId>org.technologybrewery.habushu</groupId>
+                <artifactId>habushu-maven-plugin</artifactId>
             </plugin>
         </plugins>
     </build>

--- a/extensions/extensions-docker/aissemble-model-training-api-containers/aissemble-model-training-api-sagemaker/src/main/resources/docker/Dockerfile
+++ b/extensions/extensions-docker/aissemble-model-training-api-containers/aissemble-model-training-api-sagemaker/src/main/resources/docker/Dockerfile
@@ -1,37 +1,43 @@
 # Script for creating base AIOps Model Training API image
-
 ARG DOCKER_BASELINE_REPO_ID
 ARG VERSION_AISSEMBLE
+
+#HABUSHU_BUILDER_STAGE - HABUSHU GENERATED CODE (DO NOT MODIFY)
+FROM python:3.11-slim AS habushu_builder
+# Poetry and supporting plugin installations
+RUN python -m ensurepip --upgrade && \
+    pip install poetry && \
+    poetry self add poetry-monorepo-dependency-plugin && \
+    poetry self add poetry-plugin-bundle
+
+WORKDIR /work-dir
+COPY --chown=1001 target/containerize-support ./containerize-support/
+RUN find . -type f -name pyproject.toml -exec sed -i 's|develop[[:blank:]]*=[[:blank:]]*true|develop = false|g' {} \;
+
+USER root
+WORKDIR /work-dir/containerize-support/extensions/aissemble-extensions-model-training-api-sagemaker
+ENV POETRY_CACHE_DIR="/.cache/pypoetry"
+
+# export target project's virtual environment to /opt/venv
+RUN --mount=type=cache,target=/.cache/pypoetry/ \
+    poetry lock && \
+    poetry bundle venv /opt/venv
+#HABUSHU_BUILDER_STAGE - HABUSHU GENERATED CODE (END)
+
 FROM ${DOCKER_BASELINE_REPO_ID}boozallen/aissemble-fastapi:${VERSION_AISSEMBLE} AS builder
 
-RUN python -m venv /opt/venv
+#HABUSHU_FINAL_STAGE - HABUSHU GENERATED CODE (DO NOT MODIFY)
+FROM python:3.11-slim AS final
+# Copy venv from builder and activate by adding to the path
+COPY --from=habushu_builder --chown=1001 /opt/venv /opt/venv/
 ENV PATH="/opt/venv/bin:$PATH"
+#HABUSHU_FINAL_STAGE - HABUSHU GENERATED CODE (END)
 
-COPY ./target/wheels/* /tmp/wheels/
-# Re-install any dependencies defined in the base image into the virtual environment, then install new requirements
-RUN pip install -r /tmp/requirements.txt && \
-    set -e && \
-    cd /tmp/wheels/; for x in *.whl; do pip install $x --no-cache-dir; done
-
-
-# Start a new build stage based on a slim Python image, which will have the minimal amount of code, FastAPI
-# components, and installed dependencies copied into it from the initial builder image
-FROM python:3.11-slim as final
-
-LABEL org.opencontainers.image.source = "https://github.com/boozallen/aissemble"
-
-WORKDIR /app
+LABEL org.opencontainers.image.source="https://github.com/boozallen/aissemble"
 
 # Set/move any required environmental variables and key scripts/configs needed by FastAPI from the base image
 # into the slimmed down final Python image
-ENV API_MAIN model_training_api_sagemaker
-ENV PATH="/opt/venv/bin:$PATH"
-ENV PYTHONPATH=/app
-COPY --from=builder /start.sh /start.sh
-
-# Copy over the virtual environment (and all pip installed packages) from the initial builder stage
-COPY --from=builder /opt/venv /opt/venv
-
-COPY ./target/model_training_api_sagemaker.py /app/model_training_api_sagemaker.py
+ENV API_MAIN=model_training_api_sagemaker.model_training_api_sagemaker
+COPY --from=builder --chown=1001 /start.sh /start.sh
 
 CMD ["/start.sh"]

--- a/extensions/extensions-docker/aissemble-model-training-api-containers/aissemble-model-training-api/pom.xml
+++ b/extensions/extensions-docker/aissemble-model-training-api-containers/aissemble-model-training-api/pom.xml
@@ -13,65 +13,12 @@
     <description>A base image for the aiSSEMBLE Model Training API service which runs on FastAPI</description>
 
     <packaging>docker-build</packaging>
-    
-    <properties>
-        <wheelOutputDirectory>${project.build.directory}/wheels/</wheelOutputDirectory>
-    </properties>
 
     <build>
         <plugins>
             <plugin>
-                <groupId>org.technologybrewery.orphedomos</groupId>
-                <artifactId>orphedomos-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>retrieve-wheels</id>
-                        <phase>validate</phase>
-                        <goals>
-                            <goal>retrieve-wheels</goal>
-                        </goals>
-                        <configuration>
-                            <wheelDependencies>
-                                <wheelDependency>
-                                    <artifactId>aissemble-foundation-messaging-python-client</artifactId>
-                                    <targetDirectory>${wheelOutputDirectory}</targetDirectory>
-                                </wheelDependency>
-                                <wheelDependency>
-                                    <artifactId>aissemble-foundation-model-training-api</artifactId>
-                                    <targetDirectory>${wheelOutputDirectory}</targetDirectory>
-                                </wheelDependency>															
-                            </wheelDependencies>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>			
-            <plugin>
-                <artifactId>maven-resources-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>copy-docker-resources</id>
-                        <phase>prepare-package</phase>
-                        <goals>
-                            <goal>copy-resources</goal>
-                        </goals>
-                        <configuration>
-                            <outputDirectory>${project.build.directory}</outputDirectory>
-                            <resources>
-                                <resource>
-                                    <directory>${project.basedir}/src/main/resources/docker</directory>
-                                    <filtering>false</filtering>
-                                </resource>
-                                <resource>
-                                    <directory>../../../../foundation/aissemble-foundation-model-training-api/src/model_training_api</directory>
-                                    <includes>
-                                        <include>model_training_api.py</include>
-                                    </includes>
-                                    <filtering>false</filtering>
-                                </resource>
-                            </resources>
-                        </configuration>
-                    </execution>
-                </executions>
+                <groupId>org.technologybrewery.habushu</groupId>
+                <artifactId>habushu-maven-plugin</artifactId>
             </plugin>
         </plugins>
     </build>

--- a/extensions/extensions-docker/aissemble-model-training-api-containers/aissemble-model-training-api/src/main/resources/docker/Dockerfile
+++ b/extensions/extensions-docker/aissemble-model-training-api-containers/aissemble-model-training-api/src/main/resources/docker/Dockerfile
@@ -1,36 +1,46 @@
 # Script for creating base AIOps Model Training API image
-
 ARG DOCKER_BASELINE_REPO_ID
 ARG VERSION_AISSEMBLE
-FROM ${DOCKER_BASELINE_REPO_ID}boozallen/aissemble-fastapi:${VERSION_AISSEMBLE} AS builder
-RUN python -m venv /opt/venv
+
+#HABUSHU_BUILDER_STAGE - HABUSHU GENERATED CODE (DO NOT MODIFY)
+FROM python:3.11-slim AS habushu_builder
+# Poetry and supporting plugin installations
+RUN python -m ensurepip --upgrade && \
+    pip install poetry && \
+    poetry self add poetry-monorepo-dependency-plugin && \
+    poetry self add poetry-plugin-bundle
+
+WORKDIR /work-dir
+COPY --chown=1001 target/containerize-support ./containerize-support/
+RUN find . -type f -name pyproject.toml -exec sed -i 's|develop[[:blank:]]*=[[:blank:]]*true|develop = false|g' {} \;
+
+USER root
+WORKDIR /work-dir/containerize-support/foundation/aissemble-foundation-model-training-api
+ENV POETRY_CACHE_DIR="/.cache/pypoetry"
+
+# export target project's virtual environment to /opt/venv
+RUN --mount=type=cache,target=/.cache/pypoetry/ \
+    poetry lock && \
+    poetry bundle venv /opt/venv
+#HABUSHU_BUILDER_STAGE - HABUSHU GENERATED CODE (END)
+
+FROM ghcr.io/boozallen/aissemble-fastapi:1.8.0-SNAPSHOT AS builder
+
+#HABUSHU_FINAL_STAGE - HABUSHU GENERATED CODE (DO NOT MODIFY)
+FROM python:3.11-slim AS final
+# Copy venv from builder and activate by adding to the path
+COPY --from=habushu_builder --chown=1001 /opt/venv /opt/venv/
 ENV PATH="/opt/venv/bin:$PATH"
+#HABUSHU_FINAL_STAGE - HABUSHU GENERATED CODE (END)
 
-COPY ./target/wheels/* /tmp/wheels/
-# Re-install any dependencies defined in the base image into the virtual environment, then install new requirements
-RUN pip install -r /tmp/requirements.txt && \
-    set -e && \
-    cd /tmp/wheels/; for x in *.whl; do pip install $x --no-cache-dir; done
+LABEL org.opencontainers.image.source="https://github.com/boozallen/aissemble"
 
-# Start a new build stage based on a slim Python image, which will have the minimal amount of code, FastAPI
-# components, and installed dependencies copied into it from the initial builder image
-FROM python:3.11-slim as final
-
-LABEL org.opencontainers.image.source = "https://github.com/boozallen/aissemble"
-
-WORKDIR /app
 # Set/move any required environmental variables and key scripts/configs needed by FastAPI from the base image
 # into the slimmed down final Python image
-ENV API_MAIN model_training_api
-ENV PATH="/opt/venv/bin:$PATH"
-ENV PYTHONPATH=/app
+ENV API_MAIN=model_training_api.model_training_api
 ENV PYTHONUNBUFFERED="1"
 ENV GIT_PYTHON_REFRESH="quiet"
-COPY --from=builder /start.sh /start.sh
 
-# Copy over the virtual environment (and all pip installed packages) from the initial builder stage
-COPY --from=builder /opt/venv /opt/venv
-
-COPY ./target/model_training_api.py /app/model_training_api.py
+COPY --from=builder --chown=1001 /start.sh /start.sh
 
 CMD ["/start.sh"]

--- a/extensions/extensions-docker/aissemble-nvidia/src/main/resources/docker/Dockerfile
+++ b/extensions/extensions-docker/aissemble-nvidia/src/main/resources/docker/Dockerfile
@@ -1,6 +1,6 @@
 FROM nvidia/cuda:12.1.1-base-ubuntu22.04
 
-LABEL org.opencontainers.image.source = "https://github.com/boozallen/aissemble"
+LABEL org.opencontainers.image.source="https://github.com/boozallen/aissemble"
 
 # Workaround for ubuntu fix start
 # https://bugs.launchpad.net/ubuntu/+source/glibc/+bug/1962606

--- a/extensions/extensions-docker/aissemble-pipeline-invocation/src/main/resources/docker/Dockerfile
+++ b/extensions/extensions-docker/aissemble-pipeline-invocation/src/main/resources/docker/Dockerfile
@@ -3,7 +3,7 @@ ARG DOCKER_BASELINE_REPO_ID
 ARG VERSION_AISSEMBLE
 FROM ${DOCKER_BASELINE_REPO_ID}boozallen/aissemble-quarkus:${VERSION_AISSEMBLE}
 
-LABEL org.opencontainers.image.source = "https://github.com/boozallen/aissemble"
+LABEL org.opencontainers.image.source="https://github.com/boozallen/aissemble"
 
 USER root
 ARG AISSEMBLE_HELM_REPO=oci://ghcr.io/boozallen

--- a/extensions/extensions-docker/aissemble-policy-decision-point/src/main/resources/docker/Dockerfile
+++ b/extensions/extensions-docker/aissemble-policy-decision-point/src/main/resources/docker/Dockerfile
@@ -2,7 +2,7 @@ ARG DOCKER_BASELINE_REPO_ID
 ARG VERSION_AISSEMBLE
 FROM ${DOCKER_BASELINE_REPO_ID}boozallen/aissemble-quarkus:${VERSION_AISSEMBLE}
 
-LABEL org.opencontainers.image.source = "https://github.com/boozallen/aissemble"
+LABEL org.opencontainers.image.source="https://github.com/boozallen/aissemble"
 
 USER root
 RUN microdnf install jq

--- a/extensions/extensions-docker/aissemble-quarkus/src/main/resources/docker/Dockerfile
+++ b/extensions/extensions-docker/aissemble-quarkus/src/main/resources/docker/Dockerfile
@@ -2,7 +2,7 @@
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-LABEL org.opencontainers.image.source = "https://github.com/boozallen/aissemble"
+LABEL org.opencontainers.image.source="https://github.com/boozallen/aissemble"
 
 ARG JAVA_PACKAGE=java-11-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8

--- a/extensions/extensions-docker/aissemble-spark-infrastructure/src/main/resources/docker/Dockerfile
+++ b/extensions/extensions-docker/aissemble-spark-infrastructure/src/main/resources/docker/Dockerfile
@@ -3,7 +3,7 @@ ARG DOCKER_BASELINE_REPO_ID
 FROM ${DOCKER_BASELINE_REPO_ID}boozallen/aissemble-spark:${VERSION_AISSEMBLE}
 ARG DELTA_HIVE_CONNECTOR_VERSION
 
-LABEL org.opencontainers.image.source = "https://github.com/boozallen/aissemble"
+LABEL org.opencontainers.image.source="https://github.com/boozallen/aissemble"
 
 RUN curl -L https://github.com/delta-io/connectors/releases/download/v${DELTA_HIVE_CONNECTOR_VERSION}/delta-hive-assembly_2.12-${DELTA_HIVE_CONNECTOR_VERSION}.jar \
           -o "${SPARK_HOME}"/jars/delta-hive-assembly_2.12-${DELTA_HIVE_CONNECTOR_VERSION}.jar

--- a/extensions/extensions-docker/aissemble-spark-operator/src/main/resources/docker/Dockerfile
+++ b/extensions/extensions-docker/aissemble-spark-operator/src/main/resources/docker/Dockerfile
@@ -38,7 +38,7 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o /usr/bin
 
 FROM ${DOCKER_BASELINE_REPO_ID}boozallen/aissemble-spark:${VERSION_AISSEMBLE}
 
-LABEL org.opencontainers.image.source = "https://github.com/boozallen/aissemble"
+LABEL org.opencontainers.image.source="https://github.com/boozallen/aissemble"
 
 USER root
 

--- a/extensions/extensions-docker/aissemble-spark/src/main/resources/docker/Dockerfile
+++ b/extensions/extensions-docker/aissemble-spark/src/main/resources/docker/Dockerfile
@@ -3,7 +3,7 @@
 ARG SPARK_VERSION
 FROM apache/spark-py:v${SPARK_VERSION}
 
-LABEL org.opencontainers.image.source = "https://github.com/boozallen/aissemble"
+LABEL org.opencontainers.image.source="https://github.com/boozallen/aissemble"
 
 USER root
 

--- a/extensions/extensions-docker/aissemble-vault/src/main/resources/docker/Dockerfile
+++ b/extensions/extensions-docker/aissemble-vault/src/main/resources/docker/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.13
 
-LABEL org.opencontainers.image.source = "https://github.com/boozallen/aissemble"
+LABEL org.opencontainers.image.source="https://github.com/boozallen/aissemble"
 
 # This is the release of Vault to pull in.
 ARG VAULT_VERSION=1.15.2

--- a/extensions/extensions-docker/aissemble-versioning/pom.xml
+++ b/extensions/extensions-docker/aissemble-versioning/pom.xml
@@ -14,66 +14,11 @@
 
     <packaging>docker-build</packaging>
 
-    <properties>
-        <wheelOutputDirectory>${project.build.directory}/wheels/</wheelOutputDirectory>
-    </properties>
-
     <build>
         <plugins>
-			<plugin>
-				<groupId>org.technologybrewery.orphedomos</groupId>
-				<artifactId>orphedomos-maven-plugin</artifactId>
-				<executions>
-					<execution>
-						<id>retrieve-wheels</id>
-						<phase>validate</phase>
-						<goals>
-							<goal>retrieve-wheels</goal>
-						</goals>
-						<configuration>
-							<wheelDependencies>
-								<wheelDependency>
-									<artifactId>aissemble-foundation-core-python</artifactId>
-									<targetDirectory>${wheelOutputDirectory}</targetDirectory>
-								</wheelDependency>
-								<wheelDependency>
-									<artifactId>aissemble-foundation-pdp-client-python</artifactId>
-									<targetDirectory>${wheelOutputDirectory}</targetDirectory>
-								</wheelDependency>
-								<wheelDependency>
-									<artifactId>aissemble-foundation-versioning-service</artifactId>
-									<targetDirectory>${wheelOutputDirectory}</targetDirectory>
-								</wheelDependency>																
-							</wheelDependencies>
-						</configuration>
-					</execution>
-				</executions>
-			</plugin>        
             <plugin>
-                <artifactId>maven-resources-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>copy-docker-resources</id>
-                        <phase>prepare-package</phase>
-                        <goals>
-                            <goal>copy-resources</goal>
-                        </goals>
-                        <configuration>
-                            <outputDirectory>${project.build.directory}</outputDirectory>
-                            <resources>
-                                <resource>
-                                    <directory>
-                                        ../../../foundation/aissemble-foundation-versioning-service/src/model_versioning
-                                    </directory>
-                                    <includes>
-                                        <include>versioning_api.py</include>
-                                    </includes>
-                                    <filtering>false</filtering>
-                                </resource>
-                            </resources>
-                        </configuration>
-                    </execution>
-                </executions>
+                <groupId>org.technologybrewery.habushu</groupId>
+                <artifactId>habushu-maven-plugin</artifactId>
             </plugin>
         </plugins>
     </build>

--- a/extensions/extensions-docker/aissemble-versioning/src/main/resources/docker/Dockerfile
+++ b/extensions/extensions-docker/aissemble-versioning/src/main/resources/docker/Dockerfile
@@ -1,11 +1,30 @@
 # Script for creating base AIOps Versioning image
-
 ARG DOCKER_BASELINE_REPO_ID
 ARG VERSION_AISSEMBLE
-FROM ${DOCKER_BASELINE_REPO_ID}boozallen/aissemble-fastapi:${VERSION_AISSEMBLE} AS builder
 
-RUN python -m venv /opt/venv
-ENV PATH="/opt/venv/bin:$PATH"
+#HABUSHU_BUILDER_STAGE - HABUSHU GENERATED CODE (DO NOT MODIFY)
+FROM python:3.11-slim AS habushu_builder
+# Poetry and supporting plugin installations
+RUN python -m ensurepip --upgrade && \
+    pip install poetry && \
+    poetry self add poetry-monorepo-dependency-plugin && \
+    poetry self add poetry-plugin-bundle
+
+WORKDIR /work-dir
+COPY --chown=1001 target/containerize-support ./containerize-support/
+RUN find . -type f -name pyproject.toml -exec sed -i 's|develop[[:blank:]]*=[[:blank:]]*true|develop = false|g' {} \;
+
+USER root
+WORKDIR /work-dir/containerize-support/foundation/aissemble-foundation-versioning-service
+ENV POETRY_CACHE_DIR="/.cache/pypoetry"
+
+# export target project's virtual environment to /opt/venv
+RUN --mount=type=cache,target=/.cache/pypoetry/ \
+    poetry lock && \
+    poetry bundle venv /opt/venv
+#HABUSHU_BUILDER_STAGE - HABUSHU GENERATED CODE (END)
+
+FROM ${DOCKER_BASELINE_REPO_ID}boozallen/aissemble-fastapi:${VERSION_AISSEMBLE} AS builder
 
 # Download Maven
 ARG MAVEN_VERSION=3.9.6
@@ -13,21 +32,16 @@ RUN wget https://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries
     && tar -xzf apache-maven-${MAVEN_VERSION}-bin.tar.gz -C /opt \
     && rm apache-maven-${MAVEN_VERSION}-bin.tar.gz
 
-COPY ./target/wheels/* /tmp/wheels/
-# Re-install any dependencies defined in the base image into the virtual environment, then install new requirements
-RUN pip install -r /tmp/requirements.txt && \
-    set -e && \
-    cd /tmp/wheels/; for x in *.whl; do pip install $x --no-cache-dir; done
-
-COPY ./target/versioning_api.py /app/versioning_api.py
 COPY ./src/main/resources/model_versioning /app/model_versioning
 
+#HABUSHU_FINAL_STAGE - HABUSHU GENERATED CODE (DO NOT MODIFY)
+FROM python:3.11-slim AS final
+# Copy venv from builder and activate by adding to the path
+COPY --from=habushu_builder --chown=1001 /opt/venv /opt/venv/
+ENV PATH="/opt/venv/bin:$PATH"
+#HABUSHU_FINAL_STAGE - HABUSHU GENERATED CODE (END)
 
-# Start a new build stage based on a slim Python image, which will have the minimal amount of code, FastAPI
-# components, and installed dependencies copied into it from the initial builder image
-FROM python:3.11-slim as final
-
-LABEL org.opencontainers.image.source = "https://github.com/boozallen/aissemble"
+LABEL org.opencontainers.image.source="https://github.com/boozallen/aissemble"
 
 WORKDIR /app
 
@@ -43,27 +57,15 @@ RUN echo "deb http://deb.debian.org/debian bullseye main" >> /etc/apt/sources.li
 COPY --from=builder /opt/apache-maven-* /opt/apache-maven
 ENV PATH="/opt/apache-maven/bin:$PATH"
 
-# NOTE: you will need to override this Maven settings.xml file 
-# with one that contains the credentials for the Nexus server 
+# NOTE: you will need to override this Maven settings.xml file
+# with one that contains the credentials for the Nexus server
 # you intend to use when using this versioning service and image.
 COPY ./src/main/resources/docker/settings.xml /root/.m2/
 
 # Set/move any required environmental variables and key scripts/configs needed by FastAPI from the base image
 # into the slimmed down final Python image
-ENV API_MAIN versioning_api
-ENV PATH="/opt/venv/bin:$PATH"
-ENV PYTHONPATH=/app
+ENV API_MAIN=model_versioning.versioning_api
 COPY --from=builder /start.sh /start.sh
-
-# Copy over the virtual environment (and all pip installed packages) from the initial builder stage
-COPY --from=builder /opt/venv /opt/venv
 COPY --from=builder /app /app
-
-COPY ./target/versioning_api.py /app/versioning_api.py
-
-# current workaround for arm-based machines to have cryptography installed properly for Krausening
-RUN /opt/venv/bin/python -m pip install --upgrade pip \
-    && /opt/venv/bin/python -m pip uninstall -y cryptography \
-    && /opt/venv/bin/python -m pip install cryptography==39.0.2
 
 CMD ["/start.sh"]

--- a/extensions/extensions-docker/pom.xml
+++ b/extensions/extensions-docker/pom.xml
@@ -110,6 +110,28 @@
         </dependencies>
     </dependencyManagement>
     <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.technologybrewery.habushu</groupId>
+                    <artifactId>habushu-maven-plugin</artifactId>
+                    <executions>
+                        <execution>
+                            <id>stage-python</id>
+                            <goals>
+                                <goal>containerize-dependencies</goal>
+                            </goals>
+                            <phase>prepare-package</phase>
+                            <configuration>
+                                <dockerfile>${project.basedir}/src/main/resources/docker/Dockerfile</dockerfile>
+                                <dockerBase>python:3.11-slim</dockerBase>
+                                <dockerUser>1001</dockerUser>
+                            </configuration>
+                        </execution>
+                    </executions>
+                </plugin>
+            </plugins>
+        </pluginManagement>
         <plugins>
             <plugin>
                 <groupId>io.fabric8</groupId>

--- a/foundation/foundation-mda/src/main/java/com/boozallen/aiops/mda/generator/VaultDockerModuleGenerator.java
+++ b/foundation/foundation-mda/src/main/java/com/boozallen/aiops/mda/generator/VaultDockerModuleGenerator.java
@@ -21,7 +21,7 @@ import org.technologybrewery.fermenter.mda.metamodel.ModelInstanceRepositoryMana
 import java.util.Map;
 
 /**
- * Generates the policy decision point docker module.
+ * Generates the vault docker module.
  */
 public class VaultDockerModuleGenerator extends AbstractMavenModuleGenerator {
     /*--~-~-~~

--- a/foundation/foundation-mda/src/main/resources/profiles.json
+++ b/foundation/foundation-mda/src/main/resources/profiles.json
@@ -350,9 +350,6 @@
 			},
 			{
 				"name": "dataAccessDockerPomFile"
-			},
-			{
-				"name": "vaultDockerPomFile"
 			}
 		],
 		"profileReferences": [
@@ -364,6 +361,14 @@
 			},
 			{
 				"name": "docker-pom-training-sagemaker"
+			}
+		]
+	},
+	{
+		"name": "docker-vault",
+		"targetReferences": [
+			{
+				"name": "vaultDockerPomFile"
 			}
 		]
 	},

--- a/foundation/foundation-mda/src/main/resources/templates/deployment/model-training-api/model-training-api.values.yaml.vm
+++ b/foundation/foundation-mda/src/main/resources/templates/deployment/model-training-api/model-training-api.values.yaml.vm
@@ -21,8 +21,8 @@ service:
 configMap:
   trainingApiConfig: |
     project_name=${projectName}
-    docker_registry=ghcr.io/
-    image_prefix=boozallen/
+    docker_registry=${dockerProjectRepositoryUrl}
+    image_prefix=
     image_tag=${version}
     image_pull_policy=Always
   trainingApiConfigDev: |

--- a/foundation/foundation-mda/src/main/resources/templates/deployment/versioning/versioning.values-dev.yaml.vm
+++ b/foundation/foundation-mda/src/main/resources/templates/deployment/versioning/versioning.values-dev.yaml.vm
@@ -1,4 +1,4 @@
 # Dev values for versioning.
-aissemble-fastapi-chart:
-  image:
-    imagePullPolicy: IfNotPresent
+image:
+  imagePullPolicy: IfNotPresent
+  dockerRepo: ""


### PR DESCRIPTION
The vast majority of the changes files are just updating the formatting of `ENV` and `LABEL` commands in Dockerfiles to address a build warning.  The primary files for this change were the POMs and the 3 FastAPI-based Dockerfiles:
 - aissemble-model-training-api
 - aissemble-model-training-api-sagemaker
 - aissemble-versioning
 
 Also fixed a few issues in `foundation-mda` found during OTS.