### PR TITLE
#199 fix Krausening/Quarkus config through helm

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -1007,9 +1007,6 @@ To suppress enforce-helm-version rule, you must add following plugin to the root
 
         <profile>
             <id>ci</id>
-            <properties>
-                <docker.repo.id>ghcr.io</docker.repo.id>
-            </properties>
             <build>
                 <pluginManagement>
                     <plugins>
@@ -1057,7 +1054,6 @@ To suppress enforce-helm-version rule, you must add following plugin to the root
                 </pluginManagement>
             </build>
         </profile>
-
         <profile>
             <id>integration-test</id>
             <build>

--- a/extensions/extensions-docker/aissemble-configuration-store/pom.xml
+++ b/extensions/extensions-docker/aissemble-configuration-store/pom.xml
@@ -52,6 +52,12 @@
             <artifactId>foundation-configuration-store</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>com.boozallen.aissemble</groupId>
+            <artifactId>aissemble-quarkus</artifactId>
+            <version>${project.version}</version>
+            <type>docker-build</type>
+        </dependency>
     </dependencies>
 
 </project>

--- a/extensions/extensions-docker/aissemble-configuration-store/src/main/resources/docker/Dockerfile
+++ b/extensions/extensions-docker/aissemble-configuration-store/src/main/resources/docker/Dockerfile
@@ -1,16 +1,8 @@
-FROM registry.access.redhat.com/ubi9/openjdk-17-runtime:1.20
+FROM ${docker.baseline.repo.id}/boozallen/aissemble-quarkus:${project.version}
 
 LABEL org.opencontainers.image.source="https://github.com/boozallen/aissemble"
