### PR TITLE
 #255 fix PDP image and change Dockerfile delimiter

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -589,6 +589,7 @@
                             <image>
                                 <name>${docker.repo.id}/${dockerImageName}:${dockerImageVersion}</name>
                                 <build>
+                                    <filter>@</filter>
                                     <args>
                                         <DOCKER_BASELINE_REPO_ID>${docker.baseline.repo.id}/</DOCKER_BASELINE_REPO_ID>
                                         <VERSION_AISSEMBLE>${version.aissemble}</VERSION_AISSEMBLE>

--- a/extensions/extensions-docker/aissemble-configuration-store/src/main/resources/docker/Dockerfile
+++ b/extensions/extensions-docker/aissemble-configuration-store/src/main/resources/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM ${docker.baseline.repo.id}/boozallen/aissemble-quarkus:${project.version}
+FROM @docker.baseline.repo.id@/boozallen/aissemble-quarkus:@project.version@
 
 LABEL org.opencontainers.image.source="https://github.com/boozallen/aissemble"
 

--- a/extensions/extensions-docker/aissemble-data-lineage-http-consumer/src/main/resources/docker/Dockerfile
+++ b/extensions/extensions-docker/aissemble-data-lineage-http-consumer/src/main/resources/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM ${docker.baseline.repo.id}/boozallen/aissemble-quarkus:${project.version}
+FROM @docker.baseline.repo.id@/boozallen/aissemble-quarkus:@project.version@
 
 LABEL org.opencontainers.image.source="https://github.com/boozallen/aissemble"
 

--- a/extensions/extensions-docker/aissemble-metadata/src/main/resources/docker/Dockerfile
+++ b/extensions/extensions-docker/aissemble-metadata/src/main/resources/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM ${docker.baseline.repo.id}/boozallen/aissemble-quarkus:${project.version}
+FROM @docker.baseline.repo.id@/boozallen/aissemble-quarkus:@project.version@
 
 LABEL org.opencontainers.image.source="https://github.com/boozallen/aissemble"
 

--- a/extensions/extensions-docker/aissemble-pipeline-invocation/src/main/resources/docker/Dockerfile
+++ b/extensions/extensions-docker/aissemble-pipeline-invocation/src/main/resources/docker/Dockerfile
@@ -3,7 +3,7 @@ USER root
 RUN microdnf install -y openssl gzip && \
     curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
 
-FROM ${docker.baseline.repo.id}/boozallen/aissemble-quarkus:${project.version} AS final
+FROM @docker.baseline.repo.id@/boozallen/aissemble-quarkus:@project.version@ AS final
 
 LABEL org.opencontainers.image.source="https://github.com/boozallen/aissemble"
 

--- a/extensions/extensions-docker/aissemble-policy-decision-point/README.md
+++ b/extensions/extensions-docker/aissemble-policy-decision-point/README.md
@@ -5,7 +5,7 @@ on a Quarkus server.
 
 To start this container run
 
-`docker run -p 8780:8080 boozallen/aissemble-policy-decision-point:AISSEMBLE_VERSION`
+`docker run -p 8780:8080 ghcr.io/boozallen/aissemble-policy-decision-point:AISSEMBLE_VERSION`
 
 substituting the current aiSSEMBLE&trade; version for `AISSEMBLE_VERSION`, ie 1.2.0-SNAPSHOT
 
@@ -16,15 +16,15 @@ POST localhost:8780/api/pdp
 Body:
 ``` json
 {
-  "jwt": "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.eyJqdGkiOiI3ZDZmMWZlNS05YzZiLTQ1ZGEtODlmMS0yMDM5YWIwNWZhNDEiLCJzdWIiOiJhaW9wcyIsImF1ZCI6ImF1ZGllbmNlIiwibmJmIjoxNjI0OTc2MDI5LCJpYXQiOjE2MjQ5NzYwMjksImV4cCI6MTkyNDk4MDc5NywiaXNzIjoiYWlvcHMuYXV0aG9yaXR5In0.eUBC2ink77XRf5n5JIXlLZR-fBiRmGrqo1TBFz46yZhWDY38dsh30flELE8gO5SG2rUSIe-VmmjSny8PFLNGwy5MGLwr9z56HoH7OrejJeEzCa1yBl67VWgUZhoDy3RzvARfdBnUstfigHYeQA2ECvW-b2kppYJPVUNX2uKmwfZupwqCGqIX56s7qntV0dUAjpC_KiZ3fjUz1HXqK_evWos0xPVT8XOB2ZADhh87kf7LmocYQ4Y-Z_fsou6jqYh1lQT8WeI2AKskE613nSqmTA2bax5-dOFXKWKLy8t5glyjkdqFZVrLrNkK9tXqNYpZ8efIkZKOu7T9TlsvkHU1XQ",
-  "resource": null,
+  "jwt": "eyJhbGciOiJSUzI1NiJ9.eyJqdGkiOiI0ZDdmZTRkYy00MjI5LTQxMzAtODczMi00ZTUwY2FlYmRlOTIiLCJzdWIiOiJhaXNzZW1ibGUiLCJhdWQiOiJhdWRpZW5jZSIsIm5iZiI6MTcyMjU0MjUzMiwiaWF0IjoxNzIyNTQyNTkyLCJleHAiOjE3MjI1NDYyNTIsImlzcyI6ImFpb3BzLmF1dGhvcml0eSJ9.byliAiYHgapHVHi5dl2YjzkhlUBiPXhpsvCcEIFqTIdvs6ruGYJt7a-TxG5wLRMtUA34k0fNVKVAtNAb50P8bh60FphjI9PwUwjiYio1Cek9zJbQRz8gB-FMWwOX1dsOAt4XRiUDJHeuV_Rok4fa1p0CZJeuVRAW4YSb1v_jhN-mBg59jYbOM5kXuorZ8vG-rXcl2JYCCojmDOeW48WcCivhmUq70KTZzvhSS43DeCSGF4m20-hzjNOrZfwZC6OOYg0huiETZTXq2zpFXVGlyYMlheR5Dhn79GDKvs0N42TyGfSKfXVI5oCYlUj7he9Yous9zK2vFfZYgWQtYmf0Dw",
+  "resource": "*",
   "action": "data-access"
 }
 ```
