### PR TITLE
[#442] account for lists in `YamlUtils#loadYaml`

### DIFF
--- a/foundation/foundation-upgrade/src/main/java/com/boozallen/aissemble/upgrade/migration/v1_10_0/DeltaSparkPomMigration.java
+++ b/foundation/foundation-upgrade/src/main/java/com/boozallen/aissemble/upgrade/migration/v1_10_0/DeltaSparkPomMigration.java
@@ -13,6 +13,7 @@ package com.boozallen.aissemble.upgrade.migration.v1_10_0;
 import com.boozallen.aissemble.upgrade.migration.AbstractAissembleMigration;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.maven.model.Dependency;
+import org.apache.maven.model.DependencyManagement;
 import org.apache.maven.model.InputLocation;
 import org.apache.maven.model.InputLocationTracker;
 import org.apache.maven.model.Model;
@@ -86,10 +87,13 @@ public class DeltaSparkPomMigration extends AbstractAissembleMigration {
 
     private List<Dependency> getDeltaCoreDependencies(ModelBase model) {
         List<Dependency> deltaCoreDependencies = new ArrayList<>();
-        model.getDependencyManagement().getDependencies()
-                .stream()
-                .filter(DeltaSparkPomMigration::isDeltaCore)
-                .forEach(deltaCoreDependencies::add);
+        DependencyManagement dependencyManagement = model.getDependencyManagement();
+        if (dependencyManagement != null) {
+            dependencyManagement.getDependencies()
+                    .stream()
+                    .filter(DeltaSparkPomMigration::isDeltaCore)
+                    .forEach(deltaCoreDependencies::add);
+        }
         model.getDependencies()
                 .stream()
                 .filter(DeltaSparkPomMigration::isDeltaCore)

--- a/foundation/foundation-upgrade/src/main/resources/migrations.json
+++ b/foundation/foundation-upgrade/src/main/resources/migrations.json
@@ -73,7 +73,8 @@
         "implementation": "com.boozallen.aissemble.upgrade.migration.v1_10_0.DeltaSparkYamlMigration",
         "fileSets": [
           {
-            "includes": ["**/*.yaml"]
+            "includes": ["**/*.yaml"],
+            "excludes": ["**/target/**", "**/templates/**"]
           }
         ]
       }

--- a/foundation/foundation-upgrade/src/test/java/com/boozallen/aissemble/upgrade/migration/utils/YamlUtilsSteps.java
+++ b/foundation/foundation-upgrade/src/test/java/com/boozallen/aissemble/upgrade/migration/utils/YamlUtilsSteps.java
@@ -1,0 +1,96 @@
+package com.boozallen.aissemble.upgrade.migration.utils;
+
+/*-
+ * #%L
+ * aiSSEMBLE::Foundation::Upgrade
+ * %%
+ * Copyright (C) 2021 Booz Allen
+ * %%
+ * This software package is licensed under the Booz Allen Public License. All Rights Reserved.
+ * #L%
+ */
+
+import com.boozallen.aissemble.upgrade.util.YamlUtils;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.When;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class YamlUtilsSteps {
+
+    private Path testFile;
+    private YamlUtils.YamlObject yaml;
+
+    @Given("a YAML file:")
+    public void aYamlFile(String contents) throws IOException {
+        testFile = Files.createTempFile(Path.of("target"), "yaml-util-test", "");
+        Files.writeString(testFile, contents);
+    }
+
+    @When("the file is loaded")
+    public void theFileIsLoaded() throws IOException {
+        yaml = YamlUtils.loadYaml(testFile.toFile());
+    }
+
+    @Then("the string value of the property {string} is {string}")
+    public void theStringValueOfThePropertyIs(String name, String value) {
+        String type = yaml.get(name).getClass().getSimpleName();
+        assertTrue("Property was not loaded as string: " + name + " (was " + type + ")", yaml.hasString(name));
+        assertEquals("Property value does not match for: " + name, value, yaml.getString(name));
+    }
+
+    @Then("the decimal value of the property {string} is {double}")
+    public void theDecimalValueOfThePropertyIs(String name, double value) {
+        String type = yaml.get(name).getClass().getSimpleName();
+        assertTrue("Property was not loaded as double: " + name + " (was " + type + ")", yaml.hasDouble(name));
+        assertEquals("Property value does not match for: " + name, value, yaml.getDouble(name), 0.01);
+    }
+
+    @Then("the integer value of the property {string} is {int}")
+    public void theIntegerValueOfThePropertyIs(String name, int value) {
+        String type = yaml.get(name).getClass().getSimpleName();
+        assertTrue("Property was not loaded as int: " + name + " (was " + type + ")", yaml.hasInt(name));
+        assertEquals("Property value does not match for: " + name, value, yaml.getInt(name));
+    }
+
+    @Then("the boolean value of the property {string} is {string}")
+    public void theBooleanValueOfThePropertyIs(String name, String value) {
+        String type = yaml.get(name).getClass().getSimpleName();
+        assertTrue("Property was not loaded as boolean: " + name + " (was " + type + ")", yaml.hasBoolean(name));
+        assertEquals("Property value does not match for: " + name, Boolean.valueOf(value), yaml.getBoolean(name));
+    }
+
+    @Then("the property {string} is an object")
+    public void thePropertyIsAnObject(String name) {
+        String type = yaml.get(name).getClass().getSimpleName();
+        assertTrue("Property was not loaded as object: " + name + " (was " + type + ")", yaml.hasObject(name));
+    }
+
+    @Then("the decimal value of the property {string} of the Object {string} is {double}")
+    public void theDecimalValueOfThePropertyOfTheObjectIs(String prop, String obj, double value) {
+        assertTrue("Property was not loaded as double: " + obj + "." + prop, yaml.hasDouble(obj, prop));
+        assertEquals("Property value does not match for: " + obj + "." + prop, value, yaml.getDouble(obj, prop), 0.01);
+    }
+
+    @Then("the size of the list {string} is {int}")
+    public void theSizeOfTheListIs(String name, int size) {
+        String type = yaml.get(name).getClass().getSimpleName();
+        assertTrue("Property was not loaded as list: " + name + " (was " + type + ")", yaml.hasList(name));
+        assertEquals("Property value does not match for: " + name, size, yaml.getList(name).size());
+    }
+
+    @Then("the {string} of item {int} of the list {string} is {int}")
+    public void theIntegerValueOfItemOfTheListIs(String prop, int index, String list, int value) {
+        List<YamlUtils.YamlObject> objects = yaml.getListOfObjects(list);
+        YamlUtils.YamlObject object = objects.get(index);
+        String key = list + "[" + index + "]." + prop;
+        assertEquals("Property value does not match for: " + key, value, object.getInt(prop));
+    }
+}

--- a/foundation/foundation-upgrade/src/test/java/com/boozallen/aissemble/upgrade/migration/v1_10_0/DeltaSparkMigration.java
+++ b/foundation/foundation-upgrade/src/test/java/com/boozallen/aissemble/upgrade/migration/v1_10_0/DeltaSparkMigration.java
@@ -31,6 +31,11 @@ public class DeltaSparkMigration extends AbstractMigrationTest {
         testFile = getTestFile("v1_10_0/DeltaSparkPomMigration/migration/pom.xml");
     }
 
+    @Given("a POM that references the delta-core package that does not have dependencyManagement")
+    public void aPOMThatReferencesTheDeltaCorePackageThatDoesNotHaveDependencyManagement() {
+        testFile = getTestFile("v1_10_0/DeltaSparkPomMigration/migration/no-mgmt.xml");
+    }
+
     @When("the 1.10.0 DeltaSpark yaml migration executes")
     public void theDeltaSparkYamlMigrationExecutes() {
         DeltaSparkYamlMigration migration = new DeltaSparkYamlMigration();

--- a/foundation/foundation-upgrade/src/test/resources/specifications/v1_10_0/delta-spark-migration.feature
+++ b/foundation/foundation-upgrade/src/test/resources/specifications/v1_10_0/delta-spark-migration.feature
@@ -17,3 +17,8 @@ Feature: Migrate Delta Lake Spark dependencies
     Given a POM that references the delta-core package
     When the 1.10.0 DeltaSpark POM migration executes
     Then delta-core is updated to delta-spark and the version is set to the version.delta property
+
+  Scenario: POM dependencies are migrated without dependency management
+    Given a POM that references the delta-core package that does not have dependencyManagement
+    When the 1.10.0 DeltaSpark POM migration executes
+    Then delta-core is updated to delta-spark and the version is set to the version.delta property

--- a/foundation/foundation-upgrade/src/test/resources/specifications/yaml-utils.feature
+++ b/foundation/foundation-upgrade/src/test/resources/specifications/yaml-utils.feature
@@ -1,0 +1,35 @@
+Feature: Utilities -> YAML
+
+  Scenario: I can load a YAML file with an object
+    Given a YAML file:
+       """yaml
+       name: test
+       size: 7.5
+       count: 12
+       complete: True
+       nested: {
+         size: 2.0
+       }
+       multiple:
+         - intvalue: 5
+         - intvalue: 7
+       """
+    When the file is loaded
+    Then the string value of the property "name" is "test"
+    And the decimal value of the property "size" is 7.5
+    And the integer value of the property "count" is 12
+    And the boolean value of the property "complete" is "true"
+    And the property "nested" is an object
+    And the decimal value of the property "size" of the Object "nested" is 2.0
+    And the size of the list "multiple" is 2
+    And the "intvalue" of item 1 of the list "multiple" is 7
+
+  Scenario: I can load a YAML file with a list
+    Given a YAML file:
+      """yaml
+      - red
+      - blue
+      - yellow
+      """
+    When the file is loaded
+    Then the size of the list "items" is 3

--- a/foundation/foundation-upgrade/src/test/resources/test-files/v1_10_0/DeltaSparkPomMigration/migration/no-mgmt.xml
+++ b/foundation/foundation-upgrade/src/test/resources/test-files/v1_10_0/DeltaSparkPomMigration/migration/no-mgmt.xml
@@ -1,0 +1,22 @@
+<!--
+  #%L
+  aiSSEMBLE::Foundation::Upgrade
+  %%
+  Copyright (C) 2021 Booz Allen
+  %%
+  This software package is licensed under the Booz Allen Public License. All Rights Reserved.
+  #L%
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.test</groupId>
+    <artifactId>test-pom</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.delta</groupId>
+            <artifactId>delta-core_2.13</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/foundation/foundation-upgrade/src/test/resources/test-files/v1_10_0/DeltaSparkPomMigration/validation/no-mgmt.xml
+++ b/foundation/foundation-upgrade/src/test/resources/test-files/v1_10_0/DeltaSparkPomMigration/validation/no-mgmt.xml
@@ -1,0 +1,23 @@
+<!--
+  #%L
+  aiSSEMBLE::Foundation::Upgrade
+  %%
+  Copyright (C) 2021 Booz Allen
+  %%
+  This software package is licensed under the Booz Allen Public License. All Rights Reserved.
+  #L%
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.test</groupId>
+    <artifactId>test-pom</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.delta</groupId>
+            <artifactId>delta-spark_2.13</artifactId>
+            <version>${version.delta}</version>
+        </dependency>
+    </dependencies>
+</project>


### PR DESCRIPTION
Also fixes a bug with the `hasDouble`, `hasInt`, and `hasBoolean` methods of `YamlObject`. Adds tests for `YamlUtils` including one to catch the root list issue. Finally, also updates the POM migration to account for POMs without dependency management sections.