### PR TITLE
#152 Records with the same package as a data pipeline cannot be used as inbound/outbound types

### DIFF
--- a/foundation/foundation-mda/src/main/java/com/boozallen/aiops/mda/metamodel/element/java/JavaStepDataRecordType.java
+++ b/foundation/foundation-mda/src/main/java/com/boozallen/aiops/mda/metamodel/element/java/JavaStepDataRecordType.java
@@ -22,9 +22,6 @@ import com.boozallen.aiops.mda.metamodel.element.StepDataRecordType;
  */
 public class JavaStepDataRecordType extends BaseStepDataRecordTypeDecorator {
 
-    private AIOpsModelInstanceRepostory modelRepository = ModelInstanceRepositoryManager
-            .getMetamodelRepository(AIOpsModelInstanceRepostory.class);
-
     /**
      * {@inheritDoc}
      */
@@ -41,7 +38,7 @@ public class JavaStepDataRecordType extends BaseStepDataRecordTypeDecorator {
         String fullyQualifiedRecordType = null;
 
         String packageName = getPackage();
-        if (StringUtils.isNotBlank(packageName) && !packageName.equals(modelRepository.getBasePackage())) {
+        if (StringUtils.isNotBlank(packageName) ){
             fullyQualifiedRecordType = packageName + "." + getName();
         }
 


### PR DESCRIPTION
### Description
When the package name of a record matches the package name of a Spark data pipeline, the record cannot be used as an inbound or outbound record type because a NPE is thrown.

[Issue #152 ](https://github.com/boozallen/aissemble/issues/152)