### PR TITLE
#227 - Replacing aissemble-airflow docker image with community airflow docker image.

### DIFF
--- a/DRAFT_RELEASE_NOTES.md
+++ b/DRAFT_RELEASE_NOTES.md
@@ -83,5 +83,7 @@ To start your aiSSEMBLE upgrade, update your project's pom.xml to use the 1.9.0 
 1. Repeat the previous step until all manual actions are resolved
 
 # What's Changed
-- MLFlow Chart version upgraded from `0.2.1` to `1.4.22`. 
+- MLFlow Chart version upgraded from `0.2.1` to `1.4.22`.
 - `aissemble-mlflow` Docker image using MLFlow 2.3.1 was replaced with `bitnami/mlflow:2.15.1-debian-12-r0`  Docker image using MLFlow 2.15.1.
+- Airflow Chart version upgraded from `1.10.0` to `1.15.0`.
+- `aissemble-airflow` Docker image using Airflow 2.6.2 was replaced with `apache/airflow`  Docker image using Airflow 2.9.3.

--- a/extensions/extensions-helm/aissemble-airflow-chart/Chart.yaml
+++ b/extensions/extensions-helm/aissemble-airflow-chart/Chart.yaml
@@ -10,5 +10,5 @@ sources:
   - https://github.com/boozallen/aissemble
 dependencies:
   - name: airflow
-    version: 1.10.0
+    version: 1.15.0
     repository: https://airflow.apache.org/

--- a/extensions/extensions-helm/aissemble-airflow-chart/README.md
+++ b/extensions/extensions-helm/aissemble-airflow-chart/README.md
@@ -1,10 +1,10 @@
 # aiSSEMBLE&trade; Airflow Helm Chart
