### PR TITLE
#147 BUG: Fix Delete Model Training API in aiSSEMBLE

### DIFF
--- a/foundation/aissemble-foundation-model-training-api/src/model_training_api/model_training_api.py
+++ b/foundation/aissemble-foundation-model-training-api/src/model_training_api/model_training_api.py
@@ -192,7 +192,7 @@ def list_jobs(pipeline_step: Union[str, None] = None):
         raise HTTPException(status_code=500, detail=str(e))
 
 
-@app.delete("/{training_job_name}")
+@app.delete("/training-jobs/{training_job_name}")
 def kill_job(training_job_name):
     """Delete model training job
     Args:


### PR DESCRIPTION
This PR is to fix issue https://github.com/boozallen/aissemble/issues/147

Description:
The Model Training API [documentation](https://boozallen.github.io/aissemble/aissemble/current/machine-learning-pipeline-details.html#_model_training_api) says to submit a DELETE HTTP call to remove a model training job. However, doing so results in a 403: Method Not Allowed response.