### PR TITLE
#228 - Replace aissemble-kafka 1.7.0 references with community docker image

### DIFF
--- a/DRAFT_RELEASE_NOTES.md
+++ b/DRAFT_RELEASE_NOTES.md
@@ -53,6 +53,7 @@ To reduce burden of upgrading aiSSEMBLE, the Baton project is used to automate t
 | upgrade-v2-chart-files-aissemble-version-migration | Updates the helm chart dependencies within your project's deployment resources (<YOUR_PROJECT>-deploy/src/main/resources/apps/) to use the latest version of the aiSSEMBLE |
 | upgrade-v1-chart-files-aissemble-version-migration | Updates the docker image tags within your project's deployment resources (<YOUR_PROJECT>-deploy/src/main/resources/apps/) to use the latest version of the aiSSEMBLE       |
 | ml-flow-dockerfile-migration                       | Updates the MLFlow's Dockerfile to use the bitnami/mlflow image as a base instead of the deprecated boozallen/aissemble-mlflow image"                                      |
+| airflow-dockerfile-migration                       | Updates the Airflow's Dockerfile to use the bitnami/airflow image as a base instead of the deprecated boozallen/aissemble-airflow image"                                   |
 | update-data-access-thrift-endpoint-migration       | For projects using the default data-access thrift endpoint, updates to the new endpoint associated with v2 spark-infrastructure                                            |
 
 To deactivate any of these migrations, add the following configuration to the `baton-maven-plugin` within your root `pom.xml`:
@@ -103,3 +104,4 @@ To start your aiSSEMBLE upgrade, update your project's pom.xml to use the 1.9.0 
 - `aissemble-mlflow` Docker image using MLFlow 2.3.1 was replaced with `bitnami/mlflow:2.15.1-debian-12-r0`  Docker image using MLFlow 2.15.1.
 - Airflow Chart version upgraded from `1.10.0` to `1.15.0`.
 - `aissemble-airflow` Docker image using Airflow 2.6.2 was replaced with `apache/airflow`  Docker image using Airflow 2.9.3.
+- `aissemble-kafka` Docker image using Kafka 3.5.1 was replaced with `apache/kafka`  Docker image using Kafka 3.8.0.

--- a/extensions/extensions-helm/aissemble-kafka-chart/values.yaml
+++ b/extensions/extensions-helm/aissemble-kafka-chart/values.yaml
@@ -2,12 +2,7 @@
 ## CONFIG | Kafka Configs
 ########################################
 kafka:
-  # NB: 1.7.0 is the last version to include kafka support. It is being frozen there while we
-  # align it to use a community image.  TODO in https://github.com/boozallen/aissemble/issues/228
-  image:
-    registry: ghcr.io
-    repository: boozallen/aissemble-kafka
-    tag: 1.7.0
+  kafkaVersion: 3.8.0
   fullnameOverride: kafka-cluster
   # Container Ports Configuration
   containerPorts:

--- a/foundation/foundation-mda/src/main/resources/templates/deployment/kafka/kafka.values.yaml.vm
+++ b/foundation/foundation-mda/src/main/resources/templates/deployment/kafka/kafka.values.yaml.vm
@@ -6,8 +6,6 @@ replicaCount: 1
 
 hostname: kafka-cluster
 
-  # NB: 1.7.0 is the last version to include kafka support. It is being frozen there while we
-  # align it to use a community image. TODO in https://github.com/boozallen/aissemble/issues/228
 image:
   name: boozallen/aissemble-kafka
   imagePullPolicy: Always


### PR DESCRIPTION
#228 Replace aissemble-kafka docker image with community docker image.
- Updated Kafka helm chart to pull the community Docker image from Apache.
   -  Upgraded Kafka Docker image from `3.5.1` to `3.8.0`.
- Updated Kafka Helm chart from `23.0.7` to `30.1.1`.