### PR TITLE
331 dockerhub rate limit - Resolve 429 Too Many Requests Error 

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -599,7 +599,7 @@
                                     </args>
                                     <buildx>
                                         <builderName>default</builderName>
-                                        <dockerStateDir>~/.docker</dockerStateDir>
+                                        <dockerStateDir>~/.docker/fabric8</dockerStateDir>
                                         <platforms>
                                             <platform>${docker.platforms}</platform>
                                         </platforms>

--- a/extensions/extensions-docker/aissemble-fastapi/src/main/resources/docker/Dockerfile
+++ b/extensions/extensions-docker/aissemble-fastapi/src/main/resources/docker/Dockerfile
@@ -1,6 +1,6 @@
 # Script for creating base FastAPI Docker image
 
-FROM python:3.11
+FROM docker.io/python:3.11
 
 LABEL org.opencontainers.image.source="https://github.com/boozallen/aissemble"
 
@@ -10,7 +10,7 @@ WORKDIR /app
 COPY ./src/main/resources/docker/requirements.txt /tmp/requirements.txt
 RUN pip install --no-cache-dir --upgrade -r /tmp/requirements.txt
 
-# Custom start script to run fastAPI with specific 
+# Custom start script to run fastAPI with specific
 # module (defined using MODULE environment variable)
 COPY ./src/main/resources/docker/scripts/start.sh /start.sh
 RUN chmod +x /start.sh

--- a/extensions/extensions-docker/aissemble-hive-service/src/main/resources/docker/Dockerfile
+++ b/extensions/extensions-docker/aissemble-hive-service/src/main/resources/docker/Dockerfile
@@ -1,7 +1,7 @@
 ARG METASTORE_VERSION
-FROM apache/hive:${METASTORE_VERSION} AS appsource
+FROM docker.io/apache/hive:${METASTORE_VERSION} AS appsource
 
-FROM eclipse-temurin:17-jre AS final
+FROM docker.io/eclipse-temurin:17-jre AS final
 
 LABEL org.opencontainers.image.source="https://github.com/boozallen/aissemble"
 

--- a/extensions/extensions-docker/aissemble-jenkins/aissemble-jenkins-agent/src/main/resources/docker/Dockerfile
+++ b/extensions/extensions-docker/aissemble-jenkins/aissemble-jenkins-agent/src/main/resources/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM jenkins/ssh-agent:latest-debian-jdk11
+FROM docker.io/jenkins/ssh-agent:latest-debian-jdk11
 
 LABEL org.opencontainers.image.source="https://github.com/boozallen/aissemble"
 

--- a/extensions/extensions-docker/aissemble-jenkins/aissemble-jenkins-controller/src/main/resources/docker/Dockerfile
+++ b/extensions/extensions-docker/aissemble-jenkins/aissemble-jenkins-controller/src/main/resources/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM jenkins/jenkins:lts-jdk11
+FROM docker.io/jenkins/jenkins:lts-jdk11
 
 LABEL org.opencontainers.image.source="https://github.com/boozallen/aissemble"
 

--- a/extensions/extensions-docker/aissemble-nvidia/src/main/resources/docker/Dockerfile
+++ b/extensions/extensions-docker/aissemble-nvidia/src/main/resources/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:12.1.1-base-ubuntu22.04
+FROM docker.io/nvidia/cuda:12.1.1-base-ubuntu22.04
 
 LABEL org.opencontainers.image.source="https://github.com/boozallen/aissemble"
 

--- a/extensions/extensions-docker/aissemble-spark-operator/src/main/resources/docker/Dockerfile
+++ b/extensions/extensions-docker/aissemble-spark-operator/src/main/resources/docker/Dockerfile
@@ -16,7 +16,7 @@
 ARG DOCKER_BASELINE_REPO_ID
 ARG VERSION_AISSEMBLE
 
-FROM kubeflow/spark-operator:v1beta2-1.6.2-3.5.0 AS builder
+FROM docker.io/kubeflow/spark-operator:v1beta2-1.6.2-3.5.0 AS builder
 
 # We would be able to use the kubeflow image directly, except that it is on Spark 3.5 instead of 3.4
 FROM ${DOCKER_BASELINE_REPO_ID}boozallen/aissemble-spark:${VERSION_AISSEMBLE}

--- a/extensions/extensions-docker/aissemble-spark/src/main/resources/docker/Dockerfile
+++ b/extensions/extensions-docker/aissemble-spark/src/main/resources/docker/Dockerfile
@@ -1,7 +1,7 @@
 # Script for creating base Spark Docker image
 #
 ARG SPARK_VERSION
-FROM apache/spark-py:v${SPARK_VERSION}
+FROM docker.io/apache/spark-py:v${SPARK_VERSION}
 
 LABEL org.opencontainers.image.source="https://github.com/boozallen/aissemble"
 

--- a/extensions/extensions-docker/aissemble-vault/src/main/resources/docker/Dockerfile
+++ b/extensions/extensions-docker/aissemble-vault/src/main/resources/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.13
+FROM docker.io/alpine:3.13
 
 LABEL org.opencontainers.image.source="https://github.com/boozallen/aissemble"
 

--- a/extensions/extensions-docker/aissemble-versioning/src/main/resources/docker/Dockerfile
+++ b/extensions/extensions-docker/aissemble-versioning/src/main/resources/docker/Dockerfile
@@ -20,7 +20,7 @@ RUN --mount=type=cache,target=/.cache/pypoetry/ \
     poetry bundle venv /opt/venv
 #HABUSHU_BUILDER_STAGE - HABUSHU GENERATED CODE (END)
 
-FROM python:3.11 AS builder
+FROM docker.io/python:3.11 AS builder
 
 # Download Maven
 ARG MAVEN_VERSION=3.9.6

--- a/extensions/extensions-docker/pom.xml
+++ b/extensions/extensions-docker/pom.xml
@@ -19,30 +19,6 @@
 
     <profiles>
         <profile>
-            <id>ci</id>
-            <build>
-                <pluginManagement>
-                    <plugins>
-                        <plugin>
-                            <groupId>${group.fabric8.plugin}</groupId>
-                            <artifactId>docker-maven-plugin</artifactId>
-                            <configuration><images>
-                                    <image>
-                                        <build>
-                                            <buildx>
-                                                <!-- use registry mirror to avoid docker pull too many request issues -->
-                                                <configFile>/etc/buildkitd.toml</configFile>
-                                            </buildx>
-                                        </build>
-                                    </image>
-                                </images>
-                            </configuration>
-                        </plugin>
-                    </plugins>
-                </pluginManagement>
-            </build>
-        </profile>
-        <profile>
             <id>ensure-docker-dependencies</id>
             <!-- This profile is used to ensure that the docker dependencies are encoded in Maven properly. Because of
             the way docker works, any missing image will just be downloaded from the repository. This changes the repo


### PR DESCRIPTION
Resolves the `429 Too Many Requests - Server message: toomanyrequests: You have reached your pull rate limit` Docker Hub Error.

The following changes ensure we are using our docker credentials throughout our build process:
- Explicitly state `docker.io` repo in base images
  - This allows fabric8 to pick up the registry and create a config object. Without the registry specified, fabric8 doesn't create the config object
- Update fabric8 to use own `.docker` config location
  - fabric8 cleans up after its done so when using the default `.docker` config location, fabric8 removes the docker credentials. So any module that performs a pull outside of fabric8 was no longer authenticated