### PR TITLE
[#513] remove noRdAdmin profile

### DIFF
--- a/DRAFT_RELEASE_NOTES.md
+++ b/DRAFT_RELEASE_NOTES.md
@@ -18,7 +18,15 @@ _Note: instructions for adapting to these changes are outlined in the upgrade in
 
 
 # Known Issues
-_There are no known issues with the 1.11 release._
+
+## Docker Module Build Failures
+When using a Docker daemon that does not reside in `/var/run` (e.g. running Rancher Desktop without admin privileges) the docker-maven-plugin will fail to build with the message below. To work around this failure, set the `DOCKER_HOST` variable to the location of the daemon socket file. For example, to make the docker-maven-plugin work with Rancher Desktop, run `export DOCKER_HOST=unix://$HOME/.rd/docker.sock`.
+
+```shell
+[ERROR] Failed to execute goal org.technologybrewery.fabric8:docker-maven-plugin:0.45-tb-0.1.0:build (default-build) on project final-513-spark-worker-docker:
+   Execution default-build of goal org.technologybrewery.fabric8:docker-maven-plugin:0.45-tb-0.1.0:build failed: 
+   No <dockerHost> given, no DOCKER_HOST environment variable, no read/writable '/var/run/docker.sock' or '//./pipe/docker_engine' and no external provider like Docker machine configured
+```
 
 # Known Vulnerabilities
 

--- a/README.md
+++ b/README.md
@@ -69,13 +69,9 @@ The following steps will build aiSSEMBLE. *You must follow the configuration gui
 ### Helpful Profiles
 The aiSSEMBLE baseline project provides several build profiles that may be helpful for different development environments.
 To activate each one, use the standard Maven syntax: `./mvnw clean install -P[profile_name]`, for
-instance, `./mvnw clean install -PnoRdAdmin`.  There are many profiles you can find in the root `pom.xml` file. The
+instance, `./mvnw clean install -Pintegration-test`.  There are many profiles you can find in the root `pom.xml` file. The
 following profiles are often useful when first starting with aiSSEMBLE:
 
-* *noRdAdmin*: For configurations that disallow granting administrator privileges to Rancher Desktop. Testing frameworks
-  leveraged by aiSSEMBLE may, at times, assume that the docker unix socket is located at `/var/run/docker.sock`, which is
-  not the case when presented with a non-elevated Rancher installation.  Activating this profile will override the
-  `DOCKER_HOST` seen by these dependencies, pointing it instead at `unix://$HOME/.rd/docker.sock`.
 * *integration-test*: Some integration tests require Docker and automatically start/stop Docker Compose services while
   executing tests (i.e. see the test/test-mda-models/test-data-delivery-pyspark-patterns module). **Note that the Maven
   build does not build the Docker images directly. The images are built within the Kubernetes cluster to speed up

--- a/extensions/extensions-alerting/extensions-alerting-teams/pom.xml
+++ b/extensions/extensions-alerting/extensions-alerting-teams/pom.xml
@@ -121,32 +121,4 @@
             </plugin>
         </plugins>
     </build>
-    <profiles>
-        <profile>
-            <id>noRdAdmin</id>
-            <activation>
-                <property>
-                    <name>BAH_MACHINE</name>
-                </property>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <systemPropertyVariables>
-                                <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
-                                <maven.home>${maven.home}</maven.home>
-                            </systemPropertyVariables>
-                            <environmentVariables>
-                                <DOCKER_HOST>unix://$HOME/.rd/docker.sock</DOCKER_HOST>
-                                <TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE>$HOME/.rd/docker.sock</TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE>
-                            </environmentVariables>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
 </project>

--- a/extensions/extensions-data-lineage/extensions-data-lineage-http-consumer-service/pom.xml
+++ b/extensions/extensions-data-lineage/extensions-data-lineage-http-consumer-service/pom.xml
@@ -136,34 +136,4 @@
             </plugin>
         </plugins>
     </build>
-
-    <profiles>
-        <profile>
-            <id>noRdAdmin</id>
-            <activation>
-                <property>
-                    <name>BAH_MACHINE</name>
-                </property>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <systemPropertyVariables>
-                                <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
-                                <maven.home>${maven.home}</maven.home>
-                            </systemPropertyVariables>
-                            <environmentVariables>
-                                <DOCKER_HOST>unix://$HOME/.rd/docker.sock</DOCKER_HOST>
-                                <TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE>$HOME/.rd/docker.sock
-                                </TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE>
-                            </environmentVariables>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
 </project>

--- a/extensions/extensions-pipeline-invocation-service/pom.xml
+++ b/extensions/extensions-pipeline-invocation-service/pom.xml
@@ -149,34 +149,4 @@
             </plugin>
         </plugins>
     </build>
-
-
-    <profiles>
-        <profile>
-            <id>noRdAdmin</id>
-            <activation>
-                <property>
-                    <name>BAH_MACHINE</name>
-                </property>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <systemPropertyVariables>
-                                <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
-                                <maven.home>${maven.home}</maven.home>
-                            </systemPropertyVariables>
-                            <environmentVariables>
-                                <DOCKER_HOST>unix://$HOME/.rd/docker.sock</DOCKER_HOST>
-                                <TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE>$HOME/.rd/docker.sock</TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE>
-                            </environmentVariables>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
 </project>

--- a/foundation/foundation-drift-detection/aissemble-foundation-drift-detection-client-python/tests/features/environment.py
+++ b/foundation/foundation-drift-detection/aissemble-foundation-drift-detection-client-python/tests/features/environment.py
@@ -38,7 +38,7 @@ def before_all(context):
     )
 
     # call to health check to verify Drift Detection Services are started
