### PR TITLE
#226 Replace aissemble-mflow docker image with community docker image.

### DIFF
--- a/DRAFT_RELEASE_NOTES.md
+++ b/DRAFT_RELEASE_NOTES.md
@@ -75,3 +75,5 @@ To start your aiSSEMBLE upgrade, update your project's pom.xml to use the 1.9.0 
 1. Repeat the previous step until all manual actions are resolved
 
 # What's Changed
+- MLFlow Chart version upgraded from `0.2.1` to `1.4.22`. 
+- `aissemble-mlflow` Docker image using MLFlow 2.3.1 was replaced with `bitnami/mlflow:2.15.1-debian-12-r0`  Docker image using MLFlow 2.15.1.

--- a/extensions/extensions-helm/aissemble-mlflow-chart/Chart.yaml
+++ b/extensions/extensions-helm/aissemble-mlflow-chart/Chart.yaml
@@ -9,5 +9,5 @@ sources:
   - https://github.com/boozallen/aissemble
 dependencies:
   - name: mlflow
-    version: 0.2.1
+    version: 1.4.22
     repository: https://charts.bitnami.com/bitnami

--- a/extensions/extensions-helm/aissemble-mlflow-chart/README.md
+++ b/extensions/extensions-helm/aissemble-mlflow-chart/README.md
@@ -13,8 +13,6 @@ The following properties are inherited from the base [MLflow chart](https://gith
 
 | Property | Description | Default |
 |----------|-------------|---------|
-| image.registry | MLflow image registry | NB: OSS: update with aissemble docker repository |
-| image.repository | MLflow image repository | boozallen/aissemble-mlflow |
 | image.tag | MLflow image version tag | Chart.Version |
 | postgresql.enabled | Switch to enable or disable Bitnami's PostgreSQL helm chart | False |
 | minio.enabled | Switch to enable or disable MinIO helm chart | False |

--- a/extensions/extensions-helm/aissemble-mlflow-chart/values.yaml
+++ b/extensions/extensions-helm/aissemble-mlflow-chart/values.yaml
@@ -1,10 +1,4 @@
 mlflow:
-  image:
-    # NB: will soon be updated to public mlflow image - but waiting to upgrade across the application, so point to the
-    # 2.3.1 image that was part of aissemble 1.7.0 in the meantime. TODO in https://github.com/boozallen/aissemble/issues/226
-    registry: ghcr.io
-    repository: boozallen/aissemble-mlflow
-    tag: 1.7.0
   postgresql:
     enabled: false
   minio:

--- a/foundation/foundation-upgrade/src/main/java/com/boozallen/aissemble/upgrade/migration/v1_9_0/MLFlowDockerfileMigration.java
+++ b/foundation/foundation-upgrade/src/main/java/com/boozallen/aissemble/upgrade/migration/v1_9_0/MLFlowDockerfileMigration.java
@@ -1,0 +1,80 @@
+package com.boozallen.aissemble.upgrade.migration.v1_9_0;
+
+/*-
+ * #%L
+ * aiSSEMBLE::Foundation::Upgrade
+ * %%
+ * Copyright (C) 2021 Booz Allen
+ * %%
+ * This software package is licensed under the Booz Allen Public License. All Rights Reserved.
+ * #L%
+ */
+
+import com.boozallen.aissemble.upgrade.migration.AbstractAissembleMigration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.util.Map;
+
+import static org.technologybrewery.baton.util.FileUtils.replaceLiteralInFile;
+
+/**
+    Baton migration class to identify whether MLFlow's Dockerfile needs migration or not. If it does, then it will migrate
+    the Dockerfile to reference the community MLFlow docker image.
+ **/
+
+public class MLFlowDockerfileMigration extends AbstractAissembleMigration {
+
+    public static final Logger logger = LoggerFactory.getLogger(MLFlowDockerfileMigration.class);
+    public static final Map<String, String> DOCKER_IMAGE_REFERENCE_MAP = Map.of(
+            "FROM ${DOCKER_BASELINE_REPO_ID}boozallen/aissemble-mlflow:1.7.0", "FROM bitnami/mlflow:2.15.1-debian-12-r0",
+            "ARG DOCKER_BASELINE_REPO_ID","",
+            "ARG VERSION_AISSEMBLE",""
+    );
+
+    /**
+     * Function to check whether the migration is necessary.
+     * @param file file to check
+     * @return shouldExecute - whether the migration is necessary.
+     */
+    @Override
+    protected boolean shouldExecuteOnFile(File file) {
+        boolean shouldExecute = false;
+        try (BufferedReader dockerfileReferenceConfig = new BufferedReader((new FileReader(file)))) {
+            String line;
+            while((line = dockerfileReferenceConfig.readLine()) !=null && !shouldExecute) {
+                for (String key : DOCKER_IMAGE_REFERENCE_MAP.keySet()) {
+                    if (line.contains(key)) {
+                        shouldExecute = true;
+                    }
+                }
+            }
+        } catch (Exception e) {
+            logger.error("Error in determining whether mlflow Dockerfile needs migration.");
+        }
+        return shouldExecute;
+    }
+
+    /**
+     * Performs the migration if the shouldExecuteOnFile() returns true.
+     * @param file file to migrate
+     * @return isMigrated - Whether the file was migrated successfully.
+     */
+    @Override
+    protected boolean performMigration(File file) {
+        boolean isMigrated = false;
+
+        try {
+            for (Map.Entry<String, String> entry : DOCKER_IMAGE_REFERENCE_MAP.entrySet()) {
+                replaceLiteralInFile(file, entry.getKey(), entry.getValue());
+                isMigrated = true;
+            }
+        } catch (Exception e) {
+            logger.error("Error in performing the migration for a refactored java package.");
+        }
+        return isMigrated;
+    }
+}

--- a/foundation/foundation-upgrade/src/test/java/com/boozallen/aissemble/upgrade/migration/v1_9_0/MLFlowDockerfileMigrationSteps.java
+++ b/foundation/foundation-upgrade/src/test/java/com/boozallen/aissemble/upgrade/migration/v1_9_0/MLFlowDockerfileMigrationSteps.java
@@ -1,0 +1,55 @@
+package com.boozallen.aissemble.upgrade.migration.v1_9_0;
+
+/*-
+ * #%L
+ * aiSSEMBLE::Foundation::Upgrade
+ * %%
+ * Copyright (C) 2021 Booz Allen
+ * %%
+ * This software package is licensed under the Booz Allen Public License. All Rights Reserved.
+ * #L%
+ */
+
+import com.boozallen.aissemble.upgrade.migration.AbstractAissembleMigration;
+import com.boozallen.aissemble.upgrade.migration.AbstractMigrationTest;
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
+import org.apache.commons.io.FileUtils;
+
+import java.io.File;
+
+import static org.junit.Assert.assertTrue;
+
+public class MLFlowDockerfileMigrationSteps extends AbstractMigrationTest {
+    private AbstractAissembleMigration migration;
+    private File validatedFile;
+
+    private static Boolean validateMigration(File original, File migrated) {
+        Boolean isMigrated = false;
+
+        try {
+            isMigrated =  FileUtils.contentEquals(original, migrated);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        return isMigrated;
+    }
+
+    @Given("a Dockerfile is referencing the mlflow image from aissemble-mlflow")
+    public void aDockerfileIsReferencingTheMlflowImageFromAissembleMlflow() {
+        testFile = getTestFile("v1_9_0/MLFlowDockerfileMigration/migration/Dockerfile");
+    }
+
+    @When("the 1.9.0 MLFlow Docker image migration executes")
+    public void theMLFlowDockerImageMigrationExecutes() {
+        migration = new MLFlowDockerfileMigration();
+        performMigration(migration);
+    }
+
+    @Then("the image will pull the community docker image")
+    public void theImageWillPullTheCommunityDockerImage() {
+        validatedFile = getTestFile("/v1_9_0/MLFlowDockerfileMigration/validation/Dockerfile");
+        assertTrue("Dockerfile is still referencing aissemble-mlflow instead of community mlflow Docker image.", validateMigration(testFile, validatedFile));
+    }
+}

--- a/foundation/foundation-upgrade/src/test/resources/specifications/v1_9_0/ml-flow-dockerfile-migration.feature
+++ b/foundation/foundation-upgrade/src/test/resources/specifications/v1_9_0/ml-flow-dockerfile-migration.feature
@@ -1,0 +1,6 @@
+Feature: Migration MLFlow Dockerfile
+
+  Scenario: Update the MLFlow Dockerfile to pull the community Docker image
+    Given a Dockerfile is referencing the mlflow image from aissemble-mlflow
+    When the 1.9.0 MLFlow Docker image migration executes
+    Then the image will pull the community docker image

--- a/foundation/foundation-upgrade/src/test/resources/test-files/v1_9_0/MLFlowDockerfileMigration/migration/Dockerfile
+++ b/foundation/foundation-upgrade/src/test/resources/test-files/v1_9_0/MLFlowDockerfileMigration/migration/Dockerfile
@@ -1,0 +1,14 @@
+# Script for creating policy decision point service image
+#
+# GENERATED DOCKERFILE - please ***DO*** modify.
+#
+# Generated from: ${templateName}
+
+ARG DOCKER_BASELINE_REPO_ID
+ARG VERSION_AISSEMBLE
+
+
+FROM ${DOCKER_BASELINE_REPO_ID}boozallen/aissemble-mlflow:1.7.0
+
+RUN mkdir -p /mlflow/startup
+COPY ./src/main/resources/start.sh /mlflow/startup/

--- a/foundation/foundation-upgrade/src/test/resources/test-files/v1_9_0/MLFlowDockerfileMigration/validation/Dockerfile
+++ b/foundation/foundation-upgrade/src/test/resources/test-files/v1_9_0/MLFlowDockerfileMigration/validation/Dockerfile
@@ -4,10 +4,11 @@
 #
 # Generated from: ${templateName}
 
+
+
+
+
 FROM bitnami/mlflow:2.15.1-debian-12-r0
 
 RUN mkdir -p /mlflow/startup
 COPY ./src/main/resources/start.sh /mlflow/startup/
-RUN chmod +x /mlflow/startup/start.sh
-
-CMD ["/mlflow/startup/start.sh"]


### PR DESCRIPTION
#226 Replace aissemble-mflow docker image with community docker image.
- Replacing aissemble-mlflow with community docker image from bitnami. 
- Upgrade mlflow to the latest stable version.