### PR TITLE
#199 fix environment variable substitution issue

### DIFF
--- a/extensions/extensions-docker/aissemble-hive/aissemble-hive-service/pom.xml
+++ b/extensions/extensions-docker/aissemble-hive/aissemble-hive-service/pom.xml
@@ -32,59 +32,23 @@
         </dependency>
     </dependencies>
 
-    <profiles>
-        <profile>
-            <id>ci</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>io.fabric8</groupId>
-                        <artifactId>docker-maven-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>default-push</id>
-                                <configuration>
-                                    <images>
-                                        <image>
-                                            <build>
-                                                <args>
-                                                    <METASTORE_VERSION>${version.hive.metastore}</METASTORE_VERSION>
-                                                    <JARS_DIR>${dockerbuild.jars.directory}</JARS_DIR>
-                                                </args>
-                                            </build>
-                                        </image>
-                                    </images>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
-
     <build>
         <plugins>
             <plugin>
                 <groupId>io.fabric8</groupId>
                 <artifactId>docker-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>default-build</id>
-                        <configuration>
-                            <images>
-                                <image>
-                                    <build>
-                                        <args>
-                                            <METASTORE_VERSION>${version.hive.metastore}</METASTORE_VERSION>
-                                            <JARS_DIR>${dockerbuild.jars.directory}</JARS_DIR>
-                                        </args>
-                                    </build>
-                                </image>
-                            </images>
-                        </configuration>
-                    </execution>
-                </executions>
+                <configuration>
+                    <images>
+                        <image>
+                            <build>
+                                <args>
+                                    <METASTORE_VERSION>${version.hive.metastore}</METASTORE_VERSION>
+                                    <JARS_DIR>${dockerbuild.jars.directory}</JARS_DIR>
+                                </args>
+                            </build>
+                        </image>
+                    </images>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/extensions/extensions-docker/aissemble-hive/aissemble-hive-service/src/main/resources/docker/Dockerfile
+++ b/extensions/extensions-docker/aissemble-hive/aissemble-hive-service/src/main/resources/docker/Dockerfile
@@ -12,15 +12,15 @@ ARG JARS_DIR
 ENV HADOOP_HOME=/opt/hadoop
 ENV HIVE_HOME=/opt/hive
 
-COPY --from=appsource /opt/hadoop ${HADOOP_HOME}
-COPY --from=appsource /opt/hive ${HIVE_HOME}
+COPY --from=appsource /opt/hadoop $HADOOP_HOME
+COPY --from=appsource /opt/hive $HIVE_HOME
 
 RUN groupadd -r hive --gid=1000 && \
-    useradd --home ${HIVE_HOME} -g hive --shell /usr/sbin/nologin --uid 1000 hive && \
-    chown hive:hive -R ${HIVE_HOME} && \
-    ln -s ${JAVA_HOME} /opt/jre
+    useradd --home $HIVE_HOME -g hive --shell /usr/sbin/nologin --uid 1000 hive && \
+    chown hive:hive -R $HIVE_HOME && \
+    ln -s $JAVA_HOME /opt/jre
 
