### PR TITLE
#150 switch fastapi image to python:3.11

### DIFF
--- a/extensions/extensions-docker/aissemble-fastapi/src/main/resources/docker/Dockerfile
+++ b/extensions/extensions-docker/aissemble-fastapi/src/main/resources/docker/Dockerfile
@@ -1,6 +1,6 @@
 # Script for creating base FastAPI Docker image
 
-FROM python:3.11-slim
+FROM python:3.11
 
 LABEL org.opencontainers.image.source="https://github.com/boozallen/aissemble"
 


### PR DESCRIPTION
Somehow reverted the oneline change to aissemble-fastapi without noticing in PR #196 