### PR TITLE
#302 imagePullSecrets support to Policy Decision Point chart

### DIFF
--- a/extensions/extensions-helm/aissemble-policy-decision-point-chart/README.md
+++ b/extensions/extensions-helm/aissemble-policy-decision-point-chart/README.md
@@ -9,18 +9,19 @@ helm install policy-decision-point oci://ghcr.io/boozallen/aissemble-policy-deci
 **Note**: *the version should match the aiSSEMBLE project version.*
 
 # Properties
-| Property                      | Description                                 | Required Override | Default                                                                            |
-|-------------------------------|---------------------------------------------|-------------------|------------------------------------------------------------------------------------|
-| app.name                      | Sets label for app.kubernetes.io/name       | No                | Chart.Name (aissemble-policy-decision-point-chart)                                 |
-| app.version                   | Sets label for app.kubernetes.io/version    | No                | Chart.AppVersion (aiSSEMBLE project version)                                       |
-| hostname                      | The hostname for the application            | No                | policy-decision-point                                                              |
-| image.name                    | The image name                              | Yes               | boozallen/aissemble-policy-decision-point                                          |
-| image.imagePullPolicy         | The image pull policy                       | No                | Always (ensures local docker image is pulled, rather than from Nexus repo)         |
-| image.dockerRepo              | The image docker repository                 | No                | ghcr.io/                                                                           |
-| image.tag                     | The image tag                               | No                | Chart.AppVersion                                                                   |
-| service.spec.ports            | The service spec ports                      | No                | - name: rest-api <br/>&emsp;&emsp;port: 8080 <br/>&emsp;&emsp;targetPort: 8080     |
-| deployment.ports              | The deployment ports                        | No                | - name: http-1 <br/>&emsp;&emsp;containerPort: 8080 <br/>&emsp;&emsp;protocol: TCP |
-| deployment.restartPolicy      | The deployment restart policy               | No                | Always                                                                             |
+| Property                     | Description                                                       | Required Override | Default                                                                           |
+|------------------------------|-------------------------------------------------------------------|-------------------|-----------------------------------------------------------------------------------|
+| app.name                     | Sets label for app.kubernetes.io/name                             | No                | Chart.Name (aissemble-policy-decision-point-chart)                                |
+| app.version                  | Sets label for app.kubernetes.io/version                          | No                | Chart.AppVersion (aiSSEMBLE project version)                                      |
+| hostname                     | The hostname for the application                                  | No                | policy-decision-point                                                             |
+| image.name                   | The image name                                                    | Yes               | boozallen/aissemble-policy-decision-point                                         |
+| image.imagePullPolicy        | The image pull policy                                             | No                | Always (ensure to pull from remote repository i.e. ghcr.io)                       |
+| image.dockerRepo             | The image docker repository                                       | No                | ghcr.io/                                                                          |
+| image.tag                    | The image tag                                                     | No                | Chart.AppVersion                                                                  |
+| service.spec.ports           | The service spec ports                                            | No                | - name: rest-api <br/>&emsp;&emsp;port: 8080 <br/>&emsp;&emsp;targetPort: 8080    |
+| deployment.ports             | The deployment ports                                              | No                | - name: http-1 <br/>&emsp;&emsp;containerPort: 8080 <br/>&emsp;&emsp;protocol: TCP |
+| deployment.restartPolicy     | The deployment restart policy                                     | No                | Always                                                                            |
+| deployment.imagePullSecrets  | The secrets to use for pulling any of the images used by this pod | No                | []                                                                                |
 
 # Migration from aiSSEMBLE v1 Helm Charts
 If you are migrating from the v1 version of the policy decision point chart, use the tables below to apply any existing customizations from the old chart to the new v2 chart.

--- a/extensions/extensions-helm/aissemble-policy-decision-point-chart/templates/deployment.yaml
+++ b/extensions/extensions-helm/aissemble-policy-decision-point-chart/templates/deployment.yaml
@@ -24,6 +24,10 @@ spec:
         {{- toYaml . | nindent 12}}
       {{- end }}
       serviceAccountName: {{ .Values.deployment.serviceAccountName }}
+      {{- with .Values.deployment.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       automountServiceAccountToken: {{ .Values.deployment.automountServiceAccountToken | default false }}
       {{- with .Values.deployment.volumes }}
       volumes:

--- a/extensions/extensions-helm/aissemble-policy-decision-point-chart/tests/deployment_test.yaml
+++ b/extensions/extensions-helm/aissemble-policy-decision-point-chart/tests/deployment_test.yaml
@@ -34,6 +34,8 @@ tests:
           name: test
           containerPort: 8081
           protocol: test
+        imagePullSecrets:
+          - name: regcred
     asserts:
       - equal:
           path: spec.template.spec.containers[0].ports.name
@@ -44,3 +46,8 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].ports.protocol
           value: test
+      - contains:
+          path: spec.template.spec.imagePullSecrets
+          any: true
+          content:
+            name: regcred

--- a/extensions/extensions-helm/aissemble-policy-decision-point-chart/values.yaml
+++ b/extensions/extensions-helm/aissemble-policy-decision-point-chart/values.yaml
@@ -24,3 +24,4 @@ deployment:
       containerPort: 8080
       protocol: TCP
   restartPolicy: Always
+  imagePullSecrets: []


### PR DESCRIPTION
The v2 charts for Policy Decision Point do not currently allow for the user to add an imagePullSecret so that images can be pulled from private image registries. We would like to add this functionality to the chart so that it can be used more easily in downstream projects that require the use of a private image registry.

Issue #302 https://github.com/boozallen/aissemble/issues/302