### PR TITLE
Grant spark-operator write access for the required apigroup

### DIFF
--- a/extensions/extensions-helm/aissemble-spark-operator-chart/README.md
+++ b/extensions/extensions-helm/aissemble-spark-operator-chart/README.md
@@ -45,7 +45,22 @@ aissemble-spark-operator-chart:
 | volumes                    | Volumes for the pod                | No                | `spark-logging=/tmp/spark-logging`          |
 | volumeMounts               | Volume Mounts for the pod          | No                | `spark-logging=/tmp/spark-logging`          |
 | fullnameOverride           | String to override release name    | No                | spark-operator                              |
+| rbac.createClusterRole     | See `Migrated Properties`          | No                | false                                       |
 | serviceAccounts.spark.name | Name for the spark service account | No                | spark                                       |
+
+## Migrated Properties
+The following properties have been migrated from the `spark-operator` subchart to the `aissemble-spark-operator-chart` chart.
+Any required overrides should be cognisant of the alternate path.  For example:
+
+```yaml
+aissemble-spark-operator-chart:
+  rbac:
+    createClusterRole: false
+```
+
+| Property               | Description                                                                   | Default |
+|------------------------|-------------------------------------------------------------------------------|---------|
+| rbac.createClusterRole | Create and use RBAC `ClusterRole` resources.  Migrated to use modified rules. | true    |
 
 # Shared Ivy Cache
 

--- a/extensions/extensions-helm/aissemble-spark-operator-chart/templates/rbac.yaml
+++ b/extensions/extensions-helm/aissemble-spark-operator-chart/templates/rbac.yaml
@@ -1,0 +1,140 @@
+{{- /*
+aiSSEMBLE Custom rbac.yaml
+
+Required custom rbac.yaml file that grants the sparkoperator service account 
+create, delete, and update access to the apigroup apiextensions.k8s.io. 
+
+This is necessary for the pipeline-invocation-service to create instances of the 
+SparkApplication CRD to submit pipelines to the Spark Operator for execution.
+*/}}
+
+{{- if or .Values.rbac.create .Values.rbac.createClusterRole }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "spark-operator.fullname" (index .Subcharts "spark-operator") }}
+  annotations:
+    "helm.sh/hook": pre-install, pre-upgrade
+    "helm.sh/hook-delete-policy": hook-failed, before-hook-creation
+    "helm.sh/hook-weight": "-10"
+  labels:
+    {{- include "spark-operator.labels" (index .Subcharts "spark-operator") | nindent 4 }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - "*"
+- apiGroups:
+  - ""
+  resources:
+  - services
+  - configmaps
+  - secrets
+  verbs:
+  - create
+  - get
+  - delete
+  - update
+  - list
+- apiGroups:
+  - extensions
+  - networking.k8s.io
+  resources:
+  - ingresses
+  verbs:
+  - create
+  - get
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - update
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - resourcequotas
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - create
+  - get
+  - update
+  - delete
+- apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - mutatingwebhookconfigurations
+  - validatingwebhookconfigurations
+  verbs:
+  - create
+  - get
+  - update
+  - delete
+- apiGroups:
+  - sparkoperator.k8s.io
+  resources:
+  - sparkapplications
+  - sparkapplications/status
+  - scheduledsparkapplications
+  - scheduledsparkapplications/status
+  verbs:
+  - "*"
+  {{- if .Values.batchScheduler.enable }}
+  # required for the `volcano` batch scheduler
+- apiGroups:
+  - scheduling.incubator.k8s.io
+  - scheduling.sigs.dev
+  - scheduling.volcano.sh
+  resources:
+  - podgroups
+  verbs:
+  - "*"
+  {{- end }}
+  {{ if .Values.webhook.enable }}
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - delete
+  {{- end }}
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "spark-operator.fullname" (index .Subcharts "spark-operator") }}
+  annotations:
+    "helm.sh/hook": pre-install, pre-upgrade
+    "helm.sh/hook-delete-policy": hook-failed, before-hook-creation
+    "helm.sh/hook-weight": "-10"
+  labels:
+    {{- include "spark-operator.labels" (index .Subcharts "spark-operator") | nindent 4 }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "spark-operator.serviceAccountName" (index .Subcharts "spark-operator") }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: {{ include "spark-operator.fullname" (index .Subcharts "spark-operator") }}
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/extensions/extensions-helm/aissemble-spark-operator-chart/values.template.yaml
+++ b/extensions/extensions-helm/aissemble-spark-operator-chart/values.template.yaml
@@ -30,6 +30,11 @@ spark-operator:
     fsGroup: 1000
     fsGroupChangePolicy: "OnRootMismatch"
 
+  rbac:
+    # -- Create and use RBAC `ClusterRole` resources
+    # -- Set to false in order to enable overriding with our own RBAC template
+    createClusterRole: false
+
   # volumes - Operator volumes
   volumes:
     - name: spark-logging
@@ -57,3 +62,7 @@ spark-operator:
     sparkoperator:
       # -- Optional name for the operator service account
       name: "sparkoperator"
+
+rbac:
+  # -- Set to True in order to enable overriding with our own RBAC template
+  createClusterRole: True


### PR DESCRIPTION
Found the previous rbac.yaml file we were using to define access for reasources and just copied over that. Currently, we were using the community spark-operator rbac.yaml which didnt allow write access for the apiextensions.k8s.io apigroup. 