### PR TITLE
#199 only start Vault during ITs

### DIFF
--- a/extensions/extensions-encryption/aissemble-extensions-encryption-vault-python/tests/features/encryption.feature
+++ b/extensions/extensions-encryption/aissemble-extensions-encryption-vault-python/tests/features/encryption.feature
@@ -1,32 +1,8 @@
 @properties
 Feature: Encryption
 
-  @integration
-  Scenario: Data can be encrypted and decrypted using Vault
-    Given a plain text string
-    When the string is encrypted using Vault
-    Then the encrypted string can be decrypted using Vault
-
   Scenario: Data can be encrypted and decrypted using AES algorithm
     Given a plain text string
     When the string is encrypted using AES encryption
     Then the encrypted string can be decrypted using AES
-
-  @integration
-  Scenario: Vault encryption locally by downloading a key from the server
-    Given a plain text string
-    When local vault encryption is requested
-    Then a key is downloaded from the Vault server
-
-  @integration
-  Scenario: Local Vault encryption and decryption
-    Given a plain text string
-    When local vault encryption is requested
-    Then the encrypted data can be decrypted using the local key copy
-
-  @integration
-  Scenario: Data can be encrypted and decrypted using AES GCM 96 algorithm
-    Given a plain text string
-    When the string is encrypted using AES GCM 96 encryption
-    Then the encrypted string can be decrypted using AES GCM 96
 

--- a/extensions/extensions-encryption/aissemble-extensions-encryption-vault-python/tests/features/vault.feature
+++ b/extensions/extensions-encryption/aissemble-extensions-encryption-vault-python/tests/features/vault.feature
@@ -1,0 +1,23 @@
+@properties @integration
+Feature: Encryption
+
+  Scenario: Data can be encrypted and decrypted using Vault
+    Given a plain text string
+    When the string is encrypted using Vault
+    Then the encrypted string can be decrypted using Vault
+
+  Scenario: Vault encryption locally by downloading a key from the server
+    Given a plain text string
+    When local vault encryption is requested
+    Then a key is downloaded from the Vault server
+
+  Scenario: Local Vault encryption and decryption
+    Given a plain text string
+    When local vault encryption is requested
+    Then the encrypted data can be decrypted using the local key copy
+
+  Scenario: Data can be encrypted and decrypted using AES GCM 96 algorithm
+    Given a plain text string
+    When the string is encrypted using AES GCM 96 encryption
+    Then the encrypted string can be decrypted using AES GCM 96
+


### PR DESCRIPTION
There is one unit test in `aissemble-extensions-encryption-vault-python` and 3 ITs. Because of the way the feature files and `environent.py` setup was structured, the Vault container was spun up even if only the unit test is being executed and the ITs are excluded.  This causes problems during the release as the Vault container is not available during the preparation phase, and generally slows down builds.