### PR TITLE
#150 revert fastapi image to `python:3.11` and re-use default docker cache

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -28,7 +28,7 @@
         <version.failsafe.plugin>${version.maven.surefire.plugin}</version.failsafe.plugin>
         <version.fermenter>2.10.3</version.fermenter>
         <version.fermenter.legacy.tools>2.8.0</version.fermenter.legacy.tools>
-        <version.habushu.plugin>2.16.0</version.habushu.plugin>
+        <version.habushu.plugin>2.16.1</version.habushu.plugin>
         <version.python>3.11.4</version.python>
         <version.help.plugin>3.2.0</version.help.plugin>
         <version.krausening>19</version.krausening>
@@ -550,32 +550,29 @@
                     <artifactId>docker-maven-plugin</artifactId>
                     <version>${version.fabric8.docker.maven.plugin}</version>
                     <extensions>true</extensions>
-                    <executions>
-                        <execution>
-                            <id>default-build</id>
-                            <configuration>
-                                <images>
-                                    <image>
-                                        <name>${docker.baseline.repo.id}/${dockerImageName}:${dockerImageVersion}</name>
-                                        <build>
-                                            <buildx>
-                                                <platforms>
-                                                    <platform>${docker.platforms}</platform>
-                                                </platforms>
-                                            </buildx>
-                                            <args>
-                                                <DOCKER_BASELINE_REPO_ID>${docker.baseline.repo.id}/</DOCKER_BASELINE_REPO_ID>
-                                                <VERSION_AISSEMBLE>${version.aissemble}</VERSION_AISSEMBLE>
-                                                <SPARK_VERSION>${version.spark}</SPARK_VERSION>
-                                            </args>
-                                            <contextDir>${project.basedir}</contextDir>
-                                            <dockerFile>./src/main/resources/docker/Dockerfile</dockerFile>
-                                        </build>
-                                    </image>
-                                </images>
-                            </configuration>
-                        </execution>
-                    </executions>
+                    <configuration>
+                        <images>
+                            <image>
+                                <name>${docker.baseline.repo.id}/${dockerImageName}:${dockerImageVersion}</name>
+                                <build>
+                                    <buildx>
+                                        <!-- use default cache, passed to docker via config flag.-->
+                                        <dockerStateDir>~/.docker</dockerStateDir>
+                                        <platforms>
+                                            <platform>${docker.platforms}</platform>
+                                        </platforms>
+                                    </buildx>
+                                    <args>
+                                        <DOCKER_BASELINE_REPO_ID>${docker.baseline.repo.id}/</DOCKER_BASELINE_REPO_ID>
+                                        <VERSION_AISSEMBLE>${version.aissemble}</VERSION_AISSEMBLE>
+                                        <SPARK_VERSION>${version.spark}</SPARK_VERSION>
+                                    </args>
+                                    <contextDir>${project.basedir}</contextDir>
+                                    <dockerFile>./src/main/resources/docker/Dockerfile</dockerFile>
+                                </build>
+                            </image>
+                        </images>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>${group.helm.plugin}</groupId>

--- a/extensions/extensions-docker/aissemble-model-training-api-containers/aissemble-model-training-api-sagemaker/src/main/resources/docker/Dockerfile
+++ b/extensions/extensions-docker/aissemble-model-training-api-containers/aissemble-model-training-api-sagemaker/src/main/resources/docker/Dockerfile
@@ -3,7 +3,7 @@ ARG DOCKER_BASELINE_REPO_ID
 ARG VERSION_AISSEMBLE
 
 #HABUSHU_BUILDER_STAGE - HABUSHU GENERATED CODE (DO NOT MODIFY)
-FROM python:3.11-slim AS habushu_builder
+FROM python:3.11 AS habushu_builder
 # Poetry and supporting plugin installations
 RUN python -m ensurepip --upgrade && \
     pip install poetry && \

--- a/extensions/extensions-docker/aissemble-model-training-api-containers/aissemble-model-training-api/src/main/resources/docker/Dockerfile
+++ b/extensions/extensions-docker/aissemble-model-training-api-containers/aissemble-model-training-api/src/main/resources/docker/Dockerfile
@@ -3,7 +3,7 @@ ARG DOCKER_BASELINE_REPO_ID
 ARG VERSION_AISSEMBLE
 
 #HABUSHU_BUILDER_STAGE - HABUSHU GENERATED CODE (DO NOT MODIFY)
-FROM python:3.11-slim AS habushu_builder
+FROM python:3.11 AS habushu_builder
 # Poetry and supporting plugin installations
 RUN python -m ensurepip --upgrade && \
     pip install poetry && \

