### PR TITLE
#447 Generate aggregated Cucumber report

### DIFF
--- a/cucumber-report-aggregator/pom.xml
+++ b/cucumber-report-aggregator/pom.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.boozallen.aissemble</groupId>
+        <artifactId>aissemble-root</artifactId>
+        <version>1.10.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>cucumber-report-aggregator</artifactId>
+
+    <name>aiSSEMBLE::Cucumber Report Aggregator</name>
+    <description>Consolidates all Cucumber test results across the project modules into an aggregated report for streamlined review of the test coverage.</description>
+
+    <properties>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-resources-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>copy-cucumber-reports</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${project.build.directory}/cucumber-reports-jsons/</outputDirectory>
+                            <resources>
+                                <resource>
+                                    <directory>${project.build.directory}/../../</directory>
+                                    <includes>
+                                        <include>**/cucumber.json</include>
+                                    </includes>
+                                    <filtering>true</filtering>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>net.masterthought</groupId>
+                <artifactId>maven-cucumber-reporting</artifactId>
+                <executions>
+                    <execution>
+                        <id>execution</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>generate</goal>
+                        </goals>
+                        <configuration>
+                            <projectName>aiSSEMBLE</projectName>
+                            <skipEmptyJSONFiles>true</skipEmptyJSONFiles>
+                            <outputDirectory>${project.build.directory}/../target/cucumber-reports</outputDirectory>
+                            <inputDirectory>${project.build.directory}/../target/cucumber-reports-jsons</inputDirectory>
+                            <jsonFiles>
+                                <param>**/cucumber.json</param>
+                            </jsonFiles>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,9 @@
         <module>foundation</module>
         <module>extensions</module>
         <module>test</module>
+        <!--We are relying on the sequential build from Maven; if we ever use parallel builds, we would need to
+         ensure the report aggregator depends on all other modules-->
+        <module>cucumber-report-aggregator</module>
     </modules>
 
     <scm>


### PR DESCRIPTION
#447 Generate aggregated Cucumber report
Replaces the plugin that was used in Jenkins that would aggregate all individual Cucumber reports into one. The focus of this commit will be to generate an aggregated cucumber report of ALL the tests within aiSSEMBLE.