### PR TITLE
[#469] use quotes for display version in Antora docs

### DIFF
--- a/.github/actions/update_antora/action.yaml
+++ b/.github/actions/update_antora/action.yaml
@@ -24,7 +24,7 @@ runs:
       run: |
         sed -i "s/^version: .*/version: ${{ inputs.patch-version }}/" docs/antora.yml
         version=$( ${{ inputs.is-pre-release }} && echo ${{ inputs.version }} || echo ${{ inputs.major-minor-version }} )
-        sed -i "s/^display_version: .*/display_version: $version/" docs/antora.yml
+        sed -i "s/^display_version: .*/display_version: \"$version\"/" docs/antora.yml
         sed -i "s/^prerelease: .*/prerelease: ${{ inputs.is-pre-release }}/" docs/antora.yml
         sed -i "s/^    is-pre-release: .*/    is-pre-release: ${{ inputs.is-pre-release }}/" docs/antora.yml
         find docs/modules/ROOT/attachments/ -type f -exec sed -i 's|${{ inputs.custom-facet-old-version }}|${{ inputs.custom-facet-new-version }}|g' {} +

--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -1,7 +1,7 @@
 name: aissemble
 title: aiSSEMBLE
 version: 1.11.0
-display_version: 1.11.0-SNAPSHOT
+display_version: "1.11.0-SNAPSHOT"
 prerelease: true
 nav:
   - modules/ROOT/nav.adoc


### PR DESCRIPTION
The 1.10 release caused issues with the version display in our technical docs. In `antora.yml` we previously weren't quoting the display value, which in YAML causes type coersion of `1.10` to a floating point number which is in turn truncated to `1.1`.  The `display_version` field is always intended to be a string, so it should always be quoted.

This updates our release job to quote the value when updating it and updates the current `antora.yml` with quotes.