### PR TITLE
[#373] fix chart deployment

### DIFF
--- a/extensions/extensions-helm/pom.xml
+++ b/extensions/extensions-helm/pom.xml
@@ -62,7 +62,7 @@
             </properties>
         </profile>
         <profile>
-            <id>release</id>
+            <id>ci</id>
             <properties>
                 <overwrite.dependencies>true</overwrite.dependencies>
             </properties>

--- a/test/test-mda-models/test-data-delivery-spark-model-basic/pom.xml
+++ b/test/test-mda-models/test-data-delivery-spark-model-basic/pom.xml
@@ -136,7 +136,7 @@
             <classifier>tests</classifier>
             <type>test-jar</type>
             <scope>test</scope>
-            <version>${version.aissemble}</version>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <!-- Spark hasn't migrated to Jakarta packages yet. Will need to shade it if we want to fully migrate. -->

--- a/test/test-mda-models/test-data-delivery-spark-model/pom.xml
+++ b/test/test-mda-models/test-data-delivery-spark-model/pom.xml
@@ -144,7 +144,7 @@
             <classifier>tests</classifier>
             <type>test-jar</type>
             <scope>test</scope>
-            <version>${version.aissemble}</version>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <!-- Spark hasn't migrated to Jakarta packages yet. Will need to shade it if we want to fully migrate. -->


### PR DESCRIPTION
Using the `.Chart.AppVersion` for image tags exposed a bug that was introduced when we moved to opensource.  Previously we were overwriting path dependencies in helm charts during the release process via the `release` profile. After open-sourcing our release profile name changed from `release` to `ossrh-release`, but we didn't update it in the `extensions-helm` POM.  However, it was incorrect to only rewrite dependencies during release anyway, as the chart dependencies should be rewritten _any_ time we're deploying (including snapshots). So instead we moved the functionality to the `ci` profile (which is also active during release.)

Also found an issue with release-prepare introduced by #451 preventing the version update process due to unresolved property.