-
-#This is technically the default if nothing is set, but this ensures if we move it `run-java.sh` will still be able to find it
-ENV JAVA_APP_DIR="/deployments"
 
 COPY --chown=default target/quarkus-app/lib/ $JAVA_APP_DIR/lib/
 COPY --chown=default target/quarkus-app/*.jar $JAVA_APP_DIR/
 COPY --chown=default target/quarkus-app/app/ $JAVA_APP_DIR/app/
 COPY --chown=default target/quarkus-app/quarkus/ $JAVA_APP_DIR/quarkus/
-
-ENV KRAUSENING_BASE="$JAVA_APP_DIR/krausening/base"
-
-# Setting log manager prevents vertx thread blocked exceptions. Password automatically masked by `run-java.sh`
-ENV JAVA_OPTS_APPEND="-Djava.util.logging.manager=org.jboss.logmanager.LogManager -DKRAUSENING_BASE=$KRAUSENING_BASE -DKRAUSENING_EXTENSIONS=$KRAUSENING_EXTENSIONS -DKRAUSENING_PASSWORD=$KRAUSENING_PASSWORD"

--- a/extensions/extensions-docker/aissemble-data-lineage-http-consumer/pom.xml
+++ b/extensions/extensions-docker/aissemble-data-lineage-http-consumer/pom.xml
@@ -21,7 +21,7 @@
             <groupId>com.boozallen.aissemble</groupId>
             <artifactId>aissemble-quarkus</artifactId>
             <version>${project.version}</version>
-            <type>pom</type>
+            <type>docker-build</type>
         </dependency>
     </dependencies>
     <build>

--- a/extensions/extensions-docker/aissemble-data-lineage-http-consumer/src/main/resources/docker/Dockerfile
+++ b/extensions/extensions-docker/aissemble-data-lineage-http-consumer/src/main/resources/docker/Dockerfile
@@ -1,16 +1,8 @@
-FROM registry.access.redhat.com/ubi9/openjdk-17-runtime:1.20
+FROM ${docker.baseline.repo.id}/boozallen/aissemble-quarkus:${project.version}
 
 LABEL org.opencontainers.image.source="https://github.com/boozallen/aissemble"
-
-#This is technically the default if nothing is set, but this ensures if we move it `run-java.sh` will still be able to find it
-ENV JAVA_APP_DIR="/deployments"
 
 COPY --chown=default target/quarkus-app/lib/ $JAVA_APP_DIR/lib/
 COPY --chown=default target/quarkus-app/*.jar $JAVA_APP_DIR/
 COPY --chown=default target/quarkus-app/app/ $JAVA_APP_DIR/app/
 COPY --chown=default target/quarkus-app/quarkus/ $JAVA_APP_DIR/quarkus/
-
-ENV KRAUSENING_BASE="$JAVA_APP_DIR/krausening/base"
-
-# Setting log manager prevents vertx thread blocked exceptions. Password automatically masked by `run-java.sh`
-ENV JAVA_OPTS_APPEND="-Djava.util.logging.manager=org.jboss.logmanager.LogManager -DKRAUSENING_BASE=$KRAUSENING_BASE -DKRAUSENING_EXTENSIONS=$KRAUSENING_EXTENSIONS -DKRAUSENING_PASSWORD=$KRAUSENING_PASSWORD"

--- a/extensions/extensions-docker/aissemble-metadata/pom.xml
+++ b/extensions/extensions-docker/aissemble-metadata/pom.xml
@@ -53,6 +53,12 @@
             <artifactId>extensions-metadata-service</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>com.boozallen.aissemble</groupId>
+            <artifactId>aissemble-quarkus</artifactId>
+            <version>${project.version}</version>
+            <type>docker-build</type>
+        </dependency>
     </dependencies>
 
 </project>

--- a/extensions/extensions-docker/aissemble-metadata/src/main/resources/docker/Dockerfile
+++ b/extensions/extensions-docker/aissemble-metadata/src/main/resources/docker/Dockerfile
@@ -1,17 +1,8 @@
-# Java 17 results in a module-not-exported error
-FROM registry.access.redhat.com/ubi9/openjdk-11-runtime:1.20
+FROM ${docker.baseline.repo.id}/boozallen/aissemble-quarkus:${project.version}
 
 LABEL org.opencontainers.image.source="https://github.com/boozallen/aissemble"
-
-#This is technically the default if nothing is set, but this ensures if we move it `run-java.sh` will still be able to find it
-ENV JAVA_APP_DIR="/deployments"
 
 COPY --chown=default target/quarkus-app/lib/ $JAVA_APP_DIR/lib/
 COPY --chown=default target/quarkus-app/*.jar $JAVA_APP_DIR/
 COPY --chown=default target/quarkus-app/app/ $JAVA_APP_DIR/app/
 COPY --chown=default target/quarkus-app/quarkus/ $JAVA_APP_DIR/quarkus/
-
-ENV KRAUSENING_BASE="$JAVA_APP_DIR/krausening/base"
-
-# Setting log manager prevents vertx thread blocked exceptions. Password automatically masked by `run-java.sh`
-ENV JAVA_OPTS_APPEND="-Djava.util.logging.manager=org.jboss.logmanager.LogManager -DKRAUSENING_BASE=$KRAUSENING_BASE -DKRAUSENING_EXTENSIONS=$KRAUSENING_EXTENSIONS -DKRAUSENING_PASSWORD=$KRAUSENING_PASSWORD"

--- a/extensions/extensions-docker/aissemble-pipeline-invocation/pom.xml
+++ b/extensions/extensions-docker/aissemble-pipeline-invocation/pom.xml
@@ -16,7 +16,7 @@
             <groupId>com.boozallen.aissemble</groupId>
             <artifactId>aissemble-quarkus</artifactId>
             <version>${project.version}</version>
-            <type>pom</type>
+            <type>docker-build</type>
         </dependency>
         <dependency>
             <groupId>com.boozallen.aissemble</groupId>

--- a/extensions/extensions-docker/aissemble-pipeline-invocation/src/main/resources/docker/Dockerfile
+++ b/extensions/extensions-docker/aissemble-pipeline-invocation/src/main/resources/docker/Dockerfile
@@ -1,19 +1,11 @@
-FROM registry.access.redhat.com/ubi9/openjdk-17-runtime:1.20 AS builder
+FROM registry.access.redhat.com/ubi9/openjdk-11-runtime:1.20 AS builder
 USER root
 RUN microdnf install -y openssl gzip && \
     curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
 
-FROM registry.access.redhat.com/ubi9/openjdk-17-runtime:1.20
+FROM ${docker.baseline.repo.id}/boozallen/aissemble-quarkus:${project.version} AS final
 
 LABEL org.opencontainers.image.source="https://github.com/boozallen/aissemble"
 
 COPY --from=builder /usr/local/bin/helm /usr/local/bin/helm
-
-#This is technically the default if nothing is set, but this ensures if we move it `run-java.sh` will still be able to find it
-ENV JAVA_APP_DIR="/deployments"
 COPY --chown=default target/dockerbuild/*.jar $JAVA_APP_DIR/
-
-ENV KRAUSENING_BASE="$JAVA_APP_DIR/krausening/base"
-
-# Setting log manager prevents vertx thread blocked exceptions. Password automatically masked by `run-java.sh`
-ENV JAVA_OPTS_APPEND="-Djava.util.logging.manager=org.jboss.logmanager.LogManager -DKRAUSENING_BASE=$KRAUSENING_BASE -DKRAUSENING_EXTENSIONS=$KRAUSENING_EXTENSIONS -DKRAUSENING_PASSWORD=$KRAUSENING_PASSWORD"

--- a/extensions/extensions-docker/aissemble-policy-decision-point/pom.xml
+++ b/extensions/extensions-docker/aissemble-policy-decision-point/pom.xml
@@ -50,6 +50,12 @@
             <artifactId>extensions-policy-decision-point-service</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>com.boozallen.aissemble</groupId>
+            <artifactId>aissemble-quarkus</artifactId>
+            <version>${project.version}</version>
+            <type>docker-build</type>
+        </dependency>
     </dependencies>
 
 </project>

--- a/extensions/extensions-docker/aissemble-policy-decision-point/src/main/resources/docker/Dockerfile
+++ b/extensions/extensions-docker/aissemble-policy-decision-point/src/main/resources/docker/Dockerfile
@@ -1,9 +1,6 @@
-FROM registry.access.redhat.com/ubi9/openjdk-17-runtime:1.20
+FROM ${docker.baseline.repo.id}/boozallen/aissemble-quarkus:${project.version}
 
 LABEL org.opencontainers.image.source="https://github.com/boozallen/aissemble"
-
-#This is technically the default if nothing is set, but this ensures if we move it `run-java.sh` will still be able to find it
-ENV JAVA_APP_DIR="/deployments"
 
 COPY --chown=default ./src/main/resources/truststore/aissemble-secure.jks $JAVA_APP_DIR/
 COPY --chown=default ./src/main/resources/krausening/base/aiops-security.properties $JAVA_APP_DIR/krausening/base/
@@ -11,8 +8,3 @@ COPY --chown=default ./src/main/resources/authorization/policies/test-policy.xml
 COPY --chown=default ./src/main/resources/authorization/attributes/test-attributes.json $JAVA_APP_DIR/
 COPY --chown=default ./src/main/resources/authorization/pdp.xml $JAVA_APP_DIR/
 COPY --chown=default target/dockerbuild/*.jar $JAVA_APP_DIR/
-
-ENV KRAUSENING_BASE="$JAVA_APP_DIR/krausening/base"
-
-# Setting log manager prevents vertx thread blocked exceptions. Password automatically masked by `run-java.sh`
-ENV JAVA_OPTS_APPEND="-Djava.util.logging.manager=org.jboss.logmanager.LogManager -DKRAUSENING_BASE=$KRAUSENING_BASE -DKRAUSENING_EXTENSIONS=$KRAUSENING_EXTENSIONS -DKRAUSENING_PASSWORD=$KRAUSENING_PASSWORD"

--- a/extensions/extensions-docker/aissemble-quarkus/src/main/resources/docker/Dockerfile
+++ b/extensions/extensions-docker/aissemble-quarkus/src/main/resources/docker/Dockerfile
@@ -1,36 +1,14 @@
 # Script for creating base Quarkus application Docker image
-
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
+FROM registry.access.redhat.com/ubi9/openjdk-11-runtime:1.20
 
 LABEL org.opencontainers.image.source="https://github.com/boozallen/aissemble"
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
-ARG RUN_JAVA_VERSION=1.3.8
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
+#Copy Kraus env vars to JAVA_OPTS_APPEND with run-env.s
+COPY --chown=default ./src/main/resources/scripts/ /deployments/
 
-# Install java and the run-java script
-# Also set up permissions for user `1001`
-RUN microdnf install curl ca-certificates ${JAVA_PACKAGE} tzdata-java \
-    && microdnf update \
-    && microdnf clean all \
-    && mkdir /deployments \
-    && mkdir /deployments/classpath_extra \
-    && chown 1001 /deployments \
-    && chmod "g+rwX" /deployments \
-    && chown 1001:root /deployments \
-    && curl https://repo1.maven.org/maven2/io/fabric8/run-java-sh/${RUN_JAVA_VERSION}/run-java-sh-${RUN_JAVA_VERSION}-sh.sh -o /deployments/run-java.sh \
-    && chown 1001 /deployments/run-java.sh \
-    && chmod 540 /deployments/run-java.sh \
-    && chown -R 1001:root /deployments \
-    && echo "securerandom.source=file:/dev/urandom" >> /etc/alternatives/jre/conf/security/java.security
+#This is technically the default if nothing is set, but this ensures if we move it `run-java.sh` will still be able to find it
+ENV JAVA_APP_DIR="/deployments"
+ENV KRAUSENING_BASE="$JAVA_APP_DIR/krausening/base"
 
-# Configure the JAVA_OPTIONS
-ENV JAVA_OPTIONS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
-
-EXPOSE 8080
-USER 1001
-
-
-COPY ./src/main/resources/scripts/ /deployments/
-
-ENTRYPOINT [ "/deployments/run-java.sh" ]
+# Setting log manager prevents vertx thread blocked exceptions.
+ENV JAVA_OPTS_APPEND="-Djava.util.logging.manager=org.jboss.logmanager.LogManager"

--- a/extensions/extensions-docker/aissemble-quarkus/src/main/resources/scripts/run-env.sh
+++ b/extensions/extensions-docker/aissemble-quarkus/src/main/resources/scripts/run-env.sh
@@ -18,21 +18,21 @@ then
     then
       # Default to value that was originally in Dockerfile to maintain backwards compatability.
       echo "Defaulting KRAUSENING_BASE to /deployments/krausening/"
-      export JAVA_OPTIONS="$JAVA_OPTIONS -DKRAUSENING_BASE=/deployments/krausening/"
+      export JAVA_OPTS_APPEND="$JAVA_OPTS_APPEND -DKRAUSENING_BASE=/deployments/krausening/"
     else
-      export JAVA_OPTIONS="$JAVA_OPTIONS -DKRAUSENING_BASE=$KRAUSENING_BASE"
+      export JAVA_OPTS_APPEND="$JAVA_OPTS_APPEND -DKRAUSENING_BASE=$KRAUSENING_BASE"
   fi
   if [[ ${KRAUSENING_EXTENSIONS:-x} == x ]]
     then
       echo "KRAUSENING_EXTENSIONS not set"
     else
-      export JAVA_OPTIONS="$JAVA_OPTIONS -DKRAUSENING_EXTENSIONS=$KRAUSENING_EXTENSIONS"
+      export JAVA_OPTS_APPEND="$JAVA_OPTS_APPEND -DKRAUSENING_EXTENSIONS=$KRAUSENING_EXTENSIONS"
   fi
   if [[ ${KRAUSENING_PASSWORD:-x} == x ]]
     then
       echo "KRAUSENING_PASSWORD not set"
     else
-      export JAVA_OPTIONS="$JAVA_OPTIONS -DKRAUSENING_PASSWORD=$KRAUSENING_PASSWORD"
+      export JAVA_OPTS_APPEND="$JAVA_OPTS_APPEND -DKRAUSENING_PASSWORD=$KRAUSENING_PASSWORD"
   fi
 fi
 


### PR DESCRIPTION
Prior to transitioning the Quarkus-based Docker images off of the `aissemble-quarkus` image, we were setting JAVA_OPTIONS at startup via the `run-env.sh` script to include the Krausinening configuration through environment variables.  When it was moved, the script was dropped and the ENV vars were set directly during the image build. However, this makes the config unresponsive to the `env` config for Helm deployments which removes the ability to point Krausening to a different location at deploy time. For now, we'll just revert to using `aissemble-quarkus` and the `run-env.sh` script there.  Further work on Universal Config and a more "serverless" style of deployment will likely end up illuminating a better answer in the future.