### PR TITLE
#496 Feature: Config Store injected fields should not show up as out of sync in ArgoCD

### DIFF
--- a/foundation/foundation-mda/src/main/resources/templates/deployment/argocd/v2/spark.infrastructure.yaml.vm
+++ b/foundation/foundation-mda/src/main/resources/templates/deployment/argocd/v2/spark.infrastructure.yaml.vm
@@ -6,6 +6,17 @@ metadata:
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:
+  # This is intentional to ignore differences as Mutating Webhook alters values listed below and ArgoCD or any deployment could cause out of sync
+  # because desired and actual manifest differ upon injection of values See: https://argo-cd.readthedocs.io/en/stable/user-guide/diffing/
+  ignoreDifferences:
+    - group: ""
+      kind: ConfigMap
+      jsonPointers:
+        - /data/metastore-site.xml
+    - group: apps
+      kind: StatefulSet
+      jsonPointers:
+        - /spec/template/spec/containers/0/env/2/value
   destination:
     namespace: ${projectName}
     server: {{ .Values.spec.destination.server }}


### PR DESCRIPTION
Issue: https://github.com/boozallen/aissemble/issues/496