### PR TITLE
[#366] fix data record python version

### DIFF
--- a/foundation/foundation-mda/src/main/resources/templates/data-delivery-data-records/combined.pyproject.toml.vm
+++ b/foundation/foundation-mda/src/main/resources/templates/data-delivery-data-records/combined.pyproject.toml.vm
@@ -11,7 +11,7 @@ authors = ["Your Name <you@example.com>"]
 include = ["src/${packageFolderName}/generated/**/*"]
 
 [tool.poetry.dependencies]
-python = "^3.11.4"
+python = ">=3.8"
 pyspark = "${versionSpark}"
 jsonpickle = "^2.1.0"
 

--- a/foundation/foundation-mda/src/main/resources/templates/data-delivery-data-records/separate.core.pyproject.toml.vm
+++ b/foundation/foundation-mda/src/main/resources/templates/data-delivery-data-records/separate.core.pyproject.toml.vm
@@ -11,7 +11,7 @@ authors = ["Your Name <you@example.com>"]
 include = ["src/${packageFolderName}/generated/**/*"]
 
 [tool.poetry.dependencies]
-python = "^3.11.4"
+python = ">=3.8"
 jsonpickle = "^2.1.0"
 
 aissemble-foundation-core-python = "${aissemblePythonVersion}"

--- a/foundation/foundation-mda/src/main/resources/templates/data-delivery-data-records/separate.spark.pyproject.toml.vm
+++ b/foundation/foundation-mda/src/main/resources/templates/data-delivery-data-records/separate.spark.pyproject.toml.vm
@@ -11,7 +11,7 @@ authors = ["Your Name <you@example.com>"]
 include = ["src/${packageFolderName}/generated/**/*"]
 
 [tool.poetry.dependencies]
-python = "^3.11.4"
+python = ">=3.8"
 pyspark = "${versionSpark}"
 
 aissemble-extensions-data-delivery-spark-py = "${aissemblePythonVersion}"


### PR DESCRIPTION
We updated the version bound for python to be `>=3.8` in a previous commit, but missed updating the MDA templates for data record modules. This resulted in a failure to build projects with data records, as the version range `^3.11.4` was no longer satisfied when installing the dependencies of a PySpark pipeline.