### PR TITLE
#3 Added aiSSEMBLE GitHub Action release job

### DIFF
--- a/.github/actions/install_dependencies/action.yaml
+++ b/.github/actions/install_dependencies/action.yaml
@@ -1,0 +1,48 @@
+name: 'Install Dependencies'
+description: 'Install the dependencies needed to build aissemble'
+inputs:
+  docker-username: 
+    required: true
+  docker-token:
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Install required packages
+      shell: bash
+      run: |
+        sudo apt-get update
+        sudo apt install -y build-essential libssl-dev zlib1g-dev libbz2-dev libreadline-dev libsqlite3-dev curl \
+          git libncursesw5-dev xz-utils tk-dev libxml2-dev libxmlsec1-dev libffi-dev liblzma-dev zip unzip \
+          libpython3.11
+    - name: Install Python
+      uses: gabrielfalcao/pyenv-action@v18
+      with:
+        default: 3.11.4
+    - name: Install Poetry
+      uses: snok/install-poetry@v1
+    - name: Install Helm
+      shell: bash
+      run: |
+        curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3
+        chmod 700 get_helm.sh
+        ./get_helm.sh
+    - name: Install Helm Unittest Plugin
+      shell: bash
+      run: |
+        echo "Updating helm unittest plugin to latest version..."
+        helm plugin install https://github.com/helm-unittest/helm-unittest.git
+    - name: Set up JDK 11
+      uses: actions/setup-java@v4
+      with:
+        java-version: '11'
+        distribution: 'temurin'
+    - name: Create Docker Builder Config File
+      shell: bash
+      run: sudo touch /etc/buildkitd.toml
+    - name: Login to Docker Hub
+      uses: docker/login-action@v3
+      with:
+        username: ${{ inputs.docker-username }}
+        password: ${{ inputs.docker-token }}

