### PR TITLE
#430 FIx data delivery steps not injecting smallrye when running test-data-delivery-spark-model

### DIFF
--- a/foundation/foundation-mda/src/main/java/com/boozallen/aiops/mda/metamodel/element/java/JavaStep.java
+++ b/foundation/foundation-mda/src/main/java/com/boozallen/aiops/mda/metamodel/element/java/JavaStep.java
@@ -158,6 +158,10 @@ public class JavaStep extends BaseStepDecorator {
         return isVoid(getOutbound());
     }
 
+    public boolean useEmitter() {
+        return hasNativeInbound() || hasVoidInbound();
+    }
+
     public Set<String> getBaseImports() {
         getBaseSignature();
         addPersistImports();

--- a/foundation/foundation-mda/src/main/resources/templates/data-delivery-spark/asynchronous.processor.base.java.vm
+++ b/foundation/foundation-mda/src/main/resources/templates/data-delivery-spark/asynchronous.processor.base.java.vm
@@ -26,7 +26,7 @@ import org.reactivestreams.Subscription;
 #if (${step.outbound})
 import org.eclipse.microprofile.reactive.messaging.Outgoing;
 #end
-#if ((${step.hasMessagingOutbound()} && ${step.hasNativeInbound()}))
+#if ((${step.hasMessagingOutbound()} && ${step.useEmitter()}))
 import org.eclipse.microprofile.reactive.messaging.Channel;
 import org.eclipse.microprofile.reactive.messaging.Emitter;
 #end
@@ -137,7 +137,7 @@ public abstract class ${step.capitalizedName}Base extends AbstractPipelineStep {
     #end
 #end
 
-#if ($step.hasMessagingOutbound() && $step.hasNativeInbound())
+#if ($step.hasMessagingOutbound() && $step.useEmitter())
 	@OnOverflow(value = OnOverflow.Strategy.BUFFER, bufferSize = 20)
 	@Inject
 	@Channel(OUTGOING_CHANNEL)
@@ -182,7 +182,7 @@ public abstract class ${step.capitalizedName}Base extends AbstractPipelineStep {
 	@Acknowledgment(Acknowledgment.Strategy.PRE_PROCESSING)
 	@OnOverflow(value = OnOverflow.Strategy.BUFFER, bufferSize = 20)
 	#end
-	#if (${step.hasMessagingOutbound()} && !${step.hasNativeInbound()})
+	#if (${step.hasMessagingOutbound()} && !${step.hasNativeInbound()} && !${step.hasVoidInbound()})
 	@Outgoing(OUTGOING_CHANNEL)
 	#end
 	${step.baseSignature} {
@@ -209,7 +209,7 @@ public abstract class ${step.capitalizedName}Base extends AbstractPipelineStep {
 			#if ($step.billOfMaterial && $step.billOfMaterial.enabled)
 			recordBOM();
 			#end
-			#if ($step.hasMessagingOutbound() && $step.hasNativeInbound())
+			#if ($step.hasMessagingOutbound() && $step.useEmitter())
 			${step.baseOutboundType} outboundPayload = executeStepImpl(#if (${step.baseInboundType}) inbound #end);
             #if ($pipeline.getDataLineage())
             eventEndTime = ZonedDateTime.now(ZoneOffset.UTC);

--- a/test/test-mda-models/test-data-delivery-spark-model/src/main/resources/pipelines/SparkJavaDataDeliveryPatterns.json
+++ b/test/test-mda-models/test-data-delivery-spark-model/src/main/resources/pipelines/SparkJavaDataDeliveryPatterns.json
@@ -383,6 +383,14 @@
 			}
 		},
 		{
+			"name": "VoidInboundAndMessagingOutboundAsync",
+			"type": "asynchronous",
+			"outbound": {
+				"type": "messaging",
+				"channelName": "outboundChannel"
+			}
+		},
+		{
 			"name": "MessagingOutboundWithCustomTypes",
 			"type": "synchronous",
 			"outbound": {
@@ -395,8 +403,32 @@
 			}
 		},
 		{
+			"name": "MessagingOutboundWithCustomTypesAsync",
+			"type": "asynchronous",
+			"outbound": {
+				"type": "messaging",
+				"channelName": "outboundChannel",
+				"recordType": {
+					"name": "CustomRecord",
+					"package": "com.boozallen.aiops.mda.pattern.record"
+				}
+			}
+		},
+		{
 			"name": "MessagingOutboundWithCustomRec",
 			"type": "synchronous",
+			"outbound": {
+				"type": "messaging",
+				"channelName": "outboundChannel",
+				"recordType": {
+					"name": "CustomRec",
+					"package": "com.boozallen.aiops.mda.pattern.record"
+				}
+			}
+		},
+		{
+			"name": "MessagingOutboundWithCustomRecAsync",
+			"type": "asynchronous",
 			"outbound": {
 				"type": "messaging",
 				"channelName": "outboundChannel",


### PR DESCRIPTION
We have disabled some data delivery steps as those steps are not injecting smallrye reactive messaging correctly.

It seems like any step with asynchronous type, no inbound messaging , and messaging outbound is having issue with running step execution.

Issue https://github.com/boozallen/aissemble/issues/430