### PR TITLE
#226 Replace aissemble-mflow docker image with community docker image (continued)

### DIFF
--- a/DRAFT_RELEASE_NOTES.md
+++ b/DRAFT_RELEASE_NOTES.md
@@ -24,11 +24,12 @@ The following steps will upgrade your project to 1.9. These instructions consist
 ## Automatic Upgrades
 To reduce burden of upgrading aiSSEMBLE, the Baton project is used to automate the migration of some files to the new version.  These migrations run automatically when you build your project, and are included by default when you update the `build-parent` version in your root POM.  Below is a description of all of the Baton migrations that are included with this version of aiSSEMBLE.
 
-| Migration Name                                             | Description                                                                                                                                                                |
-|------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| upgrade-tiltfile-aissemble-version-migration               | Updates the aiSSEMBLE version within your project's Tiltfile                                                                                                               |
-| upgrade-v2-chart-files-aissemble-version-migration         | Updates the helm chart dependencies within your project's deployment resources (<YOUR_PROJECT>-deploy/src/main/resources/apps/) to use the latest version of the aiSSEMBLE |
-| upgrade-v1-chart-files-aissemble-version-migration         | Updates the docker image tags within your project's deployment resources (<YOUR_PROJECT>-deploy/src/main/resources/apps/) to use the latest version of the aiSSEMBLE       |
+| Migration Name                                     | Description                                                                                                                                                                |
+|----------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| upgrade-tiltfile-aissemble-version-migration       | Updates the aiSSEMBLE version within your project's Tiltfile                                                                                                               |
+| upgrade-v2-chart-files-aissemble-version-migration | Updates the helm chart dependencies within your project's deployment resources (<YOUR_PROJECT>-deploy/src/main/resources/apps/) to use the latest version of the aiSSEMBLE |
+| upgrade-v1-chart-files-aissemble-version-migration | Updates the docker image tags within your project's deployment resources (<YOUR_PROJECT>-deploy/src/main/resources/apps/) to use the latest version of the aiSSEMBLE       |
+| ml-flow-dockerfile-migration                       | Updates the MLFlow's Dockerfile to use the bitnami/mlflow image as a base instead of the deprecated boozallen/aissemble-mlflow image"                                      |
 
 To deactivate any of these migrations, add the following configuration to the `baton-maven-plugin` within your root `pom.xml`:
 

--- a/foundation/foundation-upgrade/src/main/resources/migrations.json
+++ b/foundation/foundation-upgrade/src/main/resources/migrations.json
@@ -3,6 +3,16 @@
     "group": "v1-9-0-migrations",
     "type": "ordered",
     "migrations": [
+      {
+        "name": "ml-flow-dockerfile-migration",
+        "implementation": "com.boozallen.aissemble.upgrade.migration.v1_9_0.MLFlowDockerfileMigration",
+        "fileSets": [
+          {
+            "includes": ["*-docker/*/src/main/resources/docker/Dockerfile"],
+            "excludes": ["*-docker/*/target/Dockerfile"]
+          }
+        ]
+      }
     ]
   },
   {


### PR DESCRIPTION
#226 Replace aissemble-mflow docker image with community docker image (continued).
- Added MLFlow docker migration to Automatic Upgrades table in Release notes. 
- Added mlflow migration to migrations.json.