--- a/.github/actions/split_version/action.yaml
+++ b/.github/actions/split_version/action.yaml
@@ -1,0 +1,44 @@
+name: 'Split Version'
+description: 'Splits the inputed version into major, minor, and patch components'
+inputs:
+  version: 
+    required: true
+  release-branch:
+    required: true
+  existing-version:
+    required: true
+outputs:
+  major-minor-version:
+    value: ${{ steps.split.outputs.major-minor-version }}
+  patch-version:
+    value: ${{ steps.split.outputs.patch-version }}
+  is-pre-release:
+    value: ${{ steps.split.outputs.is-pre-release }}
+  release-branch:
+    value: ${{ steps.split.outputs.release-branch }}
+  existing-version:
+    value: ${{ steps.split.outputs.existing-version }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Split
+      id: split
+      shell: bash
+      # Gets minor version 1.9.0-rc1 -> 1.9 
+      # Gets patch version 1.9.0-rc1 -> 1.9.0
+      # Determines if release is a pre release candidate
+      # Gets the release branch inputs.release-branch != "" ? inputs.release-branch : aissemble-release-$mino_version 
+      # Gets the existing version inputs.existing-version != "" ? inputs.existing-version : $patch_version-SNAPSHOT 
+      run: |
+        major=$(echo ${{ inputs.version }} | cut -d "." -f 1) 
+        minor=$(echo ${{ inputs.version }} | cut -d "." -f 2) 
+        patch=$(echo ${{ inputs.version }} | cut -d "." -f 3 | cut -d "-" -f 1) 
+        minor_version=$major.$minor
+        patch_version=$major.$minor.$patch
+        echo "major-minor-version=$minor_version" >> $GITHUB_OUTPUT 
+        echo "patch-version=$patch_version" >> $GITHUB_OUTPUT
+        echo "is-pre-release=$( [ "${{ inputs.version }}" != "$patch_version" ] && echo true || echo false)" >> $GITHUB_OUTPUT
+        echo "release-branch=$( [ "${{ inputs.release-branch }}" != "" ] && echo "${{ inputs.release-branch }}" || echo "aissemble-release-$minor_version")" >> $GITHUB_OUTPUT
+        echo "existing-version=$( [ "${{ inputs.existing-version }}" != "" ] && echo "${{ inputs.existing-version }}" || echo "$patch_version-SNAPSHOT")" >> $GITHUB_OUTPUT
+

--- a/.github/actions/update_antora/action.yaml
+++ b/.github/actions/update_antora/action.yaml
@@ -1,0 +1,37 @@
+name: 'Update Antora docs'
+description: 'Updates the Antora docs'
+inputs:
+  version:  
+    required: true
+  major-minor-version:  
+    required: true
+  patch-version:  
+    required: true
+  is-pre-release:  
+    required: true
+  release-branch:  
+    required: true
+  custom-facet-old-version:  
+    required: true
+  custom-facet-new-version:  
+    required: true
+    
+runs:
+  using: "composite"
+  steps:
+    - name: Update
+      shell: bash
+      run: |
+        sed -i "s/^version: .*/version: ${{ inputs.patch-version }}/" docs/antora.yml
+        version=$( ${{ inputs.is-pre-release }} && echo ${{ inputs.version }} || echo ${{ inputs.major-minor-version }} )
+        sed -i "s/^display_version: .*/display_version: $version/" docs/antora.yml
+        sed -i "s/^prerelease: .*/prerelease: ${{ inputs.is-pre-release }}/" docs/antora.yml
+        sed -i "s/^    is-pre-release: .*/    is-pre-release: ${{ inputs.is-pre-release }}/" docs/antora.yml
+        find docs/modules/ROOT/attachments/ -type f -exec sed -i 's|${{ inputs.custom-facet-old-version }}|${{ inputs.custom-facet-new-version }}|g' {} +
+        git config --global user.email "aissemble@bah.com"
+        git config --global user.name "aiSSEMBLE Team"
+        git diff
+        git add docs/antora.yml docs/modules/ROOT/attachments/
+        git commit -S -m "Updating Antora documentation for version ${{ inputs.version }}"
+        git push origin HEAD:${{ inputs.release-branch }}
+

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,110 @@
+# This workflow will build a Java project with Maven, and cache/restore any dependencies to improve the workflow execution time
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-java-with-maven
+
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+name: Release aissemble
+
+on:
+  workflow_dispatch:
+    inputs:
+      releaseVersion:
+        description: "The version you want to release aiSSEMBLE on."
+        required: true
+        type: string
+      developmentVersion:
+        description: "The version that dev should be on after this release."
+        required: true
+        type: string
+      releaseBranch:
+        description: "OPTIONAL: The branch to use for running the release."
+        required: false
+        type: string
+      existingVersion:
+        description: "OPTIONAL: The existing aiSSEMBLE version. Defaults to patchVersion-SNAPSHOT"
+        required: false
+        type: string
+
+jobs:
+  build:
+
+    runs-on: arc-runner-set-aissemble
+    env:
+      DOCKER_CONFIG: /home/runner/.docker
+      RELEASE_VERSION: ${{ inputs.releaseVersion }}
+      NEXT_DEVELOPMENT_VERSION: ${{ inputs.developmentVersion }}
+      RELEASE_BRANCH: ${{ inputs.releaseBranch }}
+      EXISTING_VERSION: ${{ inputs.existingVersion }}
+
+    steps:
+      - name: Import GPG key
+        uses: crazy-max/ghaction-import-gpg@v6
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.GPG_PRIVATE_KEY_PASSPHRASE }}
+      - name: Install git
+        run: |
+          sudo apt-get update
+          sudo apt install -y git
+      - uses: actions/checkout@v4
+      - name: Split version
+        id: split_version
+        uses: ./.github/actions/split_version
+        with:
+          version: ${{ env.RELEASE_VERSION }}
+          release-branch: ${{ env.RELEASE_BRANCH }}
+          existing-version: ${{ env.EXISTING_VERSION }}
+      - name: Print release parameters
+        run: | 
+          echo "Releasing with the following parameters"
+          echo "Release version: ${{ env.RELEASE_VERSION }}"
+          echo "Next Development version: ${{ env.NEXT_DEVELOPMENT_VERSION }}"
+          echo "Major minor version: ${{ steps.split_version.outputs.major-minor-version }}"
+          echo "Patch Version: ${{ steps.split_version.outputs.patch-version }}"
+          echo "Is pre release version: ${{ steps.split_version.outputs.is-pre-release }}"
+          echo "Release branch: ${{ steps.split_version.outputs.release-branch }}"
+          echo "Existing version: ${{ steps.split_version.outputs.existing-version }}"
+      - name: Checkout release branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.split_version.outputs.release-branch }}
+      - name: Update Antora Docs
+        uses: ./.github/actions/update_antora
+        with:
+          version: ${{ env.RELEASE_VERSION }}
+          major-minor-version: ${{ steps.split_version.outputs.major-minor-version }} 
+          patch-version: ${{ steps.split_version.outputs.patch-version }}
+          is-pre-release: ${{ steps.split_version.outputs.is-pre-release }}
+          release-branch: ${{ steps.split_version.outputs.release-branch }}
+          custom-facet-old-version: ${{ steps.split_version.outputs.existing-version }}
+          custom-facet-new-version: ${{ env.RELEASE_VERSION }}
+      - name: Install dependencies
+        uses: ./.github/actions/install_dependencies
+        with:
+          docker-username: ${{ secrets.DOCKERHUB_USERNAME }}
+          docker-token: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Create settings.xml
+        run: |
+          echo "<settings><servers><server><id>ossrh</id><username>${{ secrets.SONATYPE_CENTRAL_REPO_TOKEN_USER }}</username><password>${{ secrets.SONATYPE_CENTRAL_REPO_TOKEN_KEY }}</password></server><server><id>ghcr.io</id><username>${{ secrets.GHCR_IO_USERNAME }}</username><password>${{ secrets.GHCR_IO_TOKEN }}</password></server><server><id>pypi</id><username>${{ secrets.PYPI_USERNAME }}</username><password>${{ secrets.PYPI_TOKEN }}</password></server></servers></settings>" > $HOME/.m2/settings.xml
+      - name: Release aiSSEMBLE
+        run: | 
+          ./mvnw release:clean release:prepare release:perform -s $HOME/.m2/settings.xml -U -B -Pci,gh-build -DpushChanges=true -DreleaseVersion=${{ env.RELEASE_VERSION }} -DdevelopmentVersion=${{ env.NEXT_DEVELOPMENT_VERSION }} -Dgpg.keyname=aissemble@bah.com -DsignTag=true -Dmaven.build.cache.enabled=false
+      - name: Split version
+        id: split_version_development
+        uses: ./.github/actions/split_version
+        with:
+          version: ${{ env.NEXT_DEVELOPMENT_VERSION }}
+      - name: Update Antora Docs
+        uses: ./.github/actions/update_antora
+        with:
+          version: ${{ env.NEXT_DEVELOPMENT_VERSION }}
+          patch-version: ${{ steps.split_version_development.outputs.patch-version }}
+          major-minor-version: ${{ steps.split_version_development.outputs.major-minor-version }} 
+          is-pre-release: ${{ steps.split_version_development.outputs.is-pre-release }}
+          release-branch: ${{ steps.split_version.outputs.release-branch }}
+          custom-facet-old-version: ${{ env.RELEASE_VERSION }}
+          custom-facet-new-version: ${{ env.NEXT_DEVELOPMENT_VERSION }}
+


### PR DESCRIPTION
This is a PR to add the aiSSEMBLE GitHub Action release job. This action mimics the Jenkins release job found here https://github.boozallencsn.com/aissemble/aissemble/blob/fix-ci/devops/JenkinsfileRelease.groovy

The release job aims to do the following

- Parses the inputted version to get its major, minor, and patch counterparts
- Executes a pre release update to the release branch's Antora documentation 
- Cuts a release of the release branch
- Executes a post release update to the release branch's Antora documentation 