--- a/extensions/extensions-docker/aissemble-versioning/src/main/resources/docker/Dockerfile
+++ b/extensions/extensions-docker/aissemble-versioning/src/main/resources/docker/Dockerfile
@@ -3,7 +3,7 @@ ARG DOCKER_BASELINE_REPO_ID
 ARG VERSION_AISSEMBLE
 
 #HABUSHU_BUILDER_STAGE - HABUSHU GENERATED CODE (DO NOT MODIFY)
-FROM python:3.11-slim AS habushu_builder
+FROM python:3.11 AS habushu_builder
 # Poetry and supporting plugin installations
 RUN python -m ensurepip --upgrade && \
     pip install poetry && \

--- a/extensions/extensions-docker/pom.xml
+++ b/extensions/extensions-docker/pom.xml
@@ -18,44 +18,6 @@
 
     <profiles>
         <profile>
-            <id>ci</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>io.fabric8</groupId>
-                        <artifactId>docker-maven-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>default-push</id>
-                                <configuration>
-                                    <images>
-                                        <image>
-                                            <name>${docker.baseline.repo.id}/${dockerImageName}:${dockerImageVersion}</name>
-                                            <build>
-                                                <buildx>
-                                                    <platforms>
-                                                        <platform>${docker.platforms}</platform>
-                                                    </platforms>
-                                                </buildx>
-                                                <args>
-                                                    <DELTA_HIVE_CONNECTOR_VERSION>${version.delta.hive.connector}</DELTA_HIVE_CONNECTOR_VERSION>
-                                                    <DOCKER_BASELINE_REPO_ID>${docker.baseline.repo.id}/</DOCKER_BASELINE_REPO_ID>
-                                                    <VERSION_AISSEMBLE>${version.aissemble}</VERSION_AISSEMBLE>
-                                                    <SPARK_VERSION>${version.spark}</SPARK_VERSION>
-                                                </args>
-                                                <contextDir>${project.basedir}</contextDir>
-                                                <dockerFile>./src/main/resources/docker/Dockerfile</dockerFile>
-                                            </build>
-                                        </image>
-                                    </images>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-        <profile>
             <id>ensure-docker-dependencies</id>
             <!-- This profile is used to ensure that the docker dependencies are encoded in Maven properly. Because of
             the way docker works, any missing image will just be downloaded from the repository. This changes the repo
@@ -124,7 +86,8 @@
                             <phase>prepare-package</phase>
                             <configuration>
                                 <dockerfile>${project.basedir}/src/main/resources/docker/Dockerfile</dockerfile>
-                                <dockerBase>python:3.11-slim</dockerBase>
+                                <dockerBuilderBase>python:3.11</dockerBuilderBase>
+                                <dockerFinalBase>python:3.11-slim</dockerFinalBase>
                                 <dockerUser>1001</dockerUser>
                             </configuration>
                         </execution>
@@ -136,22 +99,17 @@
             <plugin>
                 <groupId>io.fabric8</groupId>
                 <artifactId>docker-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>default-build</id>
-                        <configuration>
-                            <images>
-                                <image>
-                                    <build>
-                                        <args>
-                                            <DELTA_HIVE_CONNECTOR_VERSION>${version.delta.hive.connector}</DELTA_HIVE_CONNECTOR_VERSION>
-                                        </args>
-                                    </build>
-                                </image>
-                            </images>
-                        </configuration>
-                    </execution>
-                </executions>
+                <configuration>
+                    <images>
+                        <image>
+                            <build>
+                                <args>
+                                    <DELTA_HIVE_CONNECTOR_VERSION>${version.delta.hive.connector}</DELTA_HIVE_CONNECTOR_VERSION>
+                                </args>
+                            </build>
+                        </image>
+                    </images>
+                </configuration>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
Technically, the failures in CI were due to two issues:
 - the one line change to the `Dockerfile` of `aissemble-fastapi` to use `python:3.11`
 - a change to the builder image used by Habushu to `python:3.11`
   - In order to support using `3.11-slim` for the final image, a new version of Habushu was released an pulled in (2.16.1)

However, while diagnosing this I found some oddities that made this hard to track down:

1. `docker buildx prune` only prunes the default builder, the same seems to be true of `system prune`.
2. changing the config directory of docker via `--config` changes what builders are visible, and what cache space they are using
3. by default, the `docker-maven-plugin` creates a builder named `maven` with a config directory pointing inside the `target` of the project 

Because of this, the `aissemble-versioning` module seemed unaware of changes to the `aissemble-fastapi` base image. This both caused the issue found by CI to be missed locally, and caused difficulty with verifying that the change fixed the issue, as `aissemble-versioning` was always using the remote image.

To address this issue (and hopefully also improve build speed as [noted by fabric8](https://dmp.fabric8.io/#build-buildx)), I've set the `dockerStateDir` to re-use the default docker config location of `~/.docker`.  In the rare event that this is _not_ the default config location, we still get the benefit of sharing a cache across aissemble image builds.