### PR TITLE
[#373] use .Chart.AppVersion for image tags in custom charts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,6 +55,14 @@ jobs:
           docker-username: ${{ secrets.DOCKERHUB_USERNAME }}
           docker-token: ${{ secrets.DOCKERHUB_TOKEN }}
       #NB: We restore/save cache manually so that we save the cache even if the build fails
+      - name: Load docker build cache
+        id: cached-docker-build
+        uses: actions/cache/restore@v4
+        with:
+          path: ~/.docker/cache
+          key: docker-cache-${{ hashFiles('**/Dockerfile') }}
+          restore-keys: |
+            docker-cache-
       - name: Load m2 repository cache # Manually caching .m2 repo as the setup-java caching isn't falling back to older caches
         id: cached-m2-repo
         uses: actions/cache/restore@v4
@@ -71,14 +79,6 @@ jobs:
           key: maven-build-cache-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             maven-build-cache-
-      - name: Load docker build cache
-        id: cached-docker-build
-        uses: actions/cache/restore@v4
-        with:
-          path: ~/.docker/cache
-          key: docker-cache-${{ hashFiles('**/Dockerfile') }}
-          restore-keys: |
-            docker-cache-
       #NB: Not saving poetry cache on failure in case it's a failure caused by an in-flight python package release
       - name: Poetry cache
         id: cached-poetry
@@ -105,6 +105,13 @@ jobs:
       - name: Run Archetype Tests
         run: |
           ./mvnw -B clean install -Parchetype-test -pl :foundation-archetype
+      - name: Save docker build cache
+        id: save-docker-build
+        uses: actions/cache/save@v4
+        if: always() && steps.cached-docker-build.outputs.cache-hit != 'true'
+        with:
+          path: ~/.docker/cache
+          key: docker-cache-${{ hashFiles('**/Dockerfile') }}
       - name: Save m2 repository cache
         id: save-m2-repo
         uses: actions/cache/save@v4
@@ -119,10 +126,3 @@ jobs:
         with:
           path: ~/.m2/build-cache
           key: maven-build-cache-${{ hashFiles('**/pom.xml') }}
-      - name: Save docker build cache
-        id: save-docker-build
-        uses: actions/cache/save@v4
-        if: always() && steps.cached-docker-build.outputs.cache-hit != 'true'
-        with:
-          path: ~/.docker/cache
-          key: docker-cache-${{ hashFiles('**/Dockerfile') }}

--- a/.gitignore
+++ b/.gitignore
@@ -64,9 +64,6 @@ docs/antora-aissemble-ui/public/
 **/charts/*
 Chart.lock
 extensions/extensions-helm/aissemble-spark-operator-chart/values.yaml
-extensions/extensions-helm/aissemble-fastapi-chart/values.yaml
-extensions/extensions-helm/aissemble-quarkus-chart/values.yaml
-extensions/extensions-helm/aissemble-configuration-store-chart/values.yaml
 extensions/extensions-helm/aissemble-infrastructure-chart/values.yaml
 
 # The test project should test that we generate files that compile and have the expected structure for model options

--- a/extensions/extensions-helm/aissemble-configuration-store-chart/pom.xml
+++ b/extensions/extensions-helm/aissemble-configuration-store-chart/pom.xml
@@ -25,10 +25,6 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>com.google.code.maven-replacer-plugin</groupId>
-                <artifactId>replacer</artifactId>
-            </plugin>
-            <plugin>
                 <groupId>${group.helm.plugin}</groupId>
                 <artifactId>helm-maven-plugin</artifactId>
             </plugin>

--- a/extensions/extensions-helm/aissemble-configuration-store-chart/values.yaml
+++ b/extensions/extensions-helm/aissemble-configuration-store-chart/values.yaml
@@ -8,7 +8,7 @@ aissemble-quarkus-chart:
       repo: ghcr.io/
       name: boozallen/aissemble-configuration-store
       imagePullPolicy: IfNotPresent
-      tag: "@version.aissemble@"
+      tag: ""
     hostname: configuration-store
     restartPolicy: Always
 

--- a/extensions/extensions-helm/aissemble-fastapi-chart/.helmignore
+++ b/extensions/extensions-helm/aissemble-fastapi-chart/.helmignore
@@ -1,5 +1,2 @@
 target
 pom.xml
-
-#helm ignore the base template and generate the values.yaml via POM plugin executions
-values.template.yaml

--- a/extensions/extensions-helm/aissemble-fastapi-chart/pom.xml
+++ b/extensions/extensions-helm/aissemble-fastapi-chart/pom.xml
@@ -16,10 +16,6 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>com.google.code.maven-replacer-plugin</groupId>
-                <artifactId>replacer</artifactId>
-            </plugin>
-            <plugin>
                 <groupId>${group.helm.plugin}</groupId>
                 <artifactId>helm-maven-plugin</artifactId>
             </plugin>

--- a/extensions/extensions-helm/aissemble-fastapi-chart/values-dev.yaml
+++ b/extensions/extensions-helm/aissemble-fastapi-chart/values-dev.yaml
@@ -1,3 +1,0 @@
-image:
-  imagePullPolicy: IfNotPresent
-  dockerRepo: ""

--- a/extensions/extensions-helm/aissemble-fastapi-chart/values.yaml
+++ b/extensions/extensions-helm/aissemble-fastapi-chart/values.yaml
@@ -10,7 +10,7 @@ replicaCount: 1
 hostname: fastapi
 image:
   name: boozallen/aissemble-fastapi
-  tag: "@version.aissemble@"
+  tag: ""
   imagePullPolicy: Always
   dockerRepo: ghcr.io/
 

--- a/extensions/extensions-helm/aissemble-quarkus-chart/.helmignore
+++ b/extensions/extensions-helm/aissemble-quarkus-chart/.helmignore
@@ -1,5 +1,2 @@
 target
 pom.xml
-
-#helm ignore the base template and generate the values.yaml via POM plugin executions
-values.template.yaml

--- a/extensions/extensions-helm/aissemble-quarkus-chart/Chart.yaml
+++ b/extensions/extensions-helm/aissemble-quarkus-chart/Chart.yaml
@@ -1,4 +1,3 @@
----
 name: aissemble-quarkus-chart
 # Version is automatically set by the plugin so this is only a placeholder
 version: 1.0.0

--- a/extensions/extensions-helm/aissemble-quarkus-chart/pom.xml
+++ b/extensions/extensions-helm/aissemble-quarkus-chart/pom.xml
@@ -16,10 +16,6 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>com.google.code.maven-replacer-plugin</groupId>
-                <artifactId>replacer</artifactId>
-            </plugin>
-            <plugin>
                 <groupId>${group.helm.plugin}</groupId>
                 <artifactId>helm-maven-plugin</artifactId>
             </plugin>

--- a/extensions/extensions-helm/aissemble-quarkus-chart/values.yaml
+++ b/extensions/extensions-helm/aissemble-quarkus-chart/values.yaml
@@ -10,7 +10,7 @@ deployment:
     # Override with specific image
     name: boozallen/aissemble-quarkus
     # Overrides the default chart AppVersion value
-    tag: "@version.aissemble@"
+    tag: ""
     # Default IfNotPresent
     imagePullPolicy: ''
   volumeMounts:

--- a/extensions/extensions-helm/extensions-helm-spark-infrastructure/aissemble-spark-history-chart/templates/deployment.yaml
+++ b/extensions/extensions-helm/extensions-helm-spark-infrastructure/aissemble-spark-history-chart/templates/deployment.yaml
@@ -42,7 +42,7 @@ spec:
       {{- if or (not (empty .Values.dependencies.packages)) (not (empty .Values.dependencies.jars)) }}
       initContainers:
         - name: "populate-jar-volume"
-          image: {{ .Values.deployment.image.repository }}:{{ .Values.deployment.image.tag }}
+          image: "{{ .Values.deployment.image.repository }}:{{ .Values.deployment.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.deployment.image.imagePullPolicy | default "IfNotPresent" }}
           command: ["sh", "-c", "cp /opt/spark/jars/* /tmp/jars/"]
           volumeMounts:
@@ -50,7 +50,7 @@ spec:
               name: shs-jars
         {{- if not (empty .Values.dependencies.packages) }}
         - name: "install-spark-history-packages"
-          image: {{ .Values.deployment.image.repository }}:{{ .Values.deployment.image.tag }}
+          image: "{{ .Values.deployment.image.repository }}:{{ .Values.deployment.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.deployment.image.imagePullPolicy | default "IfNotPresent" }}
           # Uses the Ivy jar packaged with spark to download dependency packages (and their transitive dependencies) to /tmp/jars/...
           # Specifically downloads the binaries-- Does not download supplemental classifiers, ie sources
@@ -61,7 +61,7 @@ spec:
         {{- end }}
         {{- if not (empty .Values.dependencies.jars) }}
         - name: "install-spark-history-jars"
-          image: {{ .Values.deployment.image.repository }}:{{ .Values.deployment.image.tag }}
+          image: "{{ .Values.deployment.image.repository }}:{{ .Values.deployment.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.deployment.image.imagePullPolicy | default "IfNotPresent" }}
           command: ["wget", "-P", "/tmp/jars/", {{ include "deps.jars" . }}]
           volumeMounts:
@@ -71,7 +71,7 @@ spec:
       {{- end }}
       containers:
         - name: {{ .Release.Name }}
-          image: "{{ .Values.deployment.image.repository }}:{{ .Values.deployment.image.tag }}"
+          image: "{{ .Values.deployment.image.repository }}:{{ .Values.deployment.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.deployment.image.imagePullPolicy }}
           command: {{ .Values.deployment.command }}
           env:

--- a/extensions/extensions-helm/extensions-helm-spark-infrastructure/aissemble-spark-history-chart/values.yaml
+++ b/extensions/extensions-helm/extensions-helm-spark-infrastructure/aissemble-spark-history-chart/values.yaml
@@ -12,7 +12,7 @@ deployment:
   image:
     repository: "ghcr.io/boozallen/aissemble-spark"
     imagePullPolicy: IfNotPresent
-    tag: "1.10.0-SNAPSHOT"
+    tag: ""
   command: ["/opt/spark/sbin/start-history-server.sh"]
   env:
     SPARK_NO_DAEMONIZE: "true"

--- a/extensions/extensions-helm/extensions-helm-spark-infrastructure/aissemble-thrift-server-chart/templates/deployment.yaml
+++ b/extensions/extensions-helm/extensions-helm-spark-infrastructure/aissemble-thrift-server-chart/templates/deployment.yaml
@@ -38,7 +38,7 @@ spec:
       {{- if or (not (empty .Values.dependencies.packages)) (not (empty .Values.dependencies.jars)) }}
       initContainers:
         - name: "populate-thrift-service-jar-volume"
-          image: {{ .Values.deployment.image.repository }}:{{ .Values.deployment.image.tag }}
+          image: {{ .Values.deployment.image.repository }}:{{ .Values.deployment.image.tag | default .Chart.AppVersion }}
           imagePullPolicy: {{ .Values.deployment.image.imagePullPolicy | default "IfNotPresent" }}
           command: ["sh", "-c", "cp /opt/spark/jars/* /tmp/jars/"]
           volumeMounts:
@@ -46,7 +46,7 @@ spec:
               name: sts-jars
         {{- if not (empty .Values.dependencies.packages) }}
         - name: "install-thrift-packages"
-          image: {{ .Values.deployment.image.repository }}:{{ .Values.deployment.image.tag }}
+          image: {{ .Values.deployment.image.repository }}:{{ .Values.deployment.image.tag | default .Chart.AppVersion }}
           imagePullPolicy: {{ .Values.deployment.image.imagePullPolicy | default "IfNotPresent" }}
           # Uses the Ivy jar packaged with spark to download dependency packages (and their transitive dependencies) to /tmp/jars/...
           # Specifically downloads the binaries-- Does not download supplemental classifiers, ie sources
@@ -57,7 +57,7 @@ spec:
         {{- end }}
         {{- if not (empty .Values.dependencies.jars) }}
         - name: "install-thrift-jars"
-          image: {{ .Values.deployment.image.repository }}:{{ .Values.deployment.image.tag }}
+          image: {{ .Values.deployment.image.repository }}:{{ .Values.deployment.image.tag | default .Chart.AppVersion}}
           imagePullPolicy: {{ .Values.deployment.image.imagePullPolicy | default "IfNotPresent" }}
           command: ["wget", "-P", "/tmp/jars/", {{ include "deps.jars" . }}]
           volumeMounts:
@@ -67,7 +67,7 @@ spec:
       {{- end }}
       containers:
         - name: {{ .Release.Name }}
-          image: "{{ .Values.deployment.image.repository }}:{{ .Values.deployment.image.tag }}"
+          image: "{{ .Values.deployment.image.repository }}:{{ .Values.deployment.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.deployment.image.imagePullPolicy }}
           command: {{ .Values.deployment.command }}
           lifecycle:

--- a/extensions/extensions-helm/extensions-helm-spark-infrastructure/aissemble-thrift-server-chart/values.yaml
+++ b/extensions/extensions-helm/extensions-helm-spark-infrastructure/aissemble-thrift-server-chart/values.yaml
@@ -13,7 +13,7 @@ deployment:
   image:
     repository: "ghcr.io/boozallen/aissemble-spark"
     imagePullPolicy: IfNotPresent
-    tag: "1.10.0-SNAPSHOT"
+    tag: ""
   command: ["/opt/spark/sbin/start-thriftserver.sh"]
   env:
     SPARK_NO_DAEMONIZE: "true"


### PR DESCRIPTION
We have a pattern where we use the maven replacer plugin and a templatized `values.yaml` file to inject the project version at build time into our charts. This is the only way to provide the aissemble version as the image tag to a subchart. However, in many of the cases we've applied this pattern, the chart or the subchart is actually a custom chart made by us. This means we can simply modify the chart's template files to default the tag to the Chart version, which is set dynamically at build time.  This is greatly preferred as it's much more simple and standard Helm, and it avoids build cache issues. (E.g., if the Quarkus chart is cached, only the templatized values file exists on rebuild causing errors in charts that depend on the Quarkus chart.