-**Note:** The provided jwt has a long expiration date and is valid for several years.  Typically, you would configure 
-your security policies to limit how long a token can be valid and require a new token on a regular basis. To generate 
-a new token you can send a GET request to http://localhost:8080/api/token which will return a valid token.  You can 
-then substitute this token in the example json above.
+**Note:** The provided jwt is just an example and is expired. To generate a new token you can send a POST request to
+http://localhost:8080/api/authenticate with a `"username"` and `"password"`. The default example authentication mechanism
+simply returns a valid token for the given username. This can be replaced with, e.g., a Keycloak backed secure token
+service. Once you have a valid JWT, you can then substitute this token in the example json above.
 
 
 * jwt
@@ -35,9 +35,10 @@ then substitute this token in the example json above.
     * Used if you need a policy decision for performing an action.
 
 
-The default policy `test-policy.xml` will return a "PERMIT" decision if the subject has an attribute 
-`urn:aiops:accessData` with a value of true. Conversely, it will return a "DENY" decision of the same attribute is false.
-
-For this example we are using a local attribute store `LocalAttributePoint.java` which will look up attributes for 
-a given subject (from the jwt) and return the matching attributes.  
+The default policy `test-policy.xml` will return a "PERMIT" decision for the `data-access` action if the subject has an
+attribute `urn:aissemble:accessData` with a value of true. Conversely, it will return a "DENY" decision of the same
+attribute is false. For this example we are using a local attribute store `LocalAttributePoint.java` which will look up
+attributes for a given subject (from the jwt) and return the matching attributes.  This simple implementation simply
+sets the attribute to true if the subject (the user for which the token was created) is `aissemble` and false otherwise.
+For any actions other than `data-access` the policy will return a "NOT_APPLICABLE" decision.
  

