### PR TITLE
#363 fix the spark-application build issue

### DIFF
--- a/extensions/extensions-helm/aissemble-spark-application-chart/values.yaml
+++ b/extensions/extensions-helm/aissemble-spark-application-chart/values.yaml
@@ -21,7 +21,6 @@ sparkApp:
       spark.hive.metastore.uris: "thrift://hive-metastore-service:9083/default"
       spark.eventLog.dir: "/opt/spark/spark-events"
       spark.hive.metastore.warehouse.dir: "s3a://spark-infrastructure/warehouse"
-      spark.jars.ivy: "/opt/spark/.ivy2"
     dynamicAllocation:
       enabled: true
       initialExecutors: 0

--- a/foundation/foundation-mda/src/main/resources/templates/deployment/spark-operator/spark-application-dev-values.yaml.vm
+++ b/foundation/foundation-mda/src/main/resources/templates/deployment/spark-operator/spark-application-dev-values.yaml.vm
@@ -2,6 +2,7 @@ sparkApp:
     spec:
       image: "${projectName}-spark-worker-docker:latest"
       sparkConf:
+        spark.jars.ivy: "/opt/spark/.ivy2"
         spark.eventLog.enabled: "true"
         #if ("${sparkExtensions}" != "")
         spark.sql.extensions: "${sparkExtensions}"


### PR DESCRIPTION
Specifying the Ivy user directory will override the Ivy property `ivy.default.ivy.user.dir`, which will also disallow the ivy cache to use `/home/runner/.ivy2/cache` on the runner for the local test. 

Since we only use the pod cache for the dev deployments as the we only set `storeCacheOnNode: true` for the spark-operator as part of `values-dev.yaml`, we will move the ivy cache directory to the spark application `-dev-values` file
