### PR TITLE
[#370] only show Tilt notification if not config-store

### DIFF
--- a/foundation/foundation-mda/src/main/java/com/boozallen/aiops/mda/generator/AbstractKubernetesGenerator.java
+++ b/foundation/foundation-mda/src/main/java/com/boozallen/aiops/mda/generator/AbstractKubernetesGenerator.java
@@ -68,7 +68,9 @@ public abstract class AbstractKubernetesGenerator extends AbstractResourcesGener
 
         final ManualActionNotificationService manualActionNotificationService = getNotificationService();
         final String deployArtifactId = generationContext.getArtifactId();
-        addTiltNotification(generationContext, appName, deployArtifactId);
+        if (!"configuration-store".equals(appName)) {
+            addTiltNotification(generationContext, appName, deployArtifactId);
+        }
 
         final String appDependencies = generationContext.getPropertyVariables().get(APP_DEPENDENCIES);
         if (!StringUtils.isEmpty(appDependencies)) {


### PR DESCRIPTION
The Configuration Store requires special logic to be deployed properly via Tilt.  When deciding on where the MVP should be and weighing the options against our planned move _away_ from Tilt, we decided it was best to just exclude the configuration store from local deployments for now and provide projects with instructions upon request.  However, in doing that we accidentally routed the config store to the standard Tilt manual action notification, which doesn't work at all.

This change correctly supresses the Tilt manual action if it is for the config store.  Note that the only real way to ensure this check was to use the `appName`, which technically could be changed by a downstream project which would result in the manual action reappearing.  This is an edge case, and again the plan is to move away from Tilt completely anyway and that work is scheduled to start immediately after the Java upgrade.