-    health_check_url = "http://localhost:8084/q/health/live"
+    health_check_url = "http://localhost:8084/invoke-drift/health-check"
     success = False
     retries = 1
     wait = 0.1

--- a/foundation/foundation-drift-detection/foundation-drift-detection-client-java/pom.xml
+++ b/foundation/foundation-drift-detection/foundation-drift-detection-client-java/pom.xml
@@ -137,7 +137,7 @@
                                     <name>DriftDetectionService</name>
                                     <workingDir>target</workingDir>
                                     <waitForInterrupt>false</waitForInterrupt>
-                                    <healthcheckUrl>http://localhost:8080/q/health/live</healthcheckUrl>
+                                    <healthcheckUrl>http://localhost:8080/invoke-drift/healthcheck</healthcheckUrl>
                                     <arguments>
                                         <argument>java</argument>
                                         <argument>-DKRAUSENING_BASE=${basedir}/src/test/resources/krausening/base</argument>

--- a/foundation/foundation-drift-detection/foundation-drift-detection-service/pom.xml
+++ b/foundation/foundation-drift-detection/foundation-drift-detection-service/pom.xml
@@ -148,31 +148,4 @@
             </plugin>
         </plugins>
     </build>
-    <profiles>
-        <profile>
-            <id>noRdAdmin</id>
-            <activation>
-                <property>
-                    <name>BAH_MACHINE</name>
-                </property>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <systemPropertyVariables>
-                                <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
-                                <maven.home>${maven.home}</maven.home>
-                            </systemPropertyVariables>
-                            <environmentVariables>
-                                <DOCKER_HOST>unix://$HOME/.rd/docker.sock</DOCKER_HOST>
-                                <TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE>$HOME/.rd/docker.sock</TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE>
-                            </environmentVariables>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
 </project>

--- a/foundation/foundation-drift-detection/foundation-drift-detection-service/src/main/java/com/boozallen/drift/detection/service/DriftDetectionService.java
+++ b/foundation/foundation-drift-detection/foundation-drift-detection-service/src/main/java/com/boozallen/drift/detection/service/DriftDetectionService.java
@@ -11,6 +11,7 @@ package com.boozallen.drift.detection.service;
  */
 
 import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
@@ -61,4 +62,10 @@ public class DriftDetectionService {
         return driftDetector.detect(policyIdentifier, input, control);
     }
 
+    @GET
+    @Path("/healthcheck")
+    @Produces({MediaType.TEXT_PLAIN})
+    public String healthCheck() {
+        return "Drift detection service is running...\n";
+    }
 }


### PR DESCRIPTION
The TestContainers now respects the docker context so an explicit profile is no longer needed. Also fixes the healthcheck URL for drift-detection tests so the ITs don't wait the full timeout every time.

Ideally, we would use docker socket detection logic with `file.exists` and `file.missing` profile activations to update the `dockerHost` configuration or `docker.host` property of the docker-maven-plugin as indicated by the build error message when DOCKER_HOST is unset. However, because that plugin creates it's own `config.json` with only auth settings and always passes in `--config` during a buildx build, the builder will always look for the docker socket at /var/run/docker.sock. We will need to update the docker-maven-plugin source code to respect `dockerHost` during this config creation.