### PR TITLE
399-dockerhub-rate-limit - update habuhsu generated code to include registry in image names

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -34,7 +34,7 @@
         <version.failsafe.plugin>${version.maven.surefire.plugin}</version.failsafe.plugin>
         <version.fermenter>2.10.3</version.fermenter>
         <version.fermenter.legacy.tools>2.8.0</version.fermenter.legacy.tools>
-        <version.habushu.plugin>2.16.1</version.habushu.plugin>
+        <version.habushu.plugin>2.17.0</version.habushu.plugin>
         <version.python>3.11.4</version.python>
         <version.help.plugin>3.5.0</version.help.plugin>
         <version.krausening>20</version.krausening>

--- a/extensions/extensions-docker/aissemble-model-training-api-containers/aissemble-model-training-api-sagemaker/src/main/resources/docker/Dockerfile
+++ b/extensions/extensions-docker/aissemble-model-training-api-containers/aissemble-model-training-api-sagemaker/src/main/resources/docker/Dockerfile
@@ -1,10 +1,10 @@
 #HABUSHU_BUILDER_STAGE - HABUSHU GENERATED CODE (DO NOT MODIFY)
-FROM python:3.11 AS habushu_builder
+FROM docker.io/python:3.11 AS habushu_builder
 # Poetry and supporting plugin installations
 RUN python -m ensurepip --upgrade && \
     pip install poetry && \
     poetry self add poetry-monorepo-dependency-plugin && \
-    poetry self add poetry-plugin-bundle
+    poetry self add poetry-plugin-bundle@1.3.0
 
 WORKDIR /work-dir
 COPY --chown=1001 target/containerize-support ./containerize-support/
@@ -21,7 +21,7 @@ RUN --mount=type=cache,target=/.cache/pypoetry/ \
 #HABUSHU_BUILDER_STAGE - HABUSHU GENERATED CODE (END)
 
 #HABUSHU_FINAL_STAGE - HABUSHU GENERATED CODE (DO NOT MODIFY)
-FROM python:3.11-slim AS final
+FROM docker.io/python:3.11-slim AS final
 # Copy venv from builder and activate by adding to the path
 COPY --from=habushu_builder --chown=1001 /opt/venv /opt/venv/
 ENV PATH="/opt/venv/bin:$PATH"

--- a/extensions/extensions-docker/aissemble-model-training-api-containers/aissemble-model-training-api/src/main/resources/docker/Dockerfile
+++ b/extensions/extensions-docker/aissemble-model-training-api-containers/aissemble-model-training-api/src/main/resources/docker/Dockerfile
@@ -1,10 +1,10 @@
 #HABUSHU_BUILDER_STAGE - HABUSHU GENERATED CODE (DO NOT MODIFY)
-FROM python:3.11 AS habushu_builder
+FROM docker.io/python:3.11 AS habushu_builder
 # Poetry and supporting plugin installations
 RUN python -m ensurepip --upgrade && \
     pip install poetry && \
     poetry self add poetry-monorepo-dependency-plugin && \
-    poetry self add poetry-plugin-bundle
+    poetry self add poetry-plugin-bundle@1.3.0
 
 WORKDIR /work-dir
 COPY --chown=1001 target/containerize-support ./containerize-support/
@@ -21,7 +21,7 @@ RUN --mount=type=cache,target=/.cache/pypoetry/ \
 #HABUSHU_BUILDER_STAGE - HABUSHU GENERATED CODE (END)
 
 #HABUSHU_FINAL_STAGE - HABUSHU GENERATED CODE (DO NOT MODIFY)
-FROM python:3.11-slim AS final
+FROM docker.io/python:3.11-slim AS final
 # Copy venv from builder and activate by adding to the path
 COPY --from=habushu_builder --chown=1001 /opt/venv /opt/venv/
 ENV PATH="/opt/venv/bin:$PATH"

--- a/extensions/extensions-docker/aissemble-versioning/src/main/resources/docker/Dockerfile
+++ b/extensions/extensions-docker/aissemble-versioning/src/main/resources/docker/Dockerfile
@@ -1,10 +1,10 @@
 #HABUSHU_BUILDER_STAGE - HABUSHU GENERATED CODE (DO NOT MODIFY)
-FROM python:3.11 AS habushu_builder
+FROM docker.io/python:3.11 AS habushu_builder
 # Poetry and supporting plugin installations
 RUN python -m ensurepip --upgrade && \
     pip install poetry && \
     poetry self add poetry-monorepo-dependency-plugin && \
-    poetry self add poetry-plugin-bundle
+    poetry self add poetry-plugin-bundle@1.3.0
 
 WORKDIR /work-dir
 COPY --chown=1001 target/containerize-support ./containerize-support/
@@ -31,7 +31,7 @@ RUN wget https://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries
 COPY ./src/main/resources/model_versioning /app/model_versioning
 
 #HABUSHU_FINAL_STAGE - HABUSHU GENERATED CODE (DO NOT MODIFY)
-FROM python:3.11-slim AS final
+FROM docker.io/python:3.11-slim AS final
 # Copy venv from builder and activate by adding to the path
 COPY --from=habushu_builder --chown=1001 /opt/venv /opt/venv/
 ENV PATH="/opt/venv/bin:$PATH"

--- a/extensions/extensions-docker/pom.xml
+++ b/extensions/extensions-docker/pom.xml
@@ -84,8 +84,8 @@
                             <phase>prepare-package</phase>
                             <configuration>
                                 <dockerfile>${project.basedir}/src/main/resources/docker/Dockerfile</dockerfile>
-                                <dockerBuilderBase>python:3.11</dockerBuilderBase>
-                                <dockerFinalBase>python:3.11-slim</dockerFinalBase>
+                                <dockerBuilderBase>docker.io/python:3.11</dockerBuilderBase>
+                                <dockerFinalBase>docker.io/python:3.11-slim</dockerFinalBase>
                                 <dockerUser>1001</dockerUser>
                             </configuration>
                         </execution>


### PR DESCRIPTION
Update Habushu version so that python base images in Dockerfiles have fully qualified names, including the registry:
- docker.io/python:3.11
- docker.io/python:3.11-slim

Updated Modules:
- aissemble-versioning
- aissemble-model-training-api
- aissemble-model-training-api-sagemaker