### PR TITLE
[#391] add kafka dependency to test projects

### DIFF
--- a/test/test-mda-models/test-data-delivery-spark-model-basic/pom.xml
+++ b/test/test-mda-models/test-data-delivery-spark-model-basic/pom.xml
@@ -126,6 +126,10 @@
             <artifactId>foundation-metadata-producer</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.boozallen.aissemble</groupId>
+            <artifactId>extensions-messaging-kafka</artifactId>
+        </dependency>
+        <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>extensions-data-delivery-spark</artifactId>
         </dependency>

--- a/test/test-mda-models/test-data-delivery-spark-model/pom.xml
+++ b/test/test-mda-models/test-data-delivery-spark-model/pom.xml
@@ -135,6 +135,10 @@
             <artifactId>foundation-metadata-producer</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.boozallen.aissemble</groupId>
+            <artifactId>extensions-messaging-kafka</artifactId>
+        </dependency>
+        <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>extensions-data-delivery-spark</artifactId>
         </dependency>


### PR DESCRIPTION
In ad25749d we added the extensions-messaging-kafka dependency to pipelines by default so the Kafka CDI context could be added in CdiContainerFactory. The test-mda-model projects do not regenerate their POM files on rebuild, so we need to add the new dependencies manually.