### PR TITLE
Fix Python service containers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,7 +39,6 @@ generated-test/
 *.pyc
 target
 dist
-poetry.toml
 poetry.lock
 
 # the wrapper should download the jar itself

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -575,8 +575,8 @@
                                         <build>
                                             <buildx>
                                                 <builderName>maven</builderName>
-                                                <cacheTo>type=local,dest=~/.docker/cache .</cacheTo>
-                                                <cacheFrom>type=local,src=~/.docker/cache .</cacheFrom>
+                                                <cacheTo>type=local,dest=${user.home}/.docker/cache</cacheTo>
+                                                <cacheFrom>type=local,src=${user.home}/.docker/cache</cacheFrom>
                                             </buildx>
                                         </build>
                                     </image>

--- a/extensions/aissemble-extensions-model-training-api-sagemaker/poetry.toml
+++ b/extensions/aissemble-extensions-model-training-api-sagemaker/poetry.toml
@@ -1,0 +1,6 @@
+[virtualenvs]
+prefer-active-python = true
+in-project = true
+
+[repositories.dev-pypi]
+url = "https://test.pypi.org/legacy/"

--- a/extensions/extensions-data-delivery/aissemble-extensions-data-delivery-spark-py/poetry.toml
+++ b/extensions/extensions-data-delivery/aissemble-extensions-data-delivery-spark-py/poetry.toml
@@ -1,0 +1,6 @@
+[virtualenvs]
+prefer-active-python = true
+in-project = true
+
+[repositories.dev-pypi]
+url = "https://test.pypi.org/legacy/"

--- a/extensions/extensions-encryption/aissemble-extensions-encryption-vault-python/poetry.toml
+++ b/extensions/extensions-encryption/aissemble-extensions-encryption-vault-python/poetry.toml
@@ -1,0 +1,6 @@
+[virtualenvs]
+prefer-active-python = true
+in-project = true
+
+[repositories.dev-pypi]
+url = "https://test.pypi.org/legacy/"

--- a/extensions/extensions-transform/aissemble-extensions-transform-spark-python/poetry.toml
+++ b/extensions/extensions-transform/aissemble-extensions-transform-spark-python/poetry.toml
@@ -1,0 +1,6 @@
+[virtualenvs]
+prefer-active-python = true
+in-project = true
+
+[repositories.dev-pypi]
+url = "https://test.pypi.org/legacy/"

--- a/foundation/aissemble-foundation-core-python/poetry.toml
+++ b/foundation/aissemble-foundation-core-python/poetry.toml
@@ -1,0 +1,6 @@
+[virtualenvs]
+prefer-active-python = true
+in-project = true
+
+[repositories.dev-pypi]
+url = "https://test.pypi.org/legacy/"

--- a/foundation/aissemble-foundation-model-training-api/poetry.toml
+++ b/foundation/aissemble-foundation-model-training-api/poetry.toml
@@ -1,0 +1,6 @@
+[virtualenvs]
+prefer-active-python = true
+in-project = true
+
+[repositories.dev-pypi]
+url = "https://test.pypi.org/legacy/"

--- a/foundation/aissemble-foundation-versioning-service/poetry.toml
+++ b/foundation/aissemble-foundation-versioning-service/poetry.toml
@@ -1,0 +1,6 @@
+[virtualenvs]
+prefer-active-python = true
+in-project = true
+
+[repositories.dev-pypi]
+url = "https://test.pypi.org/legacy/"

--- a/foundation/foundation-drift-detection/aissemble-foundation-drift-detection-client-python/poetry.toml
+++ b/foundation/foundation-drift-detection/aissemble-foundation-drift-detection-client-python/poetry.toml
@@ -1,0 +1,6 @@
+[virtualenvs]
+prefer-active-python = true
+in-project = true
+
+[repositories.dev-pypi]
+url = "https://test.pypi.org/legacy/"

--- a/foundation/foundation-encryption/aissemble-foundation-encryption-policy-python/poetry.toml
+++ b/foundation/foundation-encryption/aissemble-foundation-encryption-policy-python/poetry.toml
@@ -1,0 +1,6 @@
+[virtualenvs]
+prefer-active-python = true
+in-project = true
+
+[repositories.dev-pypi]
+url = "https://test.pypi.org/legacy/"

--- a/foundation/foundation-lineage/aissemble-foundation-model-lineage/poetry.toml
+++ b/foundation/foundation-lineage/aissemble-foundation-model-lineage/poetry.toml
@@ -1,0 +1,6 @@
+[virtualenvs]
+prefer-active-python = true
+in-project = true
+
+[repositories.dev-pypi]
+url = "https://test.pypi.org/legacy/"

