### PR TITLE
 #199 images off of aissemble-quarkus & aissemble-fastapi

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,7 +58,7 @@ resources/proto/machine_learning_inference/generated/inference/grpc/generated
 docs/site/
 docs/antora-aissemble-ui/node_modules/
 docs/antora-aissemble-ui/public/
-/extensions/extensions-metadata-service/metastore_db/**
+/extensions/extensions-metadata-service/data/metastore_db/**
 
 
 # Helm charts
@@ -69,7 +69,8 @@ extensions/extensions-helm/aissemble-spark-operator-chart/values.yaml
 extensions/extensions-helm/aissemble-jenkins-chart/values.yaml
 extensions/extensions-helm/aissemble-mlflow-chart/values.yaml
 extensions/extensions-helm/aissemble-kafka-chart/values.yaml
-extensions/extensions-helm/extensions-helm-pipeline-invocation/aissemble-pipeline-invocation-app-chart/values.yaml
+extensions/extensions-helm/aissemble-fastapi-chart/values.yaml
+extensions/extensions-helm/aissemble-quarkus-chart/values.yaml
 
 # The test project should test that we generate files that compile and have the expected structure for model options
 # there should not be any no custom logic added and we should clean up the project properly before each build

--- a/extensions/extensions-data-delivery/extensions-data-delivery-spark/pom.xml
+++ b/extensions/extensions-data-delivery/extensions-data-delivery-spark/pom.xml
@@ -143,20 +143,25 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>net.masterthought</groupId>
+            <artifactId>cucumber-reporting</artifactId>
+            <version>${version.cucumber.reporting.plugin}</version>
+            <scope>test</scope>
+        </dependency>
+        <!-- These are large dependencies only used for ObjectStoreValidator so they're being set to provided since we
+          aren't really leveraging the ObjectStore. If we pick the ObjectStore effort back up, we should make this more
+          modular, so you're only pulling it in if you need it. -->
+        <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-s3</artifactId>
             <version>1.12.456</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-aws</artifactId>
             <version>${version.hadoop}</version>
-        </dependency>
-        <dependency>
-            <groupId>net.masterthought</groupId>
-            <artifactId>cucumber-reporting</artifactId>
-            <version>${version.cucumber.reporting.plugin}</version>
-            <scope>test</scope>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 

--- a/extensions/extensions-docker/aissemble-configuration-store/pom.xml
+++ b/extensions/extensions-docker/aissemble-configuration-store/pom.xml
@@ -49,12 +49,6 @@
             <artifactId>foundation-configuration-store</artifactId>
             <version>${project.version}</version>
         </dependency>
-        <dependency>
-            <groupId>${project.groupId}</groupId>
-            <artifactId>aissemble-quarkus</artifactId>
-            <version>${project.version}</version>
-            <type>pom</type>
-        </dependency>
     </dependencies>
 
 </project>

--- a/extensions/extensions-docker/aissemble-configuration-store/src/main/resources/docker/Dockerfile
+++ b/extensions/extensions-docker/aissemble-configuration-store/src/main/resources/docker/Dockerfile
@@ -1,12 +1,16 @@
-ARG DOCKER_BASELINE_REPO_ID
-ARG VERSION_AISSEMBLE
-FROM ${DOCKER_BASELINE_REPO_ID}boozallen/aissemble-quarkus:${VERSION_AISSEMBLE}
+FROM registry.access.redhat.com/ubi9/openjdk-17-runtime:1.20
 
 LABEL org.opencontainers.image.source="https://github.com/boozallen/aissemble"
 
-USER root
-RUN useradd --home /home/configstore --user-group --shell /usr/sbin/nologin --uid 1001 configstore
+#This is technically the default if nothing is set, but this ensures if we move it `run-java.sh` will still be able to find it
+ENV JAVA_APP_DIR="/deployments"
 
-USER 1001
+COPY --chown=default target/quarkus-app/lib/ $JAVA_APP_DIR/lib/
+COPY --chown=default target/quarkus-app/*.jar $JAVA_APP_DIR/
+COPY --chown=default target/quarkus-app/app/ $JAVA_APP_DIR/app/
+COPY --chown=default target/quarkus-app/quarkus/ $JAVA_APP_DIR/quarkus/
 
-COPY target/quarkus-app/ /deployments/
+ENV KRAUSENING_BASE="$JAVA_APP_DIR/krausening/base"
+
+# Setting log manager prevents vertx thread blocked exceptions. Password automatically masked by `run-java.sh`
+ENV JAVA_OPTS_APPEND="-Djava.util.logging.manager=org.jboss.logmanager.LogManager -DKRAUSENING_BASE=$KRAUSENING_BASE -DKRAUSENING_EXTENSIONS=$KRAUSENING_EXTENSIONS -DKRAUSENING_PASSWORD=$KRAUSENING_PASSWORD"

--- a/extensions/extensions-docker/aissemble-data-lineage-http-consumer/src/main/resources/docker/Dockerfile
+++ b/extensions/extensions-docker/aissemble-data-lineage-http-consumer/src/main/resources/docker/Dockerfile
@@ -1,7 +1,16 @@
-ARG DOCKER_BASELINE_REPO_ID
-ARG VERSION_AISSEMBLE
-FROM ${DOCKER_BASELINE_REPO_ID}boozallen/aissemble-quarkus:${VERSION_AISSEMBLE}
+FROM registry.access.redhat.com/ubi9/openjdk-17-runtime:1.20
 
 LABEL org.opencontainers.image.source="https://github.com/boozallen/aissemble"
 
-COPY target/quarkus-app/ /deployments/
+#This is technically the default if nothing is set, but this ensures if we move it `run-java.sh` will still be able to find it
+ENV JAVA_APP_DIR="/deployments"
+
+COPY --chown=default target/quarkus-app/lib/ $JAVA_APP_DIR/lib/
+COPY --chown=default target/quarkus-app/*.jar $JAVA_APP_DIR/
+COPY --chown=default target/quarkus-app/app/ $JAVA_APP_DIR/app/
+COPY --chown=default target/quarkus-app/quarkus/ $JAVA_APP_DIR/quarkus/
+
+ENV KRAUSENING_BASE="$JAVA_APP_DIR/krausening/base"
+
+# Setting log manager prevents vertx thread blocked exceptions. Password automatically masked by `run-java.sh`
+ENV JAVA_OPTS_APPEND="-Djava.util.logging.manager=org.jboss.logmanager.LogManager -DKRAUSENING_BASE=$KRAUSENING_BASE -DKRAUSENING_EXTENSIONS=$KRAUSENING_EXTENSIONS -DKRAUSENING_PASSWORD=$KRAUSENING_PASSWORD"

--- a/extensions/extensions-docker/aissemble-metadata/pom.xml
+++ b/extensions/extensions-docker/aissemble-metadata/pom.xml
@@ -49,12 +49,6 @@
             <artifactId>extensions-metadata-service</artifactId>
             <version>${project.version}</version>
         </dependency>
-        <dependency>
-            <groupId>com.boozallen.aissemble</groupId>
-            <artifactId>aissemble-quarkus</artifactId>
-            <version>${project.version}</version>
-            <type>pom</type>
-        </dependency>
     </dependencies>
 
 </project>

--- a/extensions/extensions-docker/aissemble-metadata/src/main/resources/docker/Dockerfile
+++ b/extensions/extensions-docker/aissemble-metadata/src/main/resources/docker/Dockerfile
@@ -1,12 +1,17 @@
-ARG DOCKER_BASELINE_REPO_ID
-ARG VERSION_AISSEMBLE
-FROM ${DOCKER_BASELINE_REPO_ID}boozallen/aissemble-quarkus:${VERSION_AISSEMBLE}
+# Java 17 results in a module-not-exported error
+FROM registry.access.redhat.com/ubi9/openjdk-11-runtime:1.20
 
 LABEL org.opencontainers.image.source="https://github.com/boozallen/aissemble"
 
-USER root
-RUN useradd --home /home/metadata --user-group --shell /usr/sbin/nologin --uid 1001 metadata
+#This is technically the default if nothing is set, but this ensures if we move it `run-java.sh` will still be able to find it
+ENV JAVA_APP_DIR="/deployments"
 
-USER 1001
+COPY --chown=default target/quarkus-app/lib/ $JAVA_APP_DIR/lib/
+COPY --chown=default target/quarkus-app/*.jar $JAVA_APP_DIR/
+COPY --chown=default target/quarkus-app/app/ $JAVA_APP_DIR/app/
+COPY --chown=default target/quarkus-app/quarkus/ $JAVA_APP_DIR/quarkus/
 
-COPY target/quarkus-app/ /deployments/
+ENV KRAUSENING_BASE="$JAVA_APP_DIR/krausening/base"
+
+# Setting log manager prevents vertx thread blocked exceptions. Password automatically masked by `run-java.sh`
+ENV JAVA_OPTS_APPEND="-Djava.util.logging.manager=org.jboss.logmanager.LogManager -DKRAUSENING_BASE=$KRAUSENING_BASE -DKRAUSENING_EXTENSIONS=$KRAUSENING_EXTENSIONS -DKRAUSENING_PASSWORD=$KRAUSENING_PASSWORD"

--- a/extensions/extensions-docker/aissemble-model-training-api-containers/aissemble-model-training-api-sagemaker/pom.xml
+++ b/extensions/extensions-docker/aissemble-model-training-api-containers/aissemble-model-training-api-sagemaker/pom.xml
@@ -30,11 +30,5 @@
             <version>${project.version}</version>
             <type>habushu</type>
         </dependency>
-        <dependency>
-            <groupId>com.boozallen.aissemble</groupId>
-            <artifactId>aissemble-fastapi</artifactId>
-            <version>${project.version}</version>
-            <type>pom</type>
-        </dependency>
     </dependencies>
 </project>

--- a/extensions/extensions-docker/aissemble-model-training-api-containers/aissemble-model-training-api-sagemaker/src/main/resources/docker/Dockerfile
+++ b/extensions/extensions-docker/aissemble-model-training-api-containers/aissemble-model-training-api-sagemaker/src/main/resources/docker/Dockerfile
@@ -1,7 +1,3 @@
-# Script for creating base AIOps Model Training API image
-ARG DOCKER_BASELINE_REPO_ID
-ARG VERSION_AISSEMBLE
-
 #HABUSHU_BUILDER_STAGE - HABUSHU GENERATED CODE (DO NOT MODIFY)
 FROM python:3.11 AS habushu_builder
 # Poetry and supporting plugin installations
@@ -24,8 +20,6 @@ RUN --mount=type=cache,target=/.cache/pypoetry/ \
     poetry bundle venv /opt/venv
 #HABUSHU_BUILDER_STAGE - HABUSHU GENERATED CODE (END)
 
-FROM ${DOCKER_BASELINE_REPO_ID}boozallen/aissemble-fastapi:${VERSION_AISSEMBLE} AS builder
-
 #HABUSHU_FINAL_STAGE - HABUSHU GENERATED CODE (DO NOT MODIFY)
 FROM python:3.11-slim AS final
 # Copy venv from builder and activate by adding to the path
@@ -37,7 +31,8 @@ LABEL org.opencontainers.image.source="https://github.com/boozallen/aissemble"
 
 # Set/move any required environmental variables and key scripts/configs needed by FastAPI from the base image
 # into the slimmed down final Python image
-ENV API_MAIN=model_training_api_sagemaker.model_training_api_sagemaker
-COPY --from=builder --chown=1001 /start.sh /start.sh
+ENV API_HOST='0.0.0.0'
+ENV API_PORT='80'
+ENV EXTRA_OPTS=''
 
-CMD ["/start.sh"]
+CMD python -m uvicorn "model_training_api_sagemaker.model_training_api_sagemaker:app" --host "$API_HOST" --port "$API_PORT" $EXTRA_OPTS

--- a/extensions/extensions-docker/aissemble-model-training-api-containers/aissemble-model-training-api/pom.xml
+++ b/extensions/extensions-docker/aissemble-model-training-api-containers/aissemble-model-training-api/pom.xml
@@ -30,11 +30,5 @@
             <version>${project.version}</version>
             <type>habushu</type>
         </dependency>
-        <dependency>
-            <groupId>com.boozallen.aissemble</groupId>
-            <artifactId>aissemble-fastapi</artifactId>
-            <version>${project.version}</version>
-            <type>pom</type>
-        </dependency>
     </dependencies>
 </project>

--- a/extensions/extensions-docker/aissemble-model-training-api-containers/aissemble-model-training-api/src/main/resources/docker/Dockerfile
+++ b/extensions/extensions-docker/aissemble-model-training-api-containers/aissemble-model-training-api/src/main/resources/docker/Dockerfile
@@ -1,7 +1,3 @@
-# Script for creating base AIOps Model Training API image
-ARG DOCKER_BASELINE_REPO_ID
-ARG VERSION_AISSEMBLE
-
 #HABUSHU_BUILDER_STAGE - HABUSHU GENERATED CODE (DO NOT MODIFY)
 FROM python:3.11 AS habushu_builder
 # Poetry and supporting plugin installations
@@ -24,8 +20,6 @@ RUN --mount=type=cache,target=/.cache/pypoetry/ \
     poetry bundle venv /opt/venv
 #HABUSHU_BUILDER_STAGE - HABUSHU GENERATED CODE (END)
 
-FROM ghcr.io/boozallen/aissemble-fastapi:1.8.0-SNAPSHOT AS builder
-
 #HABUSHU_FINAL_STAGE - HABUSHU GENERATED CODE (DO NOT MODIFY)
 FROM python:3.11-slim AS final
 # Copy venv from builder and activate by adding to the path
@@ -37,10 +31,10 @@ LABEL org.opencontainers.image.source="https://github.com/boozallen/aissemble"
 
 # Set/move any required environmental variables and key scripts/configs needed by FastAPI from the base image
 # into the slimmed down final Python image
-ENV API_MAIN=model_training_api.model_training_api
 ENV PYTHONUNBUFFERED="1"
 ENV GIT_PYTHON_REFRESH="quiet"
+ENV API_HOST='0.0.0.0'
+ENV API_PORT='80'
+ENV EXTRA_OPTS=''
 
-COPY --from=builder --chown=1001 /start.sh /start.sh
-
-CMD ["/start.sh"]
+CMD python -m uvicorn "model_training_api.model_training_api:app" --host "$API_HOST" --port "$API_PORT" $EXTRA_OPTS

--- a/extensions/extensions-docker/aissemble-pipeline-invocation/src/main/resources/docker/Dockerfile
+++ b/extensions/extensions-docker/aissemble-pipeline-invocation/src/main/resources/docker/Dockerfile
@@ -1,27 +1,19 @@
-# syntax=docker/dockerfile:1.3-labs
-ARG DOCKER_BASELINE_REPO_ID
-ARG VERSION_AISSEMBLE
-FROM ${DOCKER_BASELINE_REPO_ID}boozallen/aissemble-quarkus:${VERSION_AISSEMBLE}
+FROM registry.access.redhat.com/ubi9/openjdk-17-runtime:1.20 AS builder
+USER root
+RUN microdnf install -y openssl gzip && \
+    curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+
+FROM registry.access.redhat.com/ubi9/openjdk-17-runtime:1.20
 
 LABEL org.opencontainers.image.source="https://github.com/boozallen/aissemble"
 
-USER root
-# This overwrites any existing configuration in /etc/yum.repos.d/kubernetes.repo
-# Follow up by installing kubectl and helm
-RUN cat <<EOF | tee /etc/yum.repos.d/kubernetes.repo
-[kubernetes]
-name=Kubernetes
-baseurl=https://pkgs.k8s.io/core:/stable:/v1.28/rpm/
-enabled=1
-gpgcheck=1
-gpgkey=https://pkgs.k8s.io/core:/stable:/v1.28/rpm/repodata/repomd.xml.key
-EOF
+COPY --from=builder /usr/local/bin/helm /usr/local/bin/helm
 
-RUN microdnf install git tar kubectl && \
-    curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash && \
-    useradd --home /deployments/ --user-group --shell /usr/sbin/nologin --uid 1001 invocation
+#This is technically the default if nothing is set, but this ensures if we move it `run-java.sh` will still be able to find it
+ENV JAVA_APP_DIR="/deployments"
+COPY --chown=default target/dockerbuild/*.jar $JAVA_APP_DIR/
 
+ENV KRAUSENING_BASE="$JAVA_APP_DIR/krausening/base"
 
-USER 1001
-
-COPY target/dockerbuild/*.jar /deployments/
+# Setting log manager prevents vertx thread blocked exceptions. Password automatically masked by `run-java.sh`
+ENV JAVA_OPTS_APPEND="-Djava.util.logging.manager=org.jboss.logmanager.LogManager -DKRAUSENING_BASE=$KRAUSENING_BASE -DKRAUSENING_EXTENSIONS=$KRAUSENING_EXTENSIONS -DKRAUSENING_PASSWORD=$KRAUSENING_PASSWORD"

--- a/extensions/extensions-docker/aissemble-policy-decision-point/pom.xml
+++ b/extensions/extensions-docker/aissemble-policy-decision-point/pom.xml
@@ -46,12 +46,6 @@
             <artifactId>extensions-policy-decision-point-service</artifactId>
             <version>${project.version}</version>
         </dependency>
-        <dependency>
-            <groupId>com.boozallen.aissemble</groupId>
-            <artifactId>aissemble-quarkus</artifactId>
-            <version>${project.version}</version>
-            <type>pom</type>
-        </dependency>
     </dependencies>
 
 </project>

--- a/extensions/extensions-docker/aissemble-policy-decision-point/src/main/resources/docker/Dockerfile
+++ b/extensions/extensions-docker/aissemble-policy-decision-point/src/main/resources/docker/Dockerfile
@@ -1,18 +1,18 @@
-ARG DOCKER_BASELINE_REPO_ID
-ARG VERSION_AISSEMBLE
-FROM ${DOCKER_BASELINE_REPO_ID}boozallen/aissemble-quarkus:${VERSION_AISSEMBLE}
+FROM registry.access.redhat.com/ubi9/openjdk-17-runtime:1.20
 
 LABEL org.opencontainers.image.source="https://github.com/boozallen/aissemble"
 
-USER root
-RUN microdnf install jq
-USER 1001
+#This is technically the default if nothing is set, but this ensures if we move it `run-java.sh` will still be able to find it
+ENV JAVA_APP_DIR="/deployments"
 
-RUN mkdir -p /deployments/krausening/
-COPY target/dockerbuild/*.jar /deployments/
+COPY --chown=default ./src/main/resources/truststore/aissemble-secure.jks $JAVA_APP_DIR/
+COPY --chown=default ./src/main/resources/krausening/base/aiops-security.properties $JAVA_APP_DIR/krausening/base/
+COPY --chown=default ./src/main/resources/authorization/policies/test-policy.xml $JAVA_APP_DIR/
+COPY --chown=default ./src/main/resources/authorization/attributes/test-attributes.json $JAVA_APP_DIR/
+COPY --chown=default ./src/main/resources/authorization/pdp.xml $JAVA_APP_DIR/
+COPY --chown=default target/dockerbuild/*.jar $JAVA_APP_DIR/
 
-COPY ./src/main/resources/truststore/aissemble-secure.jks /deployments/
-COPY ./src/main/resources/krausening/base/aiops-security.properties /deployments/krausening/
-COPY ./src/main/resources/authorization/policies/test-policy.xml /deployments/
-COPY ./src/main/resources/authorization/attributes/test-attributes.json /deployments/
-COPY ./src/main/resources/authorization/pdp.xml /deployments/
+ENV KRAUSENING_BASE="$JAVA_APP_DIR/krausening/base"
+
+# Setting log manager prevents vertx thread blocked exceptions. Password automatically masked by `run-java.sh`
+ENV JAVA_OPTS_APPEND="-Djava.util.logging.manager=org.jboss.logmanager.LogManager -DKRAUSENING_BASE=$KRAUSENING_BASE -DKRAUSENING_EXTENSIONS=$KRAUSENING_EXTENSIONS -DKRAUSENING_PASSWORD=$KRAUSENING_PASSWORD"

--- a/extensions/extensions-docker/aissemble-versioning/pom.xml
+++ b/extensions/extensions-docker/aissemble-versioning/pom.xml
@@ -30,11 +30,5 @@
             <version>${project.version}</version>
             <type>habushu</type>
         </dependency>
-        <dependency>
-            <groupId>com.boozallen.aissemble</groupId>
-            <artifactId>aissemble-fastapi</artifactId>
-            <version>${project.version}</version>
-            <type>pom</type>
-        </dependency>
     </dependencies>
 </project>

--- a/extensions/extensions-docker/aissemble-versioning/src/main/resources/docker/Dockerfile
+++ b/extensions/extensions-docker/aissemble-versioning/src/main/resources/docker/Dockerfile
@@ -1,7 +1,3 @@
-# Script for creating base AIOps Versioning image
-ARG DOCKER_BASELINE_REPO_ID
-ARG VERSION_AISSEMBLE
-
 #HABUSHU_BUILDER_STAGE - HABUSHU GENERATED CODE (DO NOT MODIFY)
 FROM python:3.11 AS habushu_builder
 # Poetry and supporting plugin installations
@@ -24,7 +20,7 @@ RUN --mount=type=cache,target=/.cache/pypoetry/ \
     poetry bundle venv /opt/venv
 #HABUSHU_BUILDER_STAGE - HABUSHU GENERATED CODE (END)
 
-FROM ${DOCKER_BASELINE_REPO_ID}boozallen/aissemble-fastapi:${VERSION_AISSEMBLE} AS builder
+FROM python:3.11 AS builder
 
 # Download Maven
 ARG MAVEN_VERSION=3.9.6
@@ -64,8 +60,8 @@ COPY ./src/main/resources/docker/settings.xml /root/.m2/
 
 # Set/move any required environmental variables and key scripts/configs needed by FastAPI from the base image
 # into the slimmed down final Python image
-ENV API_MAIN=model_versioning.versioning_api
-COPY --from=builder /start.sh /start.sh
-COPY --from=builder /app /app
+ENV API_HOST='0.0.0.0'
+ENV API_PORT='80'
+ENV EXTRA_OPTS=''
 
-CMD ["/start.sh"]
+CMD python -m uvicorn "model_versioning.versioning_api:app" --host "$API_HOST" --port "$API_PORT" $EXTRA_OPTS

--- a/extensions/extensions-helm/aissemble-data-access-chart/values.yaml
+++ b/extensions/extensions-helm/aissemble-data-access-chart/values.yaml
@@ -1,7 +1,7 @@
 # Data Access
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
-aissemble-quarkus:
+aissemble-quarkus-chart:
   service:
     ports:
       - name: http

--- a/extensions/extensions-helm/aissemble-fastapi-chart/.helmignore
+++ b/extensions/extensions-helm/aissemble-fastapi-chart/.helmignore
@@ -1,2 +1,5 @@
 target
 pom.xml
+
+#helm ignore the base template and generate the values.yaml via POM plugin executions
+values.template.yaml

--- a/extensions/extensions-helm/aissemble-fastapi-chart/pom.xml
+++ b/extensions/extensions-helm/aissemble-fastapi-chart/pom.xml
@@ -16,6 +16,10 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>com.google.code.maven-replacer-plugin</groupId>
+                <artifactId>replacer</artifactId>
+            </plugin>
+            <plugin>
                 <groupId>${group.helm.plugin}</groupId>
                 <artifactId>helm-maven-plugin</artifactId>
             </plugin>

--- a/extensions/extensions-helm/aissemble-fastapi-chart/values.template.yaml
+++ b/extensions/extensions-helm/aissemble-fastapi-chart/values.template.yaml
@@ -10,6 +10,7 @@ replicaCount: 1
 hostname: fastapi
 image:
   name: boozallen/aissemble-fastapi
+  tag: "@version.aissemble@"
   imagePullPolicy: Always
   dockerRepo: ghcr.io/
 

--- a/extensions/extensions-helm/aissemble-keycloak-chart/values.yaml
+++ b/extensions/extensions-helm/aissemble-keycloak-chart/values.yaml
@@ -1,7 +1,6 @@
 ########################################
 ## CONFIG | Keycloak Configs
 ########################################
-aissemble-keycloak:
-   keycloak:
-      keycloakVersion: 21.1.1
-      defaultKeycloakTag: 21.1.1
+keycloak:
+   keycloakVersion: 21.1.1
+   defaultKeycloakTag: 21.1.1

--- a/extensions/extensions-helm/aissemble-lineage-http-consumer-chart/values.yaml
+++ b/extensions/extensions-helm/aissemble-lineage-http-consumer-chart/values.yaml
@@ -1,5 +1,5 @@
 ---
-aissemble-quarkus:
+aissemble-quarkus-chart:
   app:
     name: 'aissemble-lineage-http-consumer'
   deployment:

--- a/extensions/extensions-helm/aissemble-quarkus-chart/.helmignore
+++ b/extensions/extensions-helm/aissemble-quarkus-chart/.helmignore
@@ -1,2 +1,5 @@
 target
 pom.xml
+
+#helm ignore the base template and generate the values.yaml via POM plugin executions
+values.template.yaml

--- a/extensions/extensions-helm/aissemble-quarkus-chart/pom.xml
+++ b/extensions/extensions-helm/aissemble-quarkus-chart/pom.xml
@@ -16,6 +16,10 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>com.google.code.maven-replacer-plugin</groupId>
+                <artifactId>replacer</artifactId>
+            </plugin>
+            <plugin>
                 <groupId>${group.helm.plugin}</groupId>
                 <artifactId>helm-maven-plugin</artifactId>
             </plugin>

--- a/extensions/extensions-helm/aissemble-quarkus-chart/values.template.yaml
+++ b/extensions/extensions-helm/aissemble-quarkus-chart/values.template.yaml
@@ -10,7 +10,7 @@ deployment:
     # Override with specific image
     name: boozallen/aissemble-quarkus
     # Overrides the default chart AppVersion value
-    tag: ''
+    tag: "@version.aissemble@"
     # Default IfNotPresent
     imagePullPolicy: ''
   volumeMounts:

--- a/extensions/extensions-helm/aissemble-versioning-chart/values.yaml
+++ b/extensions/extensions-helm/aissemble-versioning-chart/values.yaml
@@ -3,7 +3,7 @@
 # Declare variables to be passed into your templates.
 
 # override image here
-aissemble-fastapi:
+aissemble-fastapi-chart:
   app:
     name: aissemble-versioning
   image:

--- a/extensions/extensions-helm/extensions-helm-pipeline-invocation/aissemble-pipeline-invocation-app-chart/pom.xml
+++ b/extensions/extensions-helm/extensions-helm-pipeline-invocation/aissemble-pipeline-invocation-app-chart/pom.xml
@@ -25,10 +25,6 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>com.google.code.maven-replacer-plugin</groupId>
-                <artifactId>replacer</artifactId>
-            </plugin>
-            <plugin>
                 <groupId>${group.helm.plugin}</groupId>
                 <artifactId>helm-maven-plugin</artifactId>
             </plugin>

--- a/extensions/extensions-helm/extensions-helm-pipeline-invocation/aissemble-pipeline-invocation-app-chart/values.yaml
+++ b/extensions/extensions-helm/extensions-helm-pipeline-invocation/aissemble-pipeline-invocation-app-chart/values.yaml
@@ -4,7 +4,6 @@ aissemble-quarkus-chart:
   deployment:
     image:
       name: boozallen/aissemble-pipeline-invocation
-      tag: "@version.aissemble@"
     ports:
       - name: http-1
         containerPort: 8080

--- a/extensions/extensions-helm/extensions-helm-pipeline-invocation/pom.xml
+++ b/extensions/extensions-helm/extensions-helm-pipeline-invocation/pom.xml
@@ -23,7 +23,6 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
-                <version>3.1.0</version>
                 <executions>
                     <execution>
                         <id>run tests</id>

--- a/extensions/extensions-helm/extensions-helm-spark-infrastructure/pom.xml
+++ b/extensions/extensions-helm/extensions-helm-spark-infrastructure/pom.xml
@@ -25,7 +25,6 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
-                <version>3.1.0</version>
                 <executions>
                     <execution>
                         <id>run tests</id>

--- a/extensions/extensions-metadata-service/src/main/java/com/boozallen/aiops/metadata/MetadataService.java
+++ b/extensions/extensions-metadata-service/src/main/java/com/boozallen/aiops/metadata/MetadataService.java
@@ -49,4 +49,11 @@ public class MetadataService {
                 .entity(metadata)
                 .build();
     }
+
+    @GET
+    @Path("/healthcheck")
+    @Produces({MediaType.TEXT_PLAIN})
+    public String healthCheck() {
+        return "Metadata service is running...\n";
+    }
 }

--- a/extensions/extensions-metadata-service/src/main/java/com/boozallen/aiops/metadata/hive/HiveMetadataAPIService.java
+++ b/extensions/extensions-metadata-service/src/main/java/com/boozallen/aiops/metadata/hive/HiveMetadataAPIService.java
@@ -119,6 +119,7 @@ public class HiveMetadataAPIService implements MetadataAPI {
                 .appName(metadataConfig.sparkAppName())
                 .enableHiveSupport()
                 .config("spark.driver.host", "localhost")
+                .config("spark.sql.warehouse.dir", "data/spark-warehouse")
                 .getOrCreate();
     }
 }

--- a/extensions/extensions-metadata-service/src/main/resources/hive-site.xml
+++ b/extensions/extensions-metadata-service/src/main/resources/hive-site.xml
@@ -1,0 +1,16 @@
+<!--
+  #%L
+  aiSSEMBLE::Extensions::Docker::Metadata
+  %%
+  Copyright (C) 2021 Booz Allen
+  %%
+  This software package is licensed under the Booz Allen Public License. All Rights Reserved.
+  #L%
+  -->
+<configuration>
+    <property>
+        <name>javax.jdo.option.ConnectionURL</name>
+        <value>jdbc:derby:data/metastore_db;create=true</value>
+        <description>JDBC connect string for a JDBC metastore</description>
+    </property>
+</configuration>

--- a/foundation/foundation-configuration-store/src/main/java/com/boozallen/aissemble/configuration/ConfigStoreInit.java
+++ b/foundation/foundation-configuration-store/src/main/java/com/boozallen/aissemble/configuration/ConfigStoreInit.java
@@ -40,10 +40,10 @@ public class ConfigStoreInit {
     public void init() {
         logger.info("Initialize store configuration properties and policies...");
         // We are loading all the properties upfront. In the future it might be more advantageous to load them as needed
-        String basePropertyUri = System.getProperty("KRAUSENING_BASE");
-        String environmentPropertyUri = System.getProperty("KRAUSENING_EXTENSIONS");
-        String basePolicyUri = System.getenv("BASE_POLICY_URI");
-        String environmentPolicyUri = System.getenv("ENVIRONMENT_POLICY_URI");
+        String basePropertyUri = getBootstrapConfiguration("KRAUSENING_BASE");
+        String environmentPropertyUri = getBootstrapConfiguration("KRAUSENING_EXTENSIONS");
+        String basePolicyUri = getBootstrapConfiguration("BASE_POLICY_URI");
+        String environmentPolicyUri = getBootstrapConfiguration("ENVIRONMENT_POLICY_URI");
 
         try {
             ConfigLoader configLoader = CDI.current().select(ConfigLoader.class,new Any.Literal()).get();
@@ -96,22 +96,34 @@ public class ConfigStoreInit {
         }
     }
 
+    private static String getBootstrapConfiguration(String propertyName) {
+        String propertyValue = System.getProperty(propertyName);
+        if(propertyValue == null) {
+            propertyValue = System.getenv(propertyName);
+            if(propertyValue != null) {
+                System.setProperty(propertyName, propertyValue);
+            }
+        }
+        return propertyValue;
+    }
+
     public static String getStatus() {
         return ConfigStoreInit.status.getValue();
     }
+
+    private enum Status {
+        LOAD_COMPLETE("Load Complete"),
+        LOAD_SKIPPED("Load Skipped");
+
+        private String value;
+
+        Status(final String value){
+            this.value = value;
+        }
+
+        public String getValue(){
+            return this.value;
+        }
+    }
 }
 
-enum Status {
-    LOAD_COMPLETE("Load Complete"),
-    LOAD_SKIPPED("Load Skipped");
-
-    private String value;
-
-    Status(final String value){
-        this.value = value;
-    }
-
-    public String getValue(){
-        return this.value;
-    }
-}

--- a/foundation/foundation-configuration-store/src/main/java/com/boozallen/aissemble/configuration/service/ConfigService.java
+++ b/foundation/foundation-configuration-store/src/main/java/com/boozallen/aissemble/configuration/service/ConfigService.java
@@ -48,4 +48,11 @@ public class ConfigService {
         }
         return Response.status(404).build();
     }
+
+    @GET
+    @Path("/healthcheck")
+    @Produces({MediaType.TEXT_PLAIN})
+    public String healthCheck() {
+        return "Configuration Store service is running...\n";
+    }
 }

--- a/foundation/foundation-data-access/pom.xml
+++ b/foundation/foundation-data-access/pom.xml
@@ -98,7 +98,25 @@
                     <groupId>xml-apis</groupId>
                     <artifactId>*</artifactId>
                 </exclusion>
+            <exclusion>
+                <groupId>org.apache.derby</groupId>
+                <artifactId>derby</artifactId>
+            </exclusion>
+                <exclusion>
+                    <groupId>org.apache.hadoop</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            <exclusion>
+                <groupId>org.apache.zookeeper</groupId>
+                <artifactId>zookeeper</artifactId>
+            </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <!-- Upgrade to 3.7.2 to fix CVE-2023-44981 -->
+            <groupId>org.apache.zookeeper</groupId>
+            <artifactId>zookeeper</artifactId>
+            <version>3.7.2</version>
         </dependency>
     </dependencies>
 

--- a/foundation/foundation-data-access/src/main/java/com/boozallen/aissemble/data/access/SparkQueryService.java
+++ b/foundation/foundation-data-access/src/main/java/com/boozallen/aissemble/data/access/SparkQueryService.java
@@ -20,7 +20,7 @@ import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
 import org.aeonbits.owner.KrauseningConfigFactory;
-import org.apache.commons.lang.ArrayUtils;
+import org.apache.commons.lang3.ArrayUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/test/test-mda-models/pom.xml
+++ b/test/test-mda-models/pom.xml
@@ -104,6 +104,7 @@
                     <plugin>
                         <groupId>org.codehaus.mojo</groupId>
                         <artifactId>exec-maven-plugin</artifactId>
+                        <version>3.1.0</version>
                         <executions>
                             <execution>
                                 <id>test-chart</id>


### PR DESCRIPTION
Our quarkus/fastapi images aren't really providing much utility, and because of the way fabric8 works out of the box, there are issues referencing images that are created higher up in the build.  We will work to resolve this down the road, but for now it's best just to move off of these images and prepare for potentially removing these base images entirely.

Moved `aissemble-quarkus` images:
 -  pdp
 -  metadata
 -  invocation svc
 -  config store
 -  lineage consumer

Moved `aissemble-fastapi` images:
 - versioning
 - model training
 - sagemaker training

Misc. cleanup items:
 - Address IA concerns in `foundation-data-access`
 - fix warning about missing exec plugin version in `test-mda-models`
 - fix chart references from 1.7 renames