### PR TITLE
#497 Feature: Configuration Store should be able to inject into data fields of Secrets

### DIFF
--- a/DRAFT_RELEASE_NOTES.md
+++ b/DRAFT_RELEASE_NOTES.md
@@ -54,7 +54,7 @@ To reduce burden of upgrading aiSSEMBLE, the Baton project is used to automate t
 | docker-module-pom-dependency-type-migration          | Updates the maven pipeline dependency type within your project's sub docker module pom file(`<YOUR_PROJECT>-docker/*-docker/pom.xml`) to fix the build cache checksum calculation issue |
 | enable-maven-docker-build-migration                  | Remove the maven fabric8 plugin `skip` configuration within your project's docker module pom file(`<YOUR_PROJECT>-docker/pom.xml`) to enable the maven docker build                     |
 | spark-worker-docker-image-tag-migration              | Updated the worker docker image tag to use project version                                                                                                                              |
-| spark-infrastructure-universal-config-yaml-migration | Removes the default hive username (if present) from hive-metastore-service values.yaml so that it can be set by the configuration store service                                         |
+| spark-infrastructure-universal-config-yaml-migration | Removes the default hive username and password (if present) from hive-metastore-service values.yaml so that it can be set by the configuration store service                            |
 
 To deactivate any of these migrations, add the following configuration to the `baton-maven-plugin` within your root `pom.xml`:
 