--- a/extensions/extensions-docker/aissemble-policy-decision-point/src/main/resources/authorization/attributes/test-attributes.json
+++ b/extensions/extensions-docker/aissemble-policy-decision-point/src/main/resources/authorization/attributes/test-attributes.json
@@ -1,6 +1,6 @@
 [
 	{
-		"id": "urn:aiops:accessData",
+		"id": "urn:aissemble:accessData",
 		"category": "subject",
 		"type": "boolean",
 		"required": "false",

--- a/extensions/extensions-docker/aissemble-policy-decision-point/src/main/resources/authorization/pdp.xml
+++ b/extensions/extensions-docker/aissemble-policy-decision-point/src/main/resources/authorization/pdp.xml
@@ -14,7 +14,7 @@
      xmlns:ext="http://github.com/boozallen/aissemble/authz/attribute/1"
      xmlns:xacml="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17"
      version="8.1">
-    <attributeProvider id="aiopsAttributeExtension" xsi:type="ext:AiopsAttributeExtension">
+    <attributeProvider id="aissembleAttributeExtension" xsi:type="ext:AissembleAttributeExtension">
         <xacml:Attributes Category="urn:oasis:names:tc:xacml:1.0:subject-category:access-subject"/>
     </attributeProvider>
     <policyProvider id="rootPolicyProvider" xsi:type="StaticPolicyProvider">

--- a/extensions/extensions-docker/aissemble-policy-decision-point/src/main/resources/authorization/policies/test-policy.xml
+++ b/extensions/extensions-docker/aissemble-policy-decision-point/src/main/resources/authorization/policies/test-policy.xml
@@ -41,7 +41,7 @@
 				<Apply
 						FunctionId="urn:oasis:names:tc:xacml:1.0:function:boolean-one-and-only">
 					<AttributeDesignator
-							AttributeId="urn:aiops:accessData"
+							AttributeId="urn:aissemble:accessData"
 							Category="urn:oasis:names:tc:xacml:1.0:subject-category:access-subject"
 							DataType="http://www.w3.org/2001/XMLSchema#boolean"
 							MustBePresent="false" />
@@ -76,7 +76,7 @@
 				<Apply
 						FunctionId="urn:oasis:names:tc:xacml:1.0:function:boolean-one-and-only">
 					<AttributeDesignator
-							AttributeId="urn:aiops:accessData"
+							AttributeId="urn:aissemble:accessData"
 							Category="urn:oasis:names:tc:xacml:1.0:subject-category:access-subject"
 							DataType="http://www.w3.org/2001/XMLSchema#boolean"
 							MustBePresent="false" />

--- a/extensions/extensions-docker/aissemble-policy-decision-point/src/main/resources/docker/Dockerfile
+++ b/extensions/extensions-docker/aissemble-policy-decision-point/src/main/resources/docker/Dockerfile
@@ -1,10 +1,14 @@
-FROM ${docker.baseline.repo.id}/boozallen/aissemble-quarkus:${project.version}
+FROM @docker.baseline.repo.id@/boozallen/aissemble-quarkus:@project.version@
 
 LABEL org.opencontainers.image.source="https://github.com/boozallen/aissemble"
 
-COPY --chown=default ./src/main/resources/truststore/aissemble-secure.jks $JAVA_APP_DIR/
-COPY --chown=default ./src/main/resources/krausening/base/aissemble-security.properties $JAVA_APP_DIR/krausening/base/
-COPY --chown=default ./src/main/resources/authorization/policies/test-policy.xml $JAVA_APP_DIR/
-COPY --chown=default ./src/main/resources/authorization/attributes/test-attributes.json $JAVA_APP_DIR/
-COPY --chown=default ./src/main/resources/authorization/pdp.xml $JAVA_APP_DIR/
-COPY --chown=default target/dockerbuild/*.jar $JAVA_APP_DIR/
+COPY --chown=default ./src/main/resources/truststore/aissemble-secure.jks ${JAVA_APP_DIR}/
+COPY --chown=default ./src/main/resources/krausening/base/aissemble-security.properties ${JAVA_APP_DIR}/krausening/base/
+COPY --chown=default ./src/main/resources/authorization/policies/test-policy.xml ${JAVA_APP_DIR}/
+COPY --chown=default ./src/main/resources/authorization/attributes/test-attributes.json ${JAVA_APP_DIR}/
+COPY --chown=default ./src/main/resources/authorization/pdp.xml ${JAVA_APP_DIR}/
+COPY --chown=default target/dockerbuild/*.jar ${JAVA_APP_DIR}/
+
+# Uncomment the following lines to enable remote debugging
+#ENV JAVA_OPTS_APPEND='-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:5005'
+#EXPOSE 5005

--- a/extensions/extensions-docker/aissemble-spark/src/main/resources/conf/log4j.properties
+++ b/extensions/extensions-docker/aissemble-spark/src/main/resources/conf/log4j.properties
@@ -51,4 +51,4 @@ log4j.logger.org.apache.kafka.common.utils.AppInfoParser=WARN
 log4j.logger.org.apache.hadoop.hive.metastore.RetryingHMSHandler=FATAL
 log4j.logger.org.apache.hadoop.hive.ql.exec.FunctionRegistry=ERROR
 
-log4j.additivity.com.boozallen.aiops=false
+log4j.additivity.com.boozallen.aissemble=false

--- a/extensions/extensions-docker/aissemble-versioning/README.md
+++ b/extensions/extensions-docker/aissemble-versioning/README.md
@@ -18,7 +18,7 @@ The following environment variables are required for model versioning:
 Below is a basic example of how to leverage the versioning service:
 - Extending the baseline docker image to include Nexus credentials
     ```
-    FROM boozallen/aiops-versioning:1.0
+    FROM ghcr.io/boozallen/aissemble-versioning:1.0
 
     COPY /custom/maven/settings/containing/nexus/credentials.xml /root/.m2/settings.xml
     ```
@@ -37,7 +37,7 @@ Below is a basic example of how to leverage the versioning service:
     - Add the following to the above docker-compose file:
         ```
         policy-decision-point:
-            image: ${CONTAINER_REGISTRY}boozallen/policy-decision-point-docker:latest
+            image: ghcr.io/boozallen/policy-decision-point-docker:latest
             hostname: policy-decision-point
             container_name: policy-decision-point
             ports:

--- a/extensions/extensions-docker/aissemble-versioning/src/main/resources/model_versioning/model-pom.xml
+++ b/extensions/extensions-docker/aissemble-versioning/src/main/resources/model_versioning/model-pom.xml
@@ -14,7 +14,7 @@
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
-	<groupId>com.boozallen.aiops.versioning</groupId>
+	<groupId>com.boozallen.aissemble</groupId>
 	<artifactId>model</artifactId>
 	<version>1.0.0-SNAPSHOT</version>
 


### PR DESCRIPTION
The rename of the security module in #232 broke the default Policy Decision Point image, because of the class rename of `AissembleAttributeExtension` was not propagated to the `pdp.xml` file. The demo/example policy was also broken because the subject/user name and the URN of the attribute that the `LocalAttributePoint` class was looking for was changed, but the test-attribute.json and test-policy.xml included in the image was not updated. Further, the example JWT token was for the wrong subject name.