### PR TITLE
 #270 Adjust prune workflow

### DIFF
--- a/.github/workflows/prune.yml
+++ b/.github/workflows/prune.yml
@@ -1,4 +1,4 @@
-# Prunes old aissemble-* untagged containers
+# Prunes old aissemble-* containers, excluding all release tags and the two most recent non-release tags
 
 name: Prune ghcr.io
 
@@ -10,19 +10,74 @@ on:
     - cron: "0 0 * * *"  # every day at midnight
 
 jobs:
-  build:
-
+  # Phase 1: find all docker image names and release tags
+  fetch_image_info:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Prune
-        uses: snok/container-retention-policy@v2
+      - name: Fetch all aiSSEMBLE docker image names and release versions, then save to respective outputs
+        id: fetch-image-info
+        env:
+          GH_TOKEN: ${{ secrets.GHCR_IO_TOKEN }}
+
+        # Find all docker image names that starts with "aissemble" and does not end with "-chart" and save them to matrix-values output
+        # And find all release version tags and saves them to release-values output
+        run: |
+          image_names=$(gh api \
+            -H "Accept: application/vnd.github+json" \
+            -H "-GitHub-Api-Version: 2022-11-28" \
+            -H "Authorization: Token ${GH_TOKEN}" \
+            --paginate "/orgs/boozallen/packages?package_type=container" | \
+            jq -c '[.[] | select((.name | startswith("aissemble")) and (.name | endswith("-chart") | not)) | .name]')
+          
+          # save to output
+          echo "matrix_values=${image_names}" >> $GITHUB_OUTPUT
+  
+          # loop through each image name and find all release tags using regex pattern
+          for name in $(echo "$image_names" | jq -r '.[]'); do
+              release_versions=$(gh api \
+                -H "Accept: application/vnd.github+json" \
+                -H "-GitHub-Api-Version: 2022-11-28" \
+                -H "Authorization: Token ${GH_TOKEN}" \
+                --paginate "/orgs/boozallen/packages/container/${name}/versions" \
+                | jq -r '.[] | .metadata.container.tags[] | select(test("^\\d+\\.\\d+\\.\\d+$"))')
+          
+              # append all release tags to all_release_versions array
+              all_release_versions+=("${release_versions}")
+          done
+          
+          # replace all whitespaces with newline (required for sort) and then sort all release versions while removing any duplicates
+          all_release_versions_sorted=$(echo "${all_release_versions[@]}" | tr ' ' '\n'| sort -u )
+          
+          # replace the newlines with commas and then remove the trailing comma
+          all_release_versions=$(echo "${all_release_versions_sorted[@]}" | tr '\n' ',' | sed 's/,$//')
+          
+          # save to output
+          echo "release_values=${all_release_versions}" >> $GITHUB_OUTPUT
+          
+
+    # Identify the outputs of phase 1: fetch_image_info so they can be used in phase 2
+    outputs:
+      matrix-values: ${{ steps.fetch-image-info.outputs.matrix_values }}
+      release-values: ${{ steps.fetch-image-info.outputs.release_values }}
+
+  
+  # Phase 2: loop through output of phase 1 to prune images
+  prune_ghcr:
+    # Tells workflow to wait for the "fetch_image_info" phase to finish
+    needs: fetch_image_info
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        package-name: ${{ fromJson(needs.fetch_image_info.outputs.matrix-values) }}
+
+    steps:
+      - name: Prune ghcr
+        uses: dataaxiom/ghcr-cleanup-action@v1
         with:
-          image-names: aissemble-*
-          cut-off: Two days ago UTC
-          account-type: org
-          org-name: boozallen
-          keep-at-least: 2
-          untagged-only: true
-          dry-run: false
+          log-level: info
+          package: ${{ matrix.package-name }}
           token: ${{ secrets.GHCR_IO_TOKEN }}
+          exclude-tags: ${{ needs.fetch_image_info.outputs.release-values }}
+          keep-n-tagged: 2


### PR DESCRIPTION
- Update prune workflow to use `dataaxiom/ghcr-cleanup-action@v1`
- Pass in all aiSSEMBLE docker image names through a matrix
- Pass in list of release versions to the `exclude-tags` parameter (e.g., `1.7.0,1.8.0`)
- Use `keep-n-tagged: 2` to ensure that the two most recent NON-release tagged images are saved (e.g., `1.9.0-SNAPSHOT` & `1.8.0-rc8`)