### PR TITLE
#400 overwrite ivy user directory in aissemble-spark-application-chart

### DIFF
--- a/extensions/extensions-data-delivery/aissemble-extensions-data-delivery-spark-py/src/data_delivery_spark_py/test_utils/spark_session_manager.py
+++ b/extensions/extensions-data-delivery/aissemble-extensions-data-delivery-spark-py/src/data_delivery_spark_py/test_utils/spark_session_manager.py
@@ -47,7 +47,11 @@ def create_standalone_spark_session(sparkapplication_path: str) -> SparkSession:
             ",".join(spec_map["spec"]["deps"]["repositories"]),
         )
     for key, value in spec_map["spec"]["sparkConf"].items():
-        builder = builder.config(key, value)
+        logger.info("sparkConf - key: {}, value: {}: ".format(key, value))
+        if "spark.jars.ivy" != key.lower():
+            builder = builder.config(key, value)
+        else:
+            logger.info("Skip spark config - key: {}: ".format(key))
     return builder.getOrCreate()
 
 

--- a/extensions/extensions-helm/aissemble-spark-application-chart/values.yaml
+++ b/extensions/extensions-helm/aissemble-spark-application-chart/values.yaml
@@ -21,6 +21,7 @@ sparkApp:
       spark.hive.metastore.uris: "thrift://hive-metastore-service:9083/default"
       spark.eventLog.dir: "/opt/spark/spark-events"
       spark.hive.metastore.warehouse.dir: "s3a://spark-infrastructure/warehouse"
+      spark.jars.ivy: "/opt/spark/.ivy2"
     dynamicAllocation:
       enabled: true
       initialExecutors: 0

--- a/foundation/foundation-mda/src/main/resources/templates/cucumber.spark.test.base.harness.java.vm
+++ b/foundation/foundation-mda/src/main/resources/templates/cucumber.spark.test.base.harness.java.vm
@@ -92,7 +92,11 @@ public abstract class SparkTestBaseHarness implements EventListener {
 
         for (Map.Entry<String, String> entry : sparkApplicationConfig.spec().sparkConf().entrySet()) {
             logger.warn(entry.getKey() + " " + entry.getValue());
-            builder = builder.config(entry.getKey(), entry.getValue());
+            if (!entry.getKey().equalsIgnoreCase("spark.jars.ivy")) {
+                builder = builder.config(entry.getKey(), entry.getValue());
+            } else {
+                logger.info(String.format("Skip spark config: %s", entry.getKey()));
+            }
         }
         return builder.getOrCreate();
     }

--- a/foundation/foundation-mda/src/main/resources/templates/deployment/spark-operator/spark-application-dev-values.yaml.vm
+++ b/foundation/foundation-mda/src/main/resources/templates/deployment/spark-operator/spark-application-dev-values.yaml.vm
@@ -2,7 +2,6 @@ sparkApp:
     spec:
       image: "${projectName}-spark-worker-docker:latest"
       sparkConf:
-        spark.jars.ivy: "/opt/spark/.ivy2"
         spark.eventLog.enabled: "true"
         #if ("${sparkExtensions}" != "")
         spark.sql.extensions: "${sparkExtensions}"


### PR DESCRIPTION
For java 17 upgrade, we have upgraded the aissemble-spark base image, which has a different home directory than the /opt/spark/ directory so to make sure Ivy cache can find the right directory (Ivy cache is default to the environment's home directory. e.g.: ~/.ivy2), we will need to override the ivy user directory by specifying the spark.jars.ivy directory in the chart.

Currently, to fix the build issue, we have moved the `spark.jars.ivy` from the spark application chart to the dev values file to avoid the local test issue. However, since our local test is not using the docker container but only copy over the spark configuration from the yaml file to configure the spark session in the local environment, we should not copy spark.jars.ivy directory for the spark tester setup but leave it as default so that it can still use the default home directory and when we deploying the spark application to different environment, we don't need to set spark.jars.ivy path in the values file.