### PR TITLE
#414 - JDK 17 Upgrade Support Series - Filestore & Pipeline model config

### DIFF
--- a/foundation/foundation-core-java/src/main/java/com/boozallen/aissemble/core/filestore/AbstractFileStore.java
+++ b/foundation/foundation-core-java/src/main/java/com/boozallen/aissemble/core/filestore/AbstractFileStore.java
@@ -45,10 +45,13 @@ public abstract class AbstractFileStore {
      * @return a fully connected context
      */
     public BlobStoreContext openContext() {
-        return ContextBuilder.newBuilder(fileStoreConfig.getProvider())
-                .credentials(fileStoreConfig.getAccessKeyId(), fileStoreConfig.getSecretAccessKey())
-                .overrides(fileStoreConfig.getOverrides())
-                .buildView(BlobStoreContext.class);
+        ContextBuilder contextBuilder = ContextBuilder.newBuilder(fileStoreConfig.getProvider())
+                .credentials(fileStoreConfig.getAccessKeyId(), fileStoreConfig.getSecretAccessKey());
+
+        if (fileStoreConfig.getOverrides() != null) {
+            contextBuilder.overrides(fileStoreConfig.getOverrides());
+        }
+        return contextBuilder.buildView(BlobStoreContext.class);
     }
 
     /**

--- a/foundation/foundation-core-java/src/main/java/com/boozallen/aissemble/core/filestore/EnvironmentVariableFileStoreConfig.java
+++ b/foundation/foundation-core-java/src/main/java/com/boozallen/aissemble/core/filestore/EnvironmentVariableFileStoreConfig.java
@@ -28,6 +28,7 @@ public class EnvironmentVariableFileStoreConfig extends AbstractFileStoreConfig 
 
     /**
      * Get the configurations for the given filestore name.
+     *
      * @param name the name of the filestore
      * @return the configurations from the environment variables.
      */
@@ -58,11 +59,12 @@ public class EnvironmentVariableFileStoreConfig extends AbstractFileStoreConfig 
     public Properties getOverrides() {
         // Convert namespaced override values to property names understood by JClouds
         final String overridesJsonString = this.config.get(getName() + "_FS_OVERRIDES");
-        final Gson gson = new Gson();
-        final Map overrides = gson.fromJson(overridesJsonString, Map.class);
-
         final Properties propertyOverrides = new Properties();
-        propertyOverrides.putAll(overrides);
+        if (overridesJsonString != null && !overridesJsonString.isBlank()) {
+            final Gson gson = new Gson();
+            final Map overrides = gson.fromJson(overridesJsonString, Map.class);
+            propertyOverrides.putAll(overrides);
+        }
         return propertyOverrides;
     }
 }

--- a/foundation/foundation-mda/src/main/resources/templates/file-store/file.store.impl.java.vm
+++ b/foundation/foundation-mda/src/main/resources/templates/file-store/file.store.impl.java.vm
@@ -5,8 +5,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 /**
  * Utility for accessing the ${fileStore.name} file storage. To customize
  * the file store connection modify the environment variables as per the documentation at
- * https://boozallen.github.io/aissemble/current/pipeline-metamodel.html
- *
+ * https://boozallen.github.io/aissemble/aissemble/current/pipeline-metamodel.html
  * Please **DO** modify with your customizations, as appropriate.
  *
  * Originally generated from: ${templateName}


### PR DESCRIPTION
#414 - JDK 17 Upgrade Support Series - Filestore & Pipeline model config
- Modifications to ensure FileStore and Pipeline model config is functional with the JDK 17 upgrade.
- Fixing an outdated aiSSEMBLE docs link in a FileStore template file.