--- a/foundation/foundation-lineage/foundation-data-lineage/aissemble-foundation-data-lineage-python/poetry.toml
+++ b/foundation/foundation-lineage/foundation-data-lineage/aissemble-foundation-data-lineage-python/poetry.toml
@@ -1,0 +1,6 @@
+[virtualenvs]
+prefer-active-python = true
+in-project = true
+
+[repositories.dev-pypi]
+url = "https://test.pypi.org/legacy/"

--- a/foundation/foundation-messaging/foundation-messaging-python/aissemble-foundation-messaging-python-client/poetry.toml
+++ b/foundation/foundation-messaging/foundation-messaging-python/aissemble-foundation-messaging-python-client/poetry.toml
@@ -1,0 +1,6 @@
+[virtualenvs]
+prefer-active-python = true
+in-project = true
+
+[repositories.dev-pypi]
+url = "https://test.pypi.org/legacy/"

--- a/foundation/foundation-security/aissemble-foundation-pdp-client-python/poetry.toml
+++ b/foundation/foundation-security/aissemble-foundation-pdp-client-python/poetry.toml
@@ -1,0 +1,6 @@
+[virtualenvs]
+prefer-active-python = true
+in-project = true
+
+[repositories.dev-pypi]
+url = "https://test.pypi.org/legacy/"

--- a/foundation/foundation-transform/aissemble-foundation-transform-core-python/poetry.toml
+++ b/foundation/foundation-transform/aissemble-foundation-transform-core-python/poetry.toml
@@ -1,0 +1,6 @@
+[virtualenvs]
+prefer-active-python = true
+in-project = true
+
+[repositories.dev-pypi]
+url = "https://test.pypi.org/legacy/"

--- a/test/test-mda-models/aissemble-test-data-delivery-pyspark-model-basic/poetry.toml
+++ b/test/test-mda-models/aissemble-test-data-delivery-pyspark-model-basic/poetry.toml
@@ -1,0 +1,6 @@
+[virtualenvs]
+prefer-active-python = true
+in-project = true
+
+[repositories.dev-pypi]
+url = "https://test.pypi.org/legacy/"

--- a/test/test-mda-models/aissemble-test-data-delivery-pyspark-model/poetry.toml
+++ b/test/test-mda-models/aissemble-test-data-delivery-pyspark-model/poetry.toml
@@ -1,0 +1,6 @@
+[virtualenvs]
+prefer-active-python = true
+in-project = true
+
+[repositories.dev-pypi]
+url = "https://test.pypi.org/legacy/"

--- a/test/test-mda-models/test-machine-learning-base-model/aissemble-machine-learning-training-base/poetry.toml
+++ b/test/test-mda-models/test-machine-learning-base-model/aissemble-machine-learning-training-base/poetry.toml
@@ -1,0 +1,6 @@
+[virtualenvs]
+prefer-active-python = true
+in-project = true
+
+[repositories.dev-pypi]
+url = "https://test.pypi.org/legacy/"

--- a/test/test-mda-models/test-machine-learning-model/aissemble-machine-learning-inference/poetry.toml
+++ b/test/test-mda-models/test-machine-learning-model/aissemble-machine-learning-inference/poetry.toml
@@ -1,0 +1,6 @@
+[virtualenvs]
+prefer-active-python = true
+in-project = true
+
+[repositories.dev-pypi]
+url = "https://test.pypi.org/legacy/"

--- a/test/test-mda-models/test-machine-learning-model/aissemble-machine-learning-sagemaker-training/poetry.toml
+++ b/test/test-mda-models/test-machine-learning-model/aissemble-machine-learning-sagemaker-training/poetry.toml
@@ -1,0 +1,6 @@
+[virtualenvs]
+prefer-active-python = true
+in-project = true
+
+[repositories.dev-pypi]
+url = "https://test.pypi.org/legacy/"

--- a/test/test-mda-models/test-machine-learning-model/aissemble-machine-learning-training/poetry.toml
+++ b/test/test-mda-models/test-machine-learning-model/aissemble-machine-learning-training/poetry.toml
@@ -1,0 +1,6 @@
+[virtualenvs]
+prefer-active-python = true
+in-project = true
+
+[repositories.dev-pypi]
+url = "https://test.pypi.org/legacy/"


### PR DESCRIPTION
While there are several confounding factors, the root issue was a release by the `bundle` plugin team on Friday. Release 1.4.0 appears to have a bug so that if a project has an existing virtual environment, the target location is _ignored_.  This means we weren't creating the venv bundle at `/opt/venv` as expected.

We weren't seeing this locally because we use in-project virtual environments that are not copied to CI.  For reasons outside the scope of this PR, CI was using a poetry.toml file that did _not_ use an in-project env thus encountering the bug.  To provide better consistency between CI and local (and between Maven/Habushu and native Poetry) we will commit `poetry.toml`.