### PR TITLE
 #199 cleanup pipeline invocation service chart

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,6 +69,7 @@ extensions/extensions-helm/aissemble-spark-operator-chart/values.yaml
 extensions/extensions-helm/aissemble-jenkins-chart/values.yaml
 extensions/extensions-helm/aissemble-mlflow-chart/values.yaml
 extensions/extensions-helm/aissemble-kafka-chart/values.yaml
+extensions/extensions-helm/extensions-helm-pipeline-invocation/aissemble-pipeline-invocation-app-chart/values.yaml
 
 # The test project should test that we generate files that compile and have the expected structure for model options
 # there should not be any no custom logic added and we should clean up the project properly before each build

--- a/extensions/extensions-helm/extensions-helm-pipeline-invocation/aissemble-pipeline-invocation-app-chart/.helmignore
+++ b/extensions/extensions-helm/extensions-helm-pipeline-invocation/aissemble-pipeline-invocation-app-chart/.helmignore
@@ -1,0 +1,30 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/
+
+# Maven
+target
+pom.xml
+
+#helm ignore the base template and generate the values.yaml via POM plugin executions
+values.template.yaml

--- a/extensions/extensions-helm/extensions-helm-pipeline-invocation/aissemble-pipeline-invocation-app-chart/pom.xml
+++ b/extensions/extensions-helm/extensions-helm-pipeline-invocation/aissemble-pipeline-invocation-app-chart/pom.xml
@@ -25,6 +25,10 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>com.google.code.maven-replacer-plugin</groupId>
+                <artifactId>replacer</artifactId>
+            </plugin>
+            <plugin>
                 <groupId>${group.helm.plugin}</groupId>
                 <artifactId>helm-maven-plugin</artifactId>
             </plugin>

--- a/extensions/extensions-helm/extensions-helm-pipeline-invocation/aissemble-pipeline-invocation-app-chart/values.template.yaml
+++ b/extensions/extensions-helm/extensions-helm-pipeline-invocation/aissemble-pipeline-invocation-app-chart/values.template.yaml
@@ -4,6 +4,7 @@ aissemble-quarkus-chart:
   deployment:
     image:
       name: boozallen/aissemble-pipeline-invocation
+      tag: "@version.aissemble@"
     ports:
       - name: http-1
         containerPort: 8080
@@ -32,11 +33,13 @@ aissemble-quarkus-chart:
       - mp.messaging.incoming.pipeline-invocation.value.deserializer=org.apache.kafka.common.serialization.StringDeserializer
 
   service:
-    spec:
-      ports:
-        - name: "quarkus-management"
-          port: 9001
-          targetPort: 9000
+    ports:
+      - name: "invocation-rest"
+        port: 8085
+        targetPort: 8080
+      - name: "quarkus-mgmt"
+        port: 9001
+        targetPort: 9000
 
   ingress:
     enabled: false

--- a/foundation/foundation-mda/src/main/resources/templates/deployment/pipeline-invocation-service/v2/pipeline.invocation.service.values-dev.yaml.vm
+++ b/foundation/foundation-mda/src/main/resources/templates/deployment/pipeline-invocation-service/v2/pipeline.invocation.service.values-dev.yaml.vm
@@ -2,14 +2,8 @@
 aissemble-pipeline-invocation-chart:
   aissemble-quarkus-chart:
     image:
-      dockerRepo: ""
+      imagePullPolicy: IfNotPresent
     service:
-      type: NodePort
-      ports:
-        - name: "invocation-rest"
-          port: 8080
-          targetPort: 8080
-          nodePort: 30004
-        - name: "quarkus-managed"
-          port: 9001
-          targetPort: 9000
+      type: LoadBalancer
+    ingress:
+      enabled: false

--- a/foundation/foundation-mda/src/main/resources/templates/deployment/pipeline-invocation-service/v2/pipeline.invocation.service.values.yaml.vm
+++ b/foundation/foundation-mda/src/main/resources/templates/deployment/pipeline-invocation-service/v2/pipeline.invocation.service.values.yaml.vm
@@ -4,16 +4,5 @@ valuesFileDirectory: "target/"
 
 aissemble-pipeline-invocation-chart:
   aissemble-quarkus-chart:
-    deployment:
-      image:
-        tag: ${versionTag}
-      serviceAccountName: sparkoperator
-      automountServiceAccountToken: true
     app:
       name: "${appName}"
-    service:
-      spec:
-        ports:
-          - name: "invocation-rest"
-            port: 8080
-            targetPort: 8080


### PR DESCRIPTION
Aligns `aissemble-pipeline-invocation-chart-app` with best practices by:

 - Generating the correct image tag at build time instead of embedding in downstream chart
 - Using LoadBalancer to expose services for local testing
 - Pulling common configs into the parent chart instead of embedding in downstream charts
   - includes fixing the configuration of the Quarkus chart in the default values.yaml