### PR TITLE
305 - Adding logic to automatically generate spark application file s…

### DIFF
--- a/foundation/foundation-mda/src/main/java/com/boozallen/aiops/mda/generator/SparkApplicationGenerator.java
+++ b/foundation/foundation-mda/src/main/java/com/boozallen/aiops/mda/generator/SparkApplicationGenerator.java
@@ -20,6 +20,8 @@ import com.boozallen.aiops.mda.metamodel.AIOpsModelInstanceRepostory;
 import com.boozallen.aiops.mda.metamodel.element.Pipeline;
 import com.boozallen.aiops.mda.metamodel.element.java.JavaPipeline;
 import com.boozallen.aiops.mda.metamodel.element.python.PythonPipeline;
+import com.boozallen.aiops.mda.metamodel.element.BaseFileStoreDecorator;
+import com.boozallen.aiops.mda.metamodel.element.FileStore;
 import org.apache.maven.artifact.versioning.ComparableVersion;
 import org.apache.velocity.VelocityContext;
 import org.technologybrewery.fermenter.mda.generator.GenerationContext;
@@ -142,6 +144,18 @@ public class SparkApplicationGenerator extends AbstractResourcesGenerator {
         vc.put(VelocityProperty.PROJECT_NAME, projectName);
         vc.put(VelocityProperty.PIPELINE, pipeline.getName());
         vc.put(VelocityProperty.DOCKER_PROJECT_REPOSITORY_URL, dockerProjectRepositoryUrl);
+
+        List<FileStore> fileStores = pipeline.getFileStores();
+        boolean enableFileStore = !fileStores.isEmpty();
+        vc.put(VelocityProperty.ENABLE_FILE_STORE, enableFileStore);
+        if(enableFileStore){
+            List<BaseFileStoreDecorator> decoratedStores = new ArrayList<>();
+            for(FileStore fileStore : fileStores){
+                BaseFileStoreDecorator decoratedStore = new BaseFileStoreDecorator(fileStore);
+                decoratedStores.add(decoratedStore);
+            }
+            vc.put(VelocityProperty.FILE_STORES, decoratedStores);
+        }
 
         if (!"test".equalsIgnoreCase(context.getArtifactType()) && SparkStorageEnum.S3LOCAL == metamodelRepository.getDeploymentConfigurationManager().getSparkDeploymentConfiguration().getStorageType()) {
             vc.put(VelocityProperty.USE_S3_LOCAL, true);

--- a/foundation/foundation-mda/src/main/java/com/boozallen/aiops/mda/generator/common/VelocityProperty.java
+++ b/foundation/foundation-mda/src/main/java/com/boozallen/aiops/mda/generator/common/VelocityProperty.java
@@ -46,6 +46,8 @@ public final class VelocityProperty {
     public static final String STEP = "step";
     public static final String STEPS = "steps";
     public static final String FILE_STORE = "fileStore";
+    public static final String FILE_STORES = "fileStores";
+    public static final String ENABLE_FILE_STORE = "enableFileStore";
     public static final String ENABLE_DELTA_SUPPORT = "enableDeltaSupport";
     public static final String ENABLE_HIVE_SUPPORT = "enableHiveSupport";
     public static final String ENABLE_PYSPARK_SUPPORT = "enablePySparkSupport";

--- a/foundation/foundation-mda/src/main/resources/templates/deployment/spark-operator/spark-application-base-values.yaml.vm
+++ b/foundation/foundation-mda/src/main/resources/templates/deployment/spark-operator/spark-application-base-values.yaml.vm
@@ -85,6 +85,22 @@ sparkApp:
       env:
         - name: KRAUSENING_BASE
           value: /opt/spark/krausening/base
+        #if (${enableFileStore})
+        #foreach (${fileStore} in ${fileStores})
+        - name: "${fileStore.getName()}_FS_PROVIDER"
+          value: "REPLACE ME: YOUR FILE STORE PROVIDER GOES HERE!"
+        - name: "${fileStore.getName()}_FS_ACCESS_KEY_ID"
+          valueFrom:
+            secretKeyRef:
+              name: remote-auth-config
+              key: AWS_ACCESS_KEY_ID
+        - name: "${fileStore.getName()}_FS_SECRET_ACCESS_KEY"
+          valueFrom:
+            secretKeyRef:
+              name: remote-auth-config
+              key: AWS_SECRET_ACCESS_KEY
+        #end
+        #end
         #if (${enableDataLineageSupport})
         - name: ENABLE_LINEAGE
           value: "true"

--- a/foundation/foundation-mda/src/test/java/com/boozallen/aiops/mda/metamodel/element/AbstractModelInstanceSteps.java
+++ b/foundation/foundation-mda/src/test/java/com/boozallen/aiops/mda/metamodel/element/AbstractModelInstanceSteps.java
@@ -204,8 +204,8 @@ public abstract class AbstractModelInstanceSteps {
 
     protected GenerationContext createGenerationContext(Target target) {
         VelocityEngine engine = new VelocityEngine();
-        engine.setProperty("resource.loader", "class");
-        engine.setProperty("class.resource.loader.class", "org.apache.velocity.runtime.resource.loader.ClasspathResourceLoader");
+        engine.setProperty("resource.loaders", "class");
+        engine.setProperty("resource.loader.class.class", "org.apache.velocity.runtime.resource.loader.ClasspathResourceLoader");
         engine.init();
         GenerationContext context = new GenerationContext(target);
         context.setBasePackage(BOOZ_ALLEN_PACKAGE);


### PR DESCRIPTION
…tore env variables

When a user is creating a pipeline for downstream projects, they have the option to include a [file store](https://boozallen.github.io/aissemble/aissemble/current/file-storage-details.html) into the [pipeline metamodel](https://boozallen.github.io/aissemble/aissemble/current/pipeline-metamodel.html#_pipeline_file_stores_element_options) in order to store/retrieve data from a specific location (i.e S3). This filestore pipeline element requires you to define 3 environment variables inside the created pipelines base-value.yaml. As of right now, this is a manual step that the user must take. We want to autogenerate the environment variables IFF the user includes the filestore in their pipeline implementation. The name of the pipeline model also needs to be prefixed with the pipeline name. (_FS_PROVIDER)

We need to take into account that the filestore element is not required and these environment variables should only be added if the user defines this in the pipeline model file.