-ADD ${JARS_DIR}/* ${HIVE_HOME}/lib/
+ADD ${JARS_DIR}/* $HIVE_HOME/lib/
 
 USER hive
 

--- a/extensions/extensions-docker/aissemble-spark-infrastructure/pom.xml
+++ b/extensions/extensions-docker/aissemble-spark-infrastructure/pom.xml
@@ -52,57 +52,23 @@
             <version>${version.delta}</version>
         </dependency>
     </dependencies>
-    <profiles>
-        <profile>
-            <id>ci</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>io.fabric8</groupId>
-                        <artifactId>docker-maven-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>default-push</id>
-                                <configuration>
-                                    <images>
-                                        <image>
-                                            <build>
-                                                <args>
-                                                    <JARS_DIR>${dockerbuild.jars.directory}</JARS_DIR>
-                                                </args>
-                                            </build>
-                                        </image>
-                                    </images>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
 
     <build>
         <plugins>
             <plugin>
                 <groupId>io.fabric8</groupId>
                 <artifactId>docker-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>default-build</id>
-                        <configuration>
-                            <images>
-                                <image>
-                                    <build>
-                                        <args>
-                                            <JARS_DIR>${dockerbuild.jars.directory}</JARS_DIR>
-                                        </args>
-                                    </build>
-                                </image>
-                            </images>
-                        </configuration>
-                    </execution>
-                </executions>
+                <configuration>
+                    <images>
+                        <image>
+                            <build>
+                                <args>
+                                    <JARS_DIR>${dockerbuild.jars.directory}</JARS_DIR>
+                                </args>
+                            </build>
+                        </image>
+                    </images>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/extensions/extensions-docker/aissemble-spark-infrastructure/src/main/resources/docker/Dockerfile
+++ b/extensions/extensions-docker/aissemble-spark-infrastructure/src/main/resources/docker/Dockerfile
@@ -6,9 +6,9 @@ ARG DELTA_HIVE_CONNECTOR_VERSION
 LABEL org.opencontainers.image.source="https://github.com/boozallen/aissemble"
 
 RUN curl -L https://github.com/delta-io/connectors/releases/download/v${DELTA_HIVE_CONNECTOR_VERSION}/delta-hive-assembly_2.12-${DELTA_HIVE_CONNECTOR_VERSION}.jar \
-          -o "${SPARK_HOME}"/jars/delta-hive-assembly_2.12-${DELTA_HIVE_CONNECTOR_VERSION}.jar
+          -o "$SPARK_HOME"/jars/delta-hive-assembly_2.12-${DELTA_HIVE_CONNECTOR_VERSION}.jar
 ARG JARS_DIR
-ADD ${JARS_DIR}/* ${SPARK_HOME}/jars/
+ADD ${JARS_DIR}/* $SPARK_HOME/jars/
 
 ENV SPARK_NO_DAEMONIZE=true
 USER spark

--- a/extensions/extensions-docker/aissemble-spark/src/main/resources/docker/Dockerfile
+++ b/extensions/extensions-docker/aissemble-spark/src/main/resources/docker/Dockerfile
@@ -10,11 +10,11 @@ USER root
 # Configures the desired version of Python to install
 ARG PYTHON_VERSION=3.11
 # Setup Spark home directory
-RUN mkdir ${SPARK_HOME}/checkpoint && \
-  mkdir ${SPARK_HOME}/krausening && \
-  mkdir ${SPARK_HOME}/warehouse && \
-  mkdir ${SPARK_HOME}/policies && \
-  mkdir ${SPARK_HOME}/logs && \
+RUN mkdir $SPARK_HOME/checkpoint && \
+  mkdir $SPARK_HOME/krausening && \
+  mkdir $SPARK_HOME/warehouse && \
+  mkdir $SPARK_HOME/policies && \
+  mkdir $SPARK_HOME/logs && \
   useradd --home /opt/spark --group 0 --shell /usr/sbin/nologin --uid 185 spark && \
   chown -R spark:spark /opt/spark
 
@@ -41,9 +41,9 @@ RUN apt-get update -y && apt-get install --assume-yes \
 RUN ln -sf /usr/bin/python3.11 /usr/bin/python3
 
 ## Add spark configurations
-COPY ./src/main/resources/conf/ ${SPARK_HOME}/conf/
+COPY ./src/main/resources/conf/ $SPARK_HOME/conf/
 
-RUN chown -R spark:spark ${SPARK_HOME}/conf/
+RUN chown -R spark:spark $SPARK_HOME/conf/
 
 # Fixed the Reflection API breaks java module boundary issue for Java 16+
 ENV JDK_JAVA_OPTIONS='--add-opens java.base/java.lang=ALL-UNNAMED'


### PR DESCRIPTION
We use curly braces for some of the ENV substitutions in our Dockerfiles, but because fabric8 does Maven property expansion, and by default looks for ${} to do that substitution, we were getting injection of host machine values instead of properly using the VM’s env. This PR is to change the environment variable substitution from ${X} to $X
