### PR TITLE
#258 update policy-decision-point to package service into zip instead of uber-jar

### DIFF
--- a/extensions/extensions-data-lineage/extensions-data-lineage-http-consumer-service/pom.xml
+++ b/extensions/extensions-data-lineage/extensions-data-lineage-http-consumer-service/pom.xml
@@ -139,26 +139,6 @@
                     <skipOriginalJarRename>true</skipOriginalJarRename>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-dependency-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>unpack-docker-resources</id>
-                        <phase>prepare-package</phase>
-                        <goals>
-                            <goal>unpack-dependencies</goal>
-                        </goals>
-                        <configuration>
-                            <outputDirectory>${project.build.directory}</outputDirectory>
-                            <includeArtifactIds>extensions-data-lineage</includeArtifactIds>
-                            <type>zip</type>
-                            <classifier>app</classifier>
-                            <failOnMissingClassifierArtifact>true</failOnMissingClassifierArtifact>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
             <!-- Packages the quarkus app and its dependencies into a zip-->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/extensions/extensions-docker/aissemble-policy-decision-point/pom.xml
+++ b/extensions/extensions-docker/aissemble-policy-decision-point/pom.xml
@@ -24,15 +24,17 @@
                 <artifactId>maven-dependency-plugin</artifactId>
                 <executions>
                     <execution>
-                        <id>copy-docker-resources</id>
+                        <id>unpack-docker-resources</id>
                         <phase>prepare-package</phase>
                         <goals>
-                            <goal>copy-dependencies</goal>
+                            <goal>unpack-dependencies</goal>
                         </goals>
                         <configuration>
-                            <outputDirectory>${project.build.directory}/dockerbuild</outputDirectory>
+                            <outputDirectory>${project.build.directory}</outputDirectory>
                             <includeArtifactIds>extensions-policy-decision-point-service</includeArtifactIds>
-                            <classifier>runner</classifier>
+                            <type>zip</type>
+                            <classifier>app</classifier>
+                            <failOnMissingClassifierArtifact>true</failOnMissingClassifierArtifact>
                         </configuration>
                     </execution>
                 </executions>

--- a/extensions/extensions-docker/aissemble-policy-decision-point/src/main/resources/docker/Dockerfile
+++ b/extensions/extensions-docker/aissemble-policy-decision-point/src/main/resources/docker/Dockerfile
@@ -7,8 +7,10 @@ COPY --chown=default ./src/main/resources/krausening/base/aissemble-security.pro
 COPY --chown=default ./src/main/resources/authorization/policies/test-policy.xml ${JAVA_APP_DIR}/
 COPY --chown=default ./src/main/resources/authorization/attributes/test-attributes.json ${JAVA_APP_DIR}/
 COPY --chown=default ./src/main/resources/authorization/pdp.xml ${JAVA_APP_DIR}/
-COPY --chown=default target/dockerbuild/*.jar ${JAVA_APP_DIR}/
-
+COPY --chown=default target/quarkus-app/lib/ ${JAVA_APP_DIR}/lib/
+COPY --chown=default target/quarkus-app/*.jar ${JAVA_APP_DIR}/
+COPY --chown=default target/quarkus-app/app/ ${JAVA_APP_DIR}/app/
+COPY --chown=default target/quarkus-app/quarkus/ ${JAVA_APP_DIR}/quarkus/
 # Uncomment the following lines to enable remote debugging
 #ENV JAVA_OPTS_APPEND='-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:5005'
 #EXPOSE 5005

--- a/extensions/extensions-security/extensions-policy-decision-point-service/pom.xml
+++ b/extensions/extensions-security/extensions-policy-decision-point-service/pom.xml
@@ -12,10 +12,6 @@
     <name>aiSSEMBLE::Extensions::Security::Policy Decision Point Service</name>
     <description>Policy Decision Point Services</description>
 
-    <properties>
-        <quarkus.package.type>uber-jar</quarkus.package.type>
-    </properties>
-
     <dependencyManagement>
         <dependencies>
             <dependency>
@@ -84,6 +80,26 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
+            </plugin>
+            <!-- Packages the quarkus app and its dependencies into a zip-->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <descriptors>
+                        <descriptor>${project.basedir}/src/main/resources/quarkus-app.xml</descriptor>
+                    </descriptors>
+                    <finalName>quarkus</finalName>
+                    <appendAssemblyId>true</appendAssemblyId>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/extensions/extensions-security/extensions-policy-decision-point-service/src/main/resources/quarkus-app.xml
+++ b/extensions/extensions-security/extensions-policy-decision-point-service/src/main/resources/quarkus-app.xml
@@ -8,9 +8,9 @@
   #L%
   -->
 <assembly
-    xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
+        xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
     <id>app</id>
 
     <includeBaseDirectory>false</includeBaseDirectory>
@@ -21,7 +21,7 @@
 
     <fileSets>
         <fileSet>
-            <directory>${project.build.directory}/quarkus-app/</directory>
+            <directory>${project.build.directory}/quarkus-app</directory>
             <outputDirectory>quarkus-app/</outputDirectory>
         </fileSet>
     </fileSets>


### PR DESCRIPTION
In the past we have packaged jar files using the uber-jar pattern. This has turned out to be problematic for downstream projects due to how plugin.xml is compiled. For this reason, we now package them into a zip file. policy-decision-point still use the old pattern and need to be migrated

Github issue:
https://github.com/boozallen/aissemble/issues/258