--- a/extensions/extensions-helm/extensions-helm-spark-infrastructure/aissemble-hive-metastore-service-chart/README.md
+++ b/extensions/extensions-helm/extensions-helm-spark-infrastructure/aissemble-hive-metastore-service-chart/README.md
@@ -45,11 +45,17 @@ helm install hive-metastore-service oci://ghcr.io/boozallen/aissemble-hive-metas
 See [the official bitnami documentation](https://github.com/bitnami/charts/tree/main/bitnami/mysql) for full
 configuration options.
 
-| Property         | Default             |
-|------------------|---------------------|
-| fullnameOverride | "hive-metastore-db" |
-| auth.database    | "metastore"         |
-| auth.username    | "hive"              |
+| Property         | Default                                                                            |
+|------------------|------------------------------------------------------------------------------------|
+| fullnameOverride | "hive-metastore-db"                                                                |
+| auth.database    | "metastore"                                                                        |
+| auth.username    | $getConfigValue(groupName=spark-infrastructure;propertyName=metastore.db.username) |
+| auth.password    | $getConfigValue(groupName=spark-infrastructure;propertyName=metastore.db.password) |
+
+**Note**: 
+By Default, username and passwords are being injected from [Universal Configuration Store](https://boozallen.github.io/aissemble/aissemble/current/configuration-store.html).
+Configuration Store will look for $getConfigValue(...) and find properties file to inject values from corresponding groupName and propertyName.
+
 
 # Migration from aiSSEMBLE v1 Helm Charts
 

--- a/extensions/extensions-helm/extensions-helm-spark-infrastructure/aissemble-hive-metastore-service-chart/values.yaml
+++ b/extensions/extensions-helm/extensions-helm-spark-infrastructure/aissemble-hive-metastore-service-chart/values.yaml
@@ -25,6 +25,7 @@ mysql:
     # Note: Changing these values requires removal of the `hive-metastore-db-0` PVC, or manual modification of the
     # persisted database.
     username: $getConfigValue(groupName=spark-infrastructure;propertyName=metastore.db.username)
+    password: $getConfigValue(groupName=spark-infrastructure;propertyName=metastore.db.password)
 
 hive:
   dbType: "mysql"

--- a/foundation/foundation-configuration-store/pom.xml
+++ b/foundation/foundation-configuration-store/pom.xml
@@ -165,6 +165,11 @@
             <artifactId>jakarta.ws.rs-api</artifactId>
             <version>${version.jakarta.wr.rs}</version>
         </dependency>
+        <dependency>
+            <groupId>com.tdunning</groupId>
+            <artifactId>json</artifactId>
+            <version>1.8</version>
+        </dependency>
 
         <!-- quarkus dependencies -->
         <dependency>

--- a/foundation/foundation-configuration-store/src/main/java/com/boozallen/aissemble/configuration/mutating/webhook/ConfigMutatingWebhook.java
+++ b/foundation/foundation-configuration-store/src/main/java/com/boozallen/aissemble/configuration/mutating/webhook/ConfigMutatingWebhook.java
@@ -9,17 +9,20 @@ package com.boozallen.aissemble.configuration.mutating.webhook;
  * This software package is licensed under the Booz Allen Public License. All Rights Reserved.
  * #L%
  */
- 
+
 import com.boozallen.aissemble.configuration.store.ConfigLoader;
 import com.boozallen.aissemble.configuration.store.Property;
 import com.boozallen.aissemble.configuration.store.PropertyKey;
 import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.json.JsonReadFeature;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.flipkart.zjsonpatch.JsonDiff;
 import io.fabric8.kubernetes.api.model.StatusBuilder;
 import org.apache.commons.lang3.StringUtils;
+import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -36,6 +39,7 @@ import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.core.MediaType;
+
 import java.util.Base64;
 import java.util.HashMap;
 import java.util.Map;
@@ -58,7 +62,7 @@ public class ConfigMutatingWebhook {
 
     @Inject
     public ConfigLoader configLoader;
-    
+
     @POST
     @Path("/process")
     @Consumes(MediaType.APPLICATION_JSON)
@@ -83,9 +87,18 @@ public class ConfigMutatingWebhook {
         AdmissionResponse response;
         try {
             String json = mapper.writeValueAsString(request.getObject());
+
+            //This scans to see if there's any config need to be injected and replace corresponding values and saves into updatedJson
             String updatedJson = replaceConfigStoreKeysWithConfigValue(json);
 
-            if (!updatedJson.isEmpty()) {
+            if(request.getKind().getKind().equals("Secret")) {
+                //if replaceConfigStoreKeysWithConfigValue doesn't have any injection it would return empty, so we need original json to scan.
+                String secretJson = updatedJson.isEmpty() ? json: updatedJson;
+                boolean plainTextInjectionUpdated = !updatedJson.isEmpty();
+                updatedJson = replaceSecretConfigStoreKeyWithConfigValue(secretJson, mapper, plainTextInjectionUpdated);
+            }
+
+            if (!updatedJson.isEmpty()){
                 JsonNode patch = JsonDiff.asJson(mapper.readTree(json), mapper.readTree(updatedJson));
                 response = new AdmissionResponseBuilder()
                         .withAllowed(true)
@@ -94,7 +107,7 @@ public class ConfigMutatingWebhook {
                         .withPatchType("JSONPatch")
                         .build();
                 logger.info("The kubernetes resource request has been updated.");
-            } else {
+            }else {
                 response = new AdmissionResponseBuilder()
                         .withAllowed(true)
                         .withUid(request.getUid())
@@ -129,9 +142,58 @@ public class ConfigMutatingWebhook {
         }
     }
 
+
+    /**
+     * This method is to inject values in the data fields for any encoded Configvalues from the properties file and save it as based64 encoded.
+     *
+     * @param json json string to scan
+     * @param mapper json object mapper
+     * @param plainTextInjectionUpdated boolean that plain text injection is updated.
+     * @return updatedJSON  If no injection, return empty.
+     */
+    private String replaceSecretConfigStoreKeyWithConfigValue(String json, ObjectMapper mapper, boolean plainTextInjectionUpdated) throws JsonProcessingException {
+        String updatedJSON = json;
+        JSONObject jsonObject = new JSONObject(json);
+        //If there's no data key, no injection can be done.
+        if(!jsonObject.has("data")) {
+            return plainTextInjectionUpdated ? json : "";
+        }
+        String dataString = jsonObject.getString("data");
+        Map<String, String> secretDataMap = mapper.readValue(dataString, new TypeReference<>() {});
+
+        //key being base64 val that has getConfigValue value being actual value to inject from property.
+        Map<String, String> injectionMap = new HashMap<>();
+
+        for(String secretDataVal : secretDataMap.values()) {
+            String decodedStr = new String(Base64.getDecoder().decode(secretDataVal));
+
+            if(decodedStr.startsWith(CONFIG_STORE_INJECT_START)) {
+                //trim out unnecessary strings
+                String[] injectionKeyValuePair = decodedStr.substring(CONFIG_STORE_INJECT_START.length(),decodedStr.length()-1).split(PROPERTY_KEY_DELIMITER);
+                Map<String, String> injectionKeyValueMap = convertToKeyMap(injectionKeyValuePair);
+                String propertyValue = getProperty(injectionKeyValueMap.get(GROUP_NAME), injectionKeyValueMap.get(PROPERTY_NAME));
+                injectionMap.put(secretDataVal, new String(Base64.getEncoder().encode(propertyValue.getBytes())));
+            }
+        }
+
+        for(Map.Entry<String, String> injection: injectionMap.entrySet()) {
+            updatedJSON = updatedJSON.replace(injection.getKey(), injection.getValue());
+        }
+
+        //We still need to carry out plain text injection differences.
+        if(plainTextInjectionUpdated) {
+            return updatedJSON.equals(json) ? json : updatedJSON;
+        }
+
+        //If there is no change in injection in both secret and plain text, return empty. If there are any change, return updated JSON.
+        return updatedJSON.equals(json) ? "" : updatedJSON;
+
+    }
+
     private String replaceConfigStoreKeysWithConfigValue(String json) {
         StringBuilder updatedJson = new StringBuilder();
         String[] data = json.split(Pattern.quote(CONFIG_STORE_INJECT_START));
+
         // if the config store key is found
         if (data.length > 1) {
             updatedJson.append(data[0]);
@@ -161,5 +223,4 @@ public class ConfigMutatingWebhook {
 
         return map;
     }
- }
- 
+}

--- a/foundation/foundation-configuration-store/src/test/java/com/boozallen/aissemble/configuration/mutating/webhook/MutatingWebhookSteps.java
+++ b/foundation/foundation-configuration-store/src/test/java/com/boozallen/aissemble/configuration/mutating/webhook/MutatingWebhookSteps.java
@@ -23,7 +23,10 @@ import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
 import io.fabric8.kubernetes.api.model.GroupVersionKind;
 import io.fabric8.kubernetes.api.model.GroupVersionResource;
+import io.fabric8.kubernetes.api.model.KubernetesResource;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.api.model.Secret;
+import io.fabric8.kubernetes.api.model.SecretBuilder;
 import io.fabric8.kubernetes.api.model.admission.v1.AdmissionRequest;
 import io.fabric8.kubernetes.api.model.admission.v1.AdmissionReview;
 import io.fabric8.kubernetes.api.model.admission.v1.AdmissionReviewBuilder;
@@ -35,38 +38,79 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.Base64;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.List;
 
 public class MutatingWebhookSteps {
     private static final String expectedInjectedValue = "env-access-key-id";
+    private static final String expectedInjectedSecretValue = "env-pass";
     private final ObjectMapper objectMapper = new ObjectMapper();
     private ValidatableResponse response;
     private AdmissionReview admissionReviewRequest;
     private ConfigMap configMap;
+    private Secret secret;
+    private ObjectMeta objectMeta;
     private Map<String, String > configMapData;
+    private Map<String, String> secretData;
     private String responsePatch;
+
 
     @Given("a ConfigMap definition that contains the substitution key exists")
     public void aConfigMapDefinitionThatContainsTheSubstituionKeyExists() {
         final String propertyKey = "groupName=aws-credentials;propertyName=AWS_ACCESS_KEY_ID";
+        objectMeta = new ObjectMeta();
+        HashMap<String, String> metaLabels = new HashMap();
+        metaLabels.put("aissemble-configuration-store", "enabled");
+        objectMeta.setLabels(metaLabels);
         configMapData = new HashMap<>();
         configMapData.put("AWS_ACCESS_KEY_ID", ConfigMutatingWebhook.CONFIG_STORE_INJECT_START + propertyKey + ConfigMutatingWebhook.CONFIG_STORE_INJECT_END);
     }
 
-    @Given("the ConfigMap definition has the injection metadata label")
-    public void theConfigMapDefinitionHasTheInjectionMetatdataLabel() {
+    @Given("a Secret definition that contains the encoded substitution key exists")
+    public void aSecretDefinitionThatContainsTheEncodedSubstituionKeyExists() {
+        final String testPasswordValue = ConfigMutatingWebhook.CONFIG_STORE_INJECT_START + "groupName=aws-credentials;propertyName=AWS_PASSWORD" + ConfigMutatingWebhook.CONFIG_STORE_INJECT_END;
+        objectMeta = new ObjectMeta();
         HashMap<String, String> metaLabels = new HashMap();
         metaLabels.put("aissemble-configuration-store", "enabled");
-        ObjectMeta objectMeta = new ObjectMeta();
         objectMeta.setLabels(metaLabels);
+
+        secretData = new HashMap<>();
+        secretData.put("AWS_PASSWORD", new String(org.apache.commons.codec.binary.Base64.encodeBase64(testPasswordValue.getBytes())));
+    }
+
+    @Given("a Secret definition that contains the encoded and plain text substitution key exists")
+    public void aSecretDefinitionThatContainsTheEncodedAndPlainTextSubstituionKeyExists() {
+        final String testPasswordValue = ConfigMutatingWebhook.CONFIG_STORE_INJECT_START + "groupName=aws-credentials;propertyName=AWS_PASSWORD" + ConfigMutatingWebhook.CONFIG_STORE_INJECT_END;
+        final String propertyKey = "groupName=aws-credentials;propertyName=AWS_ACCESS_KEY_ID";
+
+        objectMeta = new ObjectMeta();
+        HashMap<String, String> metaLabels = new HashMap();
+        metaLabels.put("aissemble-configuration-store", "enabled");
+        metaLabels.put("TEST_META",  ConfigMutatingWebhook.CONFIG_STORE_INJECT_START + propertyKey + ConfigMutatingWebhook.CONFIG_STORE_INJECT_END);
+        objectMeta.setLabels(metaLabels);
+
+        secretData = new HashMap<>();
+        secretData.put("AWS_PASSWORD", new String(org.apache.commons.codec.binary.Base64.encodeBase64(testPasswordValue.getBytes())));
+    }
+
+    @Given("the ConfigMap definition has the injection metadata label")
+    public void theConfigMapDefinitionHasTheInjectionMetatdataLabel() {
         configMap = new ConfigMapBuilder()
                 .withData(configMapData)
                 .withMetadata(objectMeta)
                 .build();
     }
 
+    @Given("the Secret definition has the injection metadata label")
+    public void theSecretDefinitionHasTheInjectionMetatdataLabel() {
+        secret = new SecretBuilder()
+                .withData(secretData)
+                .withMetadata(objectMeta)
+                .build();
+    }
+
     @When("a kubernetes resource request is made to create a ConfigMap")
     public void aKubernetesResourceRequestIsMade() throws JsonProcessingException {
-        this.admissionReviewRequest = createAdmissionReviewRequest();
+        this.admissionReviewRequest = createAdmissionReviewRequest("ConfigMap", "configmaps", configMap);
 
         // Convert AdmissionReview object to JSON
         String admissionReviewRequestJson = this.objectMapper.writeValueAsString(admissionReviewRequest);
@@ -79,7 +123,22 @@ public class MutatingWebhookSteps {
                 .then();
     }
 
-    @Then("the ConfigMap patch is returned")
+    @When("a kubernetes resource request is made to create a Secret")
+    public void aKubernetesResourceRequestIsMadeForSecret() throws JsonProcessingException {
+        this.admissionReviewRequest = createAdmissionReviewRequest("Secret", "secret", secret);
+
+        // Convert AdmissionReview object to JSON
+        String admissionReviewRequestJson = this.objectMapper.writeValueAsString(admissionReviewRequest);
+
+        response = given()
+                .contentType("application/json")
+                .body(admissionReviewRequestJson)
+                .when()
+                .post("/webhook/process")
+                .then();
+    }
+
+    @Then("the patch is returned")
     public void theProcessedKubernetesResourceIsReturned() throws JsonProcessingException {
         response.statusCode(200);
 
@@ -98,19 +157,37 @@ public class MutatingWebhookSteps {
         JsonNode jsonPatch = objectMapper.readTree(new String(Base64.getDecoder().decode(responsePatch)));
         assertEquals("The response patch does not contain the injected value", expectedInjectedValue, jsonPatch.findValue("value").asText());
     }
+
+    @Then("the Secret patch contains the encoded injected value")
+    public void theSecretDefinitionContainsTheInjectedValue() throws JsonProcessingException {
+        JsonNode jsonPatch = objectMapper.readTree(new String(Base64.getDecoder().decode(responsePatch)));
+        String encodedInjectedSecretValue = new String(Base64.getEncoder().encode(expectedInjectedSecretValue.getBytes()));
+        List<String> valuesList = jsonPatch.findValues("value").stream().map(JsonNode::asText).toList();
+        assertTrue("The response patch does not contain the injected value", valuesList.contains(encodedInjectedSecretValue));
+    }
+
+    @Then("the Secret patch contains the both plain text and encoded injected value")
+    public void theSecretDefinitionContainsPlainAndEncodedTheInjectedValue() throws JsonProcessingException {
+        JsonNode jsonPatch = objectMapper.readTree(new String(Base64.getDecoder().decode(responsePatch)));
+        String encodedInjectedSecretValue = new String(Base64.getEncoder().encode(expectedInjectedSecretValue.getBytes()));
+        List<String> valuesList = jsonPatch.findValues("value").stream().map(JsonNode::asText).toList();
+        assertTrue("The response patch does not contain the injected value", valuesList.contains(encodedInjectedSecretValue));
+        assertTrue("The response patch does not contain the injected value", valuesList.contains(expectedInjectedValue));
+    }
+
     /**
      * Create an {@link AdmissionReviewRequest} for testing
      */
-    private AdmissionReview createAdmissionReviewRequest() {
+    private AdmissionReview createAdmissionReviewRequest(String kind, String resource, KubernetesResource resourceObj) {
         AdmissionRequest request = new AdmissionRequest();
         request.setUid("example-uid");
-        request.setKind(new GroupVersionKind("", "ConfigMap", "v1"));
-        request.setResource(new GroupVersionResource("", "configmaps", "v1"));
+        request.setKind(new GroupVersionKind("", kind, "v1"));
+        request.setResource(new GroupVersionResource("", resource, "v1"));
         request.setName("example-pod");
         request.setNamespace("default");
 
         // Set the pod on the request
-        request.setObject(configMap);
+        request.setObject(resourceObj);
 
         // Create AdmissionReview with the request
         return new AdmissionReviewBuilder()

--- a/foundation/foundation-configuration-store/src/test/java/com/boozallen/aissemble/configuration/store/LoadConfigurationsSteps.java
+++ b/foundation/foundation-configuration-store/src/test/java/com/boozallen/aissemble/configuration/store/LoadConfigurationsSteps.java
@@ -162,7 +162,7 @@ public class LoadConfigurationsSteps {
  
     @Then("augments the base with the environment properties")
     public void augmentsTheBaseWithTheEnvironmentConfigurations() {
-        assertEquals(13, TestPropertyDao.loadedProperties.size());
+        assertEquals(14, TestPropertyDao.loadedProperties.size());
         assertPropertySetsEqual(createExpectedProperties(), new HashSet<>(TestPropertyDao.loadedProperties.values()));
     }
 

--- a/foundation/foundation-configuration-store/src/test/resources/configurations/base/aws-credentials.properties
+++ b/foundation/foundation-configuration-store/src/test/resources/configurations/base/aws-credentials.properties
@@ -8,5 +8,6 @@
 # #L%
 ###
 AWS_ACCESS_KEY_ID=base-access-key-id
+AWS_PASSWORD=env-pass
 # This is a test only value and holds no significance
 AWS_SECRET_ACCESS_KEY=ENC(Hs0eE3pKIxqntLXVuqgBJE9e9uFy29W8bMDocqbiakbFPhQf6Xp5oAL1Z6m6tdd3i0sEREN2pX2chS4q6KxiIw==)

--- a/foundation/foundation-configuration-store/src/test/resources/specifications/mutating-webhook.feature
+++ b/foundation/foundation-configuration-store/src/test/resources/specifications/mutating-webhook.feature
@@ -6,5 +6,22 @@ Feature: Modify kubernetes resources with config values using a mutating webhook
       And a ConfigMap definition that contains the substitution key exists
       And the ConfigMap definition has the injection metadata label
      When a kubernetes resource request is made to create a ConfigMap
-     Then the ConfigMap patch is returned
+     Then the patch is returned
       And the ConfigMap patch contains the injected value
+
+  Scenario: The configuration service can inject encoded values to newly created Secret
+    Given the configuration service has started
+    And a Secret definition that contains the encoded substitution key exists
+    And the Secret definition has the injection metadata label
+    When a kubernetes resource request is made to create a Secret
+    Then the patch is returned
+    And the Secret patch contains the encoded injected value
+
+
+  Scenario: The configuration service can inject both plain text and encoded values to newly created Secret
+    Given the configuration service has started
+    And a Secret definition that contains the encoded and plain text substitution key exists
+    And the Secret definition has the injection metadata label
+    When a kubernetes resource request is made to create a Secret
+    Then the patch is returned
+    And the Secret patch contains the both plain text and encoded injected value

--- a/foundation/foundation-mda/src/main/resources/templates/deployment/spark-infrastructure/configurations/base/spark-infrastructure.properties.vm
+++ b/foundation/foundation-mda/src/main/resources/templates/deployment/spark-infrastructure/configurations/base/spark-infrastructure.properties.vm
@@ -2,3 +2,4 @@
 # Password and other sensitive information should be encrypted using krausening
 # (See Here: https://github.com/TechnologyBrewery/krausening/tree/dev/krausening/#krausening-in-four-pints-leveraging-jasypt-for-encryptingdecrypting-properties)
 metastore.db.username=hive
+metastore.db.password=hive

--- a/foundation/foundation-mda/src/main/resources/templates/deployment/spark-infrastructure/v2/spark.infrastructure.values.yaml.vm
+++ b/foundation/foundation-mda/src/main/resources/templates/deployment/spark-infrastructure/v2/spark.infrastructure.values.yaml.vm
@@ -52,7 +52,6 @@ aissemble-hive-metastore-service-chart:
       # persisted database.
       rootPassword: hive
       replicationPassword: hive
-      password: hive
 
   deployment:
     env:


### PR DESCRIPTION
Any value in the data field of a Kubernetes Secret are required to be base64 encoded. This means the standard injection string of $getConfig(group, property) must be base64 encoded before being submitted to a cluster. The Config Store injection service should recognize when a Secret is being processed and decode its data values to ensure full injection.