-Baseline Helm chart for packaging and deploying Airflow. Built on the [official Helm chart](https://airflow.apache.org/docs/helm-chart/stable) and managed during the 
-normal Maven build lifecycle and placed in the **target/helm/repo** directory. See 
+Baseline Helm chart for packaging and deploying Airflow. Built on the [official Helm chart](https://airflow.apache.org/docs/helm-chart/stable) and managed during the
+normal Maven build lifecycle and placed in the **target/helm/repo** directory. See
 [Helm Maven Plugin](https://github.com/kokuwaio/helm-maven-plugin) for more details.
 
 # Basic usage with Helm CLI
-To use the module, perform [extension-helm setup](../README.md#leveraging-extensions-helm) and override the chart 
+To use the module, perform [extension-helm setup](../README.md#leveraging-extensions-helm) and override the chart
 version with the desired aiSSEMBLE version. For example:
 ```bash
 helm install airflow oci://ghcr.io/boozallen/aissemble-airflow-chart --version <AISSEMBLE-VERSION>
@@ -13,18 +13,15 @@ helm install airflow oci://ghcr.io/boozallen/aissemble-airflow-chart --version <
 
 # Properties
 
-The following properties are inherited from the base [Airflow chart](https://github.com/apache/airflow/tree/helm-chart/1.10.0/chart), 
-but with updated default values. 
+The following properties are inherited from the base [Airflow chart](https://github.com/apache/airflow/tree/helm-chart/1.15.0/chart),
+but with updated default values.
 
-*NOTE* there are several values that should be modified before use in a production environment; see 
-[production documentation](https://airflow.apache.org/docs/helm-chart/1.10.0/production-guide.html) for details. 
+*NOTE* there are several values that should be modified before use in a production environment; see
+[production documentation](https://airflow.apache.org/docs/helm-chart/1.15.0/production-guide.html) for details.
 
 | Property | Description | Default                                                                                                                                                                                                                                                                                             |
 |----------|-------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| airflowVersion | The version of airflow to use | 2.6.2                                                                                                                                                                                                                                                                                               | 
-| defaultAirflowRepository | The airflow repo and image to use | ghcr.io/boozallen/aissemble-airflow                                                                                                                                                                                                                                                                 | 
-| defaultAirflowTag | The airflow image tag | Chart.Version                                                                                                                                                                                                                                                                                       | 
-| images.airflow.pullPolicy | The airflow image pull policy | Always                                                                                                                                                                                                                                                                                              |
+| airflowVersion | The version of airflow to use | 2.9.3                                                                                                                                                                                                                                                                                              | 
 | executor | The mechanism that handles the running of tasks | KubernetesExecutor                                                                                                                                                                                                                                                                                  |
 | statsd.enabled | Custom metrics service | false                                                                                                                                                                                                                                                                                               |
 | triggerer.enabled | Monitors all deferred tasks in your environment | false                                                                                                                                                                                                                                                                                               |
@@ -50,16 +47,16 @@ but with updated default values.
 | volumes | Volumes for airflow | &emsp;- name: model <br/>&emsp;&emsp;persistentVolumeClaim: <br/>&emsp;&emsp;&emsp;claimName: model <br/>&emsp;- name: boms-notebook <br/>&emsp;&emsp;persistentVolumeClaim: <br/>&emsp;&emsp;&emsp;claimName: boms-notebook                                                                        |
 
 
-All properties must be prefixed with the key `aissemble-airflow-chart.airflow` to override any values in the chart. See 
-[helm documentation](https://helm.sh/docs/chart_template_guide/subcharts_and_globals/#overriding-values-from-a-parent-chart) 
+All properties must be prefixed with the key `aissemble-airflow-chart.airflow` to override any values in the chart. See
+[helm documentation](https://helm.sh/docs/chart_template_guide/subcharts_and_globals/#overriding-values-from-a-parent-chart)
 for more info.
 
 # Migration from aiSSEMBLE v1 Helm Charts
-If you are migrating from the v1 version of the airflow chart, use the tables below to apply any existing customizations 
+If you are migrating from the v1 version of the airflow chart, use the tables below to apply any existing customizations
 from the old chart to the new v2 chart.
 
 ## Property Location
-All properties listed below have been moved to the parent chart. If any properties are set to the default value, we 
+All properties listed below have been moved to the parent chart. If any properties are set to the default value, we
 recommend removing them from your values file entirely.
 
 **Note**: *all new property locations include the prefix `aissemble-airflow-chart.airflow`*
@@ -81,7 +78,7 @@ recommend removing them from your values file entirely.
 | deployment.volumes | volumes | Yes                |                                                                                                                                                                                      |
 | ingress.enabled | ingress.web.enabled | No                 |                                                                                                                                                                                      |
 | ingress.metadata.annotations | ingress.web.annotations | No                |                                                                                                                                                                                      |
-| ingress.hosts[\*].host | ingress.web.hosts[\*].name | No                | 
+| ingress.hosts[\*].host | ingress.web.hosts[\*].name | No                |
 | ingress.hosts[\*].paths[\*].path | ingress.web.path | No                | To provide additional paths with custom service names, make use of `ingress.web.precedingPaths[*].serviceName` or `ingress.web.succeedingPaths[*].serviceName`                       |
 | ingress.hosts[\*].paths[\*].pathType | ingress.web.pathType | No                |                                                                                                                                                                                      | 
 
@@ -104,8 +101,8 @@ The following properties no longer exist.
 ## Additional Changes
 
 ### Dockerfile
-The following script `<YOUR-PROJECT>-docker/<YOUR-PROJECT>-airflow-docker/src/main/resources/start.sh` and it's 
-associated usage in the `<YOUR-PROJECT>-docker/<YOUR-PROJECT>-airflow-docker/src/main/resources/docker/Dockerfile` 
+The following script `<YOUR-PROJECT>-docker/<YOUR-PROJECT>-airflow-docker/src/main/resources/start.sh` and it's
+associated usage in the `<YOUR-PROJECT>-docker/<YOUR-PROJECT>-airflow-docker/src/main/resources/docker/Dockerfile`
 should be removed:
 ```
 COPY ./src/main/resources/start.sh $AIRFLOW_HOME/

--- a/extensions/extensions-helm/aissemble-airflow-chart/values.yaml
+++ b/extensions/extensions-helm/aissemble-airflow-chart/values.yaml
@@ -2,17 +2,7 @@
 ## CONFIG | Airflow Configs
 ########################################
 airflow:
-  airflowVersion: 2.6.2
-
-
-  # NB: 1.7.0 is the last version to include airflow support. It is being frozen there until it is removed or pulled
-  # into an extension project.  TODO in https://github.com/boozallen/aissemble/issues/227
-  defaultAirflowRepository: ghcr.io/boozallen/aissemble-airflow
-  defaultAirflowTag: 1.7.0
-
-  images:
-    airflow:
-      pullPolicy: Always
+  airflowVersion: 2.9.3
 
   executor: KubernetesExecutor
 

--- a/foundation/foundation-upgrade/src/main/java/com/boozallen/aissemble/upgrade/migration/v1_9_0/AirflowDockerfileMigration.java
+++ b/foundation/foundation-upgrade/src/main/java/com/boozallen/aissemble/upgrade/migration/v1_9_0/AirflowDockerfileMigration.java
@@ -1,0 +1,95 @@
+package com.boozallen.aissemble.upgrade.migration.v1_9_0;
+
+/*-
+ * #%L
+ * aiSSEMBLE::Foundation::Upgrade
+ * %%
+ * Copyright (C) 2021 Booz Allen
+ * %%
+ * This software package is licensed under the Booz Allen Public License. All Rights Reserved.
+ * #L%
+ */
+
+import com.boozallen.aissemble.upgrade.migration.AbstractAissembleMigration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.technologybrewery.baton.util.FileUtils.replaceLiteralInFile;
+import static org.technologybrewery.baton.util.FileUtils.readAllFileLines;
+import static org.technologybrewery.baton.util.FileUtils.writeFile;
+
+
+/**
+ * Baton migration class to identify whether Airflow's Dockerfile needs migration or not. If it does, then it will migrate
+ * the Dockerfile to reference the community Airflow docker image.
+ **/
+
+public class AirflowDockerfileMigration extends AbstractAissembleMigration {
+
+    public static final Logger logger = LoggerFactory.getLogger(AirflowDockerfileMigration.class);
+
+    public static final String FROM_BOOZALLEN_AISSEMBLE_AIRFLOW_DOCKERFILE = "FROM ${DOCKER_BASELINE_REPO_ID}boozallen/aissemble-airflow:1.7.0";
+    public static final String FROM_APACHE_AIRFLOW_DOCKER_STRING = "FROM apache/airflow:2.9.3";
+
+    /**
+     * Function to check whether the migration is necessary.
+     *
+     * @param file file to check
+     * @return shouldExecute - whether the migration is necessary.
+     */
+    @Override
+    protected boolean shouldExecuteOnFile(File file) {
+        boolean shouldExecute = false;
+        try (BufferedReader dockerfileReferenceConfig = new BufferedReader((new FileReader(file)))) {
+            String line;
+            while ((line = dockerfileReferenceConfig.readLine()) != null) {
+                if (line.contains(FROM_BOOZALLEN_AISSEMBLE_AIRFLOW_DOCKERFILE)) {
+                    shouldExecute = true;
+                    break;
+                }
+            }
+        } catch (Exception e) {
+            logger.error("Error in determining whether Airflow Dockerfile needs migration.");
+        }
+        return shouldExecute;
+    }
+
+    /**
+     * Performs the migration if the shouldExecuteOnFile() returns true.
+     *
+     * @param file file to migrate
+     * @return isMigrated - Whether the file was migrated successfully.
+     */
+    @Override
+    protected boolean performMigration(File file) {
+        boolean isMigrated = false;
+
+        try {
+            // update FROM to point to community docker image:
+            replaceLiteralInFile(file, FROM_BOOZALLEN_AISSEMBLE_AIRFLOW_DOCKERFILE, FROM_APACHE_AIRFLOW_DOCKER_STRING);
+
+            // remove ARG that are no longer needed:
+            List<String> removalTargets = new ArrayList<>();
+            List<String> lines = readAllFileLines(file);
+            for (String line : lines) {
+                if ("ARG DOCKER_BASELINE_REPO_ID".equals(line) || "ARG VERSION_AISSEMBLE".equals(line)) {
+                    removalTargets.add(line);
+                }
+            }
+            lines.removeAll(removalTargets);
+            writeFile(file, lines);
+
+            isMigrated = true;
+
+        } catch (Exception e) {
+            logger.error("Error in performing the migration for a refactored java package.");
+        }
+        return isMigrated;
+    }
+}

--- a/foundation/foundation-upgrade/src/main/resources/migrations.json
+++ b/foundation/foundation-upgrade/src/main/resources/migrations.json
@@ -4,6 +4,16 @@
     "type": "ordered",
     "migrations": [
       {
+        "name": "airflow-dockerfile-migration",
+        "implementation": "com.boozallen.aissemble.upgrade.migration.v1_9_0.AirflowDockerfileMigration",
+        "fileSets": [
+          {
+            "includes": ["*-docker/*/src/main/resources/docker/Dockerfile"],
+            "excludes": ["*-docker/*/target/Dockerfile"]
+          }
+        ]
+      },
+      {
         "name": "ml-flow-dockerfile-migration",
         "implementation": "com.boozallen.aissemble.upgrade.migration.v1_9_0.MLFlowDockerfileMigration",
         "fileSets": [

--- a/foundation/foundation-upgrade/src/test/java/com/boozallen/aissemble/upgrade/migration/AbstractMigrationTest.java
+++ b/foundation/foundation-upgrade/src/test/java/com/boozallen/aissemble/upgrade/migration/AbstractMigrationTest.java
@@ -10,6 +10,9 @@ package com.boozallen.aissemble.upgrade.migration;
  * #L%
  */
 
+import org.apache.commons.io.FileUtils;
+import org.technologybrewery.baton.BatonException;
+
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Paths;
@@ -21,6 +24,14 @@ public abstract class AbstractMigrationTest {
     protected boolean successful;
 
     private static final String TEST_FILES_FOLDER = Paths.get("target", "test-classes", "test-files").toString();
+
+    protected static boolean validateMigration(File original, File migrated) {
+        try {
+            return FileUtils.contentEquals(original, migrated);
+        } catch (Exception e) {
+            return false;
+        }
+    }
 
     protected static void addTestFile(String subPath) throws IOException {
         File testFile = Paths.get(TEST_FILES_FOLDER, subPath).toFile();

--- a/foundation/foundation-upgrade/src/test/java/com/boozallen/aissemble/upgrade/migration/v1_9_0/AirflowDockerfileMigrationSteps.java
+++ b/foundation/foundation-upgrade/src/test/java/com/boozallen/aissemble/upgrade/migration/v1_9_0/AirflowDockerfileMigrationSteps.java
@@ -1,0 +1,59 @@
+package com.boozallen.aissemble.upgrade.migration.v1_9_0;
+
+/*-
+ * #%L
+ * aiSSEMBLE::Foundation::Upgrade
+ * %%
+ * Copyright (C) 2021 Booz Allen
+ * %%
+ * This software package is licensed under the Booz Allen Public License. All Rights Reserved.
+ * #L%
+ */
+
+import com.boozallen.aissemble.upgrade.migration.AbstractAissembleMigration;
+import com.boozallen.aissemble.upgrade.migration.AbstractMigrationTest;
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
+
+import java.io.File;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class AirflowDockerfileMigrationSteps extends AbstractMigrationTest {
+    private AbstractAissembleMigration migration;
+    private File validatedFile;
+
+    @Given("a Dockerfile is referencing the airflow image from aissemble-airflow")
+    public void aDockerfileIsReferencingTheAirflowImageFromAissembleAirflow() {
+        testFile = getTestFile("v1_9_0/AirflowDockerfileMigration/migration/Dockerfile");
+    }
+
+    @Given("a Docker file is referencing the community airflow image")
+    public void aDockerFileIsReferencingTheCommunityAirflowImage() {
+        testFile = getTestFile("v1_9_0/AirflowDockerfileMigration/migration/negative-Dockerfile");
+    }
+
+    @Given("a Docker file is not referencing Airflow")
+    public void aDockerFileIsNotReferencingAirflow() {
+        testFile = getTestFile("v1_9_0/AirflowDockerfileMigration/migration/negative-non-Airflow-Dockerfile");
+    }
+
+    @When("the 1.9.0 Airflow Docker image migration executes")
+    public void theAirflowDockerImageMigrationExecutes() {
+        migration = new AirflowDockerfileMigration();
+        performMigration(migration);
+    }
+
+    @Then("the Dockerfile will pull the community docker Airflow image")
+    public void theDockerfileWillPullTheCommunityDockerAirflowImage() {
+        validatedFile = getTestFile("/v1_9_0/AirflowDockerfileMigration/validation/Dockerfile");
+        assertTrue("Dockerfile is still referencing aissemble-airflow instead of community airflow Docker image.", validateMigration(testFile, validatedFile));
+    }
+
+    @Then("the airflow migration is skipped")
+    public void theAirflowMigrationIsSkipped() {
+        assertFalse("The migration is processing a Dockerfile that does NOT require a migration!", shouldExecute);
+    }
+}

--- a/foundation/foundation-upgrade/src/test/java/com/boozallen/aissemble/upgrade/migration/v1_9_0/MLFlowDockerfileMigrationSteps.java
+++ b/foundation/foundation-upgrade/src/test/java/com/boozallen/aissemble/upgrade/migration/v1_9_0/MLFlowDockerfileMigrationSteps.java
@@ -26,17 +26,6 @@ public class MLFlowDockerfileMigrationSteps extends AbstractMigrationTest {
     private AbstractAissembleMigration migration;
     private File validatedFile;
 
-    private static Boolean validateMigration(File original, File migrated) {
-        Boolean isMigrated = false;
-
-        try {
-            isMigrated =  FileUtils.contentEquals(original, migrated);
-        } catch (Exception e) {
-            throw new BatonException("Problem performing migration!", e);
-        }
-        return isMigrated;
-    }
-
     @Given("a Dockerfile is referencing the mlflow image from aissemble-mlflow")
     public void aDockerfileIsReferencingTheMlflowImageFromAissembleMlflow() {
         testFile = getTestFile("v1_9_0/MLFlowDockerfileMigration/migration/applicable-Dockerfile");
@@ -65,5 +54,4 @@ public class MLFlowDockerfileMigrationSteps extends AbstractMigrationTest {
         validatedFile = getTestFile("/v1_9_0/MLFlowDockerfileMigration/validation/inapplicable-Dockerfile");
         assertTrue("The migration is processing Dockerfile it should NOT be migrating!", validateMigration(testFile, validatedFile));
     }
-
 }

--- a/foundation/foundation-upgrade/src/test/resources/specifications/v1_9_0/airflow-dockerfile-migration.feature
+++ b/foundation/foundation-upgrade/src/test/resources/specifications/v1_9_0/airflow-dockerfile-migration.feature
@@ -1,0 +1,16 @@
+Feature: Migration Airflow Dockerfile
+
+  Scenario: Update the Airflow Dockerfile to pull the community Docker image
+    Given a Dockerfile is referencing the airflow image from aissemble-airflow
+    When the 1.9.0 Airflow Docker image migration executes
+    Then the Dockerfile will pull the community docker Airflow image
+
+  Scenario: Do not update the Airflow Dockerfile when the file is already pulling the community Airflow Docker image
+    Given a Docker file is referencing the community airflow image
+    When the 1.9.0 Airflow Docker image migration executes
+    Then the airflow migration is skipped
+
+  Scenario: Skip Dockerfiles that are not Airflow related
+    Given a Docker file is not referencing Airflow
+    When the 1.9.0 Airflow Docker image migration executes
+    Then the airflow migration is skipped

--- a/foundation/foundation-upgrade/src/test/resources/test-files/v1_9_0/AirflowDockerfileMigration/migration/Dockerfile
+++ b/foundation/foundation-upgrade/src/test/resources/test-files/v1_9_0/AirflowDockerfileMigration/migration/Dockerfile
@@ -1,10 +1,13 @@
-# Script for creating base Airflow Docker image
+# Script for creating policy decision point service image
 #
-# GENERATED DockerFile - please ***DO*** modify.
+# GENERATED DOCKERFILE - please ***DO*** modify.
 #
 # Generated from: ${templateName}
 
-FROM apache/airflow:2.9.3
+ARG DOCKER_BASELINE_REPO_ID
+ARG VERSION_AISSEMBLE
+
+FROM ${DOCKER_BASELINE_REPO_ID}boozallen/aissemble-airflow:1.7.0
 
 # Airflow variables
 ARG AIRFLOW_USER_HOME=/home/airflow

--- a/foundation/foundation-upgrade/src/test/resources/test-files/v1_9_0/AirflowDockerfileMigration/migration/negative-Dockerfile
+++ b/foundation/foundation-upgrade/src/test/resources/test-files/v1_9_0/AirflowDockerfileMigration/migration/negative-Dockerfile
@@ -1,8 +1,9 @@
-# Script for creating base Airflow Docker image
+# Script for creating policy decision point service image
 #
-# GENERATED DockerFile - please ***DO*** modify.
+# GENERATED DOCKERFILE - please ***DO*** modify.
 #
 # Generated from: ${templateName}
+
 
 FROM apache/airflow:2.9.3
 

--- a/foundation/foundation-upgrade/src/test/resources/test-files/v1_9_0/AirflowDockerfileMigration/migration/negative-non-Airflow-Dockerfile
+++ b/foundation/foundation-upgrade/src/test/resources/test-files/v1_9_0/AirflowDockerfileMigration/migration/negative-non-Airflow-Dockerfile
@@ -1,0 +1,14 @@
+# Script for creating policy decision point service image
+#
+# GENERATED DOCKERFILE - please ***DO*** modify.
+#
+# Generated from: templates/general-docker/policy.decision.point.docker.file.vm
+
+ARG DOCKER_BASELINE_REPO_ID
+ARG VERSION_AISSEMBLE
+
+FROM ${DOCKER_BASELINE_REPO_ID}boozallen/aissemble-policy-decision-point:${VERSION_AISSEMBLE}
+
+USER 1001
+
+COPY ./target/aissemble-security.properties /deployments/krausening/

--- a/foundation/foundation-upgrade/src/test/resources/test-files/v1_9_0/AirflowDockerfileMigration/validation/Dockerfile
+++ b/foundation/foundation-upgrade/src/test/resources/test-files/v1_9_0/AirflowDockerfileMigration/validation/Dockerfile
@@ -1,8 +1,9 @@
-# Script for creating base Airflow Docker image
+# Script for creating policy decision point service image
 #
-# GENERATED DockerFile - please ***DO*** modify.
+# GENERATED DOCKERFILE - please ***DO*** modify.
 #
 # Generated from: ${templateName}
+
 
 FROM apache/airflow:2.9.3
 

--- a/foundation/foundation-upgrade/src/test/resources/test-files/v1_9_0/AirflowDockerfileMigration/validation/negative-Dockerfile
+++ b/foundation/foundation-upgrade/src/test/resources/test-files/v1_9_0/AirflowDockerfileMigration/validation/negative-Dockerfile
@@ -1,8 +1,9 @@
-# Script for creating base Airflow Docker image
+# Script for creating policy decision point service image
 #
-# GENERATED DockerFile - please ***DO*** modify.
+# GENERATED DOCKERFILE - please ***DO*** modify.
 #
 # Generated from: ${templateName}
+
 
 FROM apache/airflow:2.9.3
 


### PR DESCRIPTION
#227 Replace aissemble-airflow docker image with community docker image.
- Airflow will now be pulling from the community Docker image. '
- Airflow helm chart upgraded from 1.10.0 to 1.15.0. 
- Migration script for switching aissemble-airflow to community Airflow Docker image.