### PR TITLE
#507 revert the 'push cucumber report to GitHub Pages branch' workflow step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -100,12 +100,6 @@ jobs:
       - name: Run Archetype Tests
         run: |
           ./mvnw -B clean install -Parchetype-test -pl :foundation-archetype
-      - name: Publish aggregated Cucumber report
-        uses: peaceiris/actions-gh-pages@v3
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./cucumber-report-aggregator/target/cucumber-reports/cucumber-html-reports
-          destination_dir: test-reports
       - name: Save docker build cache
         id: save-docker-build
         uses: runs-on/cache/save@v4


### PR DESCRIPTION
Based on past experience with the separated branch for handling documentation, we had a lot of confusion so to avoid the same thing happen again, we will remove this `gh-pages` branch and have other ways to publish the cucumber report. This is to revert the change made per [PR](https://github.com/boozallen/aissemble/pull/490/files).