### PR TITLE
[#525] update libraries on Spark images

### DIFF
--- a/DRAFT_RELEASE_NOTES.md
+++ b/DRAFT_RELEASE_NOTES.md
@@ -9,6 +9,9 @@ To better align development processes with processes in CI/CD and higher environ
 ## Data Access Upgrade
 Data access through [GraphQL](https://graphql.org/) has been deprecated and replaced with [Trino](https://trino.io/). Trino is optimized for performing queries against large datasets by leveraging a distributed architecture that processes queries in parallel, enabling fast and scalable data retrieval.
 
+## Spark Upgrade
+Spark and PySpark have been upgraded from version 3.5.2 to 3.5.4.
+
 # Breaking Changes
 _Note: instructions for adapting to these changes are outlined in the upgrade instructions below._
 

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -79,7 +79,7 @@
         <version.javax.servlet>3.1.0</version.javax.servlet>
 
         <!-- Spark Default Dependencies.  See `spark-*` profiles below for alternative sets -->
-        <version.spark>3.5.2</version.spark>
+        <version.spark>3.5.4</version.spark>
         <version.scala>2.12.20</version.scala>
         <version.scala.minor>2.12</version.scala.minor>
         <version.delta>3.2.1</version.delta>
@@ -1038,33 +1038,6 @@ To suppress enforce-helm-version rule, you must add following plugin to the root
                                 <addPypiRepoAsPackageSources>false</addPypiRepoAsPackageSources>
                                 <useDevRepository>true</useDevRepository>
                             </configuration>
-                        </plugin>
-                        <plugin>
-                            <groupId>${group.fabric8.plugin}</groupId>
-                            <artifactId>docker-maven-plugin</artifactId>
-                            <version>${version.fabric8.docker.maven.plugin}</version>
-                            <executions>
-                                <execution>
-                                    <id>default-build</id>
-                                    <phase>package</phase>
-                                    <goals>
-                                        <goal>build</goal>
-                                    </goals>
-                                    <configuration>
-                                        <!-- Deploy will build all platforms, so skip build phase in this case: -->
-                                        <buildArchiveOnly>true</buildArchiveOnly>
-                                        <images>
-                                            <image>
-                                                <build>
-                                                    <buildx>
-                                                        <builderName>maven</builderName>
-                                                    </buildx>
-                                                </build>
-                                            </image>
-                                        </images>
-                                    </configuration>
-                                </execution>
-                            </executions>
                         </plugin>
                     </plugins>
                 </pluginManagement>

--- a/build-support/aissemble-enforcer-extension/src/main/java/com/boozallen/aissemble/maven/enforcer/helper/HelmVersionHelper.java
+++ b/build-support/aissemble-enforcer-extension/src/main/java/com/boozallen/aissemble/maven/enforcer/helper/HelmVersionHelper.java
@@ -31,7 +31,7 @@ public class HelmVersionHelper {
     private static final Logger logger = LoggerFactory.getLogger(HelmVersionHelper.class);
 
     private static final String HELM_COMMAND = "helm";
-    private static final String EXTRACT_VERSION_REGEX = "\"v((\\d\\.?)+)\"";
+    private static final String EXTRACT_VERSION_REGEX = "Version:\"v(.*?)\"";
 
     private final File workingDirectory;
 

--- a/extensions/extensions-data-delivery/aissemble-extensions-data-delivery-spark-py/pyproject.toml
+++ b/extensions/extensions-data-delivery/aissemble-extensions-data-delivery-spark-py/pyproject.toml
@@ -11,7 +11,7 @@ packages = [
 [tool.poetry.dependencies]
 python = ">=3.8"
 krausening = ">=20"
-pyspark = "3.5.2"
+pyspark = "3.5.4"
 pyyaml = "^6.0"
 
 [tool.poetry.group.dev.dependencies]

--- a/extensions/extensions-docker/aissemble-spark-infrastructure/pom.xml
+++ b/extensions/extensions-docker/aissemble-spark-infrastructure/pom.xml
@@ -24,7 +24,7 @@
             <groupId>com.boozallen.aissemble</groupId>
             <artifactId>aissemble-spark</artifactId>
             <version>${project.version}</version>
-            <type>pom</type>
+            <type>docker-build</type>
         </dependency>
         <dependency>
             <groupId>org.apache.hadoop</groupId>
@@ -70,6 +70,64 @@
                         </image>
                     </images>
                 </configuration>
+                <executions>
+                    <execution>
+                        <id>test-image</id>
+                        <phase>integration-test</phase>
+                        <goals>
+                            <goal>start</goal>
+                        </goals>
+                        <configuration>
+                            <showLogs>true</showLogs>
+                            <images>
+                                <image>
+                                    <run>
+                                        <containerNamePattern>${project.artifactId}-test</containerNamePattern>
+                                        <!-- If autoRemove is true and wait is specified, the build will fail. See https://github.com/fabric8io/docker-maven-plugin/issues/1622 -->
+                                        <autoRemove>false</autoRemove>
+                                        <entrypoint>sh -c /tmp/test/image-test.sh</entrypoint>
+                                        <wait>
+                                            <time>60000</time>
+                                            <http>
+                                                <!-- History server check -->
+                                                <url>http://localhost:18080</url>
+                                            </http>
+                                            <!-- Thrift server check -->
+                                            <log>.*HiveThriftServer2 started.*</log>
+                                        </wait>
+                                        <volumes>
+                                            <bind>
+                                                <volume>${project.basedir}/src/test/resources:/tmp/test</volume>
+                                            </bind>
+                                        </volumes>
+                                    </run>
+                                </image>
+                            </images>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>test-image-cleanup</id>
+                        <phase>post-integration-test</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <executable>docker</executable>
+                            <arguments>
+                                <argument>rm</argument>
+                                <argument>-f</argument>
+                                <argument>${project.artifactId}-test</argument>
+                                <argument>hive-metastore-db</argument>
+                            </arguments>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/extensions/extensions-docker/aissemble-spark-infrastructure/src/test/resources/image-test.sh
+++ b/extensions/extensions-docker/aissemble-spark-infrastructure/src/test/resources/image-test.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+###
+# #%L
+# aiSSEMBLE::Extensions::Docker::Spark Infrastructure
+# %%
+# Copyright (C) 2021 Booz Allen
+# %%
+# This software package is licensed under the Booz Allen Public License. All Rights Reserved.
+# #L%
+###
+
+#Create events dir that's usually mounted at runtime
+mkdir /tmp/spark-events
+$SPARK_HOME/sbin/start-history-server.sh &
+
+#Switch to Embedded Derby DB for Thrift Server test
+sed -i 's/jdbc:mysql:\/\/hive-metastore-db:3306\/metastore?createDatabaseIfNotExist=true&amp;allowPublicKeyRetrieval=true&amp;useSSL=false/jdbc:derby:\/tmp\/metastore;create=true/' $SPARK_HOME/conf/hive-site.xml
+sed -i 's/com.mysql.cj.jdbc.Driver/org.apache.derby.jdbc.EmbeddedDriver/' $SPARK_HOME/conf/hive-site.xml
+$SPARK_HOME/sbin/start-thriftserver.sh

--- a/extensions/extensions-docker/aissemble-spark-operator/pom.xml
+++ b/extensions/extensions-docker/aissemble-spark-operator/pom.xml
@@ -67,7 +67,7 @@
             <groupId>com.boozallen.aissemble</groupId>
             <artifactId>aissemble-spark</artifactId>
             <version>${project.version}</version>
-            <type>pom</type>
+            <type>docker-build</type>
         </dependency>
     </dependencies>
 </project>

--- a/extensions/extensions-docker/aissemble-spark-operator/src/main/resources/docker/Dockerfile
+++ b/extensions/extensions-docker/aissemble-spark-operator/src/main/resources/docker/Dockerfile
@@ -18,7 +18,7 @@ ARG VERSION_AISSEMBLE
 
 FROM docker.io/kubeflow/spark-operator:v1beta2-1.6.2-3.5.0 AS builder
 
-# We would be able to use the kubeflow image directly, except that it is on Spark 3.5 instead of 3.4
+# Use our image as a base to ensure Spark version alignment and take advantage of image hardening
 FROM ${DOCKER_BASELINE_REPO_ID}boozallen/aissemble-spark:${VERSION_AISSEMBLE}
 
 LABEL org.opencontainers.image.source="https://github.com/boozallen/aissemble"

--- a/extensions/extensions-docker/aissemble-spark/pom.xml
+++ b/extensions/extensions-docker/aissemble-spark/pom.xml
@@ -64,6 +64,49 @@
             <plugin>
                 <groupId>${group.fabric8.plugin}</groupId>
                 <artifactId>docker-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>test-image</id>
+                        <phase>integration-test</phase>
+                        <goals>
+                            <goal>start</goal>
+                        </goals>
+                        <configuration>
+                            <showLogs>true</showLogs>
+                            <images>
+                                <image>
+                                    <run>
+                                        <containerNamePattern>${project.artifactId}-test</containerNamePattern>
+                                        <!-- If autoRemove is true, the build will fail. See https://github.com/fabric8io/docker-maven-plugin/issues/1622 -->
+                                        <autoRemove>false</autoRemove>
+                                        <cmd>/opt/spark/bin/spark-submit /opt/spark/examples/src/main/python/pi.py</cmd>
+                                        <wait>
+                                            <time>60000</time>
+                                            <exit>0</exit>
+                                        </wait>
+                                    </run>
+                                </image>
+                            </images>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>test-image-cleanup</id>
+                        <phase>post-integration-test</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <executable>docker</executable>
+                            <commandlineArgs>rm ${project.artifactId}-test</commandlineArgs>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/extensions/extensions-docker/aissemble-spark/src/main/resources/docker/Dockerfile
+++ b/extensions/extensions-docker/aissemble-spark/src/main/resources/docker/Dockerfile
@@ -4,13 +4,16 @@ ARG SPARK_VERSION
 ARG SCALA_VERSION
 FROM docker.io/apache/spark:${SPARK_VERSION}-scala${SCALA_VERSION}-java17-python3-ubuntu
 
+#pull var from global scope to build stage
+ARG SPARK_VERSION
+ARG PYTHON_VERSION=3.11
+
 LABEL org.opencontainers.image.source="https://github.com/boozallen/aissemble"
 
 USER root
 
-# Configures the desired version of Python to install
-ARG PYTHON_VERSION=3.11
 # Setup Spark home directory
+RUN usermod -d /opt/spark spark
 RUN mkdir $SPARK_HOME/checkpoint && \
   mkdir $SPARK_HOME/krausening && \
   mkdir $SPARK_HOME/warehouse && \
@@ -28,21 +31,29 @@ RUN apt-get update -y && apt-get install --assume-yes \
   curl \
   python${PYTHON_VERSION} \
   python${PYTHON_VERSION}-dev \
-#TODO is distutils needed?
   python${PYTHON_VERSION}-distutils \
-#Patch for CVE-2023-4863: upgrade libwebp7 to latest
+#Patch for CVE-2023-4863: upgrade libwebp7 to 1.3.2+
   && apt-get upgrade -y libwebp7 \
   && rm -rf /var/lib/apt/lists/* \
   && apt-get clean \
-  && ln -s /usr/bin/python${PYTHON_VERSION} /usr/bin/python
+  && ln -s /usr/bin/python${PYTHON_VERSION} /usr/bin/python \
+#Patch for CVE-2023-0286: upgrade cryptography to 39.0.1+ (https://github.com/advisories/GHSA-x4qr-2fvf-3mr5)
+  && python -m pip install --upgrade cryptography
 
 # Pyspark uses `python3` to execute pyspark pipelines. This links out latest python install to that command.
 RUN ln -sf /usr/bin/python3.11 /usr/bin/python3
 
+# Update gosu (based on https://github.com/tianon/gosu/blob/master/INSTALL.md)
+# Fixes: GO-2023-2185, GO-2023-1840, GO-2023-1568
+COPY --from=docker.io/tianon/gosu:1.17-debian /gosu /usr/sbin/gosu
+
+# Update library jars used by Spark and register PySpark as an available python package
+COPY --chmod=755 ./src/main/resources/scripts/setup.sh $SPARK_HOME/setup.sh
+RUN $SPARK_HOME/setup.sh $SPARK_HOME $SPARK_VERSION
+
 ## Add spark configurations
 COPY ./src/main/resources/conf/ $SPARK_HOME/conf/
-
-RUN chown -R spark:spark $SPARK_HOME/conf/
+RUN chown -R spark:spark $SPARK_HOME
 
 # Fixed the Reflection API breaks java module boundary issue for Java 16+
 ENV JDK_JAVA_OPTIONS='--add-opens java.base/java.lang=ALL-UNNAMED'

--- a/extensions/extensions-docker/aissemble-spark/src/main/resources/scripts/setup.sh
+++ b/extensions/extensions-docker/aissemble-spark/src/main/resources/scripts/setup.sh
@@ -1,0 +1,132 @@
+#!/bin/sh
+###
+# #%L
+# aiSSEMBLE::Extensions::Docker::Spark
+# %%
+# Copyright (C) 2021 Booz Allen
+# %%
+# This software package is licensed under the Booz Allen Public License. All Rights Reserved.
+# #L%
+###
+
+#---
+## Updates a Spark's JARs based on a list of Maven coordinates
+##
+## @Arguments: list of maven coordinates in `group:artifact:version:classifier` format where `:classifier` is optional
+#---
+update_maven_jars() {
+  echo
+  echo "Updating jars in $SPARK_JARS ($SPARK_VERSION)"
+  echo
+  mvnjars="$1"
+
+  mkdir /tmp/jars || exit $?
+  for gav in $mvnjars; do
+    #Parse GAV into separate variables, classifier may or may not be present as the last item
+    group=$(echo "$gav" | cut -d : -f 1)
+    artifact=$(echo "$gav" | cut -d : -f 2)
+    version=$(echo "$gav" | cut -d : -f 3)
+    classifier=$(echo "$gav" | cut -d : -f 4)
+    if [ -n "$classifier" ]; then
+      classifier="-$classifier"
+    fi
+    echo "-------------------------------------------"
+    echo "Replacing $group:$artifact with updated JAR"
+
+    # Fetch the updated JAR from Maven Central
+    jar="$artifact-$version$classifier.jar"
+    path=$(echo "$group" | sed 's|\.|/|g')
+    url="https://repo1.maven.org/maven2/$path/$artifact/$version/$jar"
+    echo "Fetching $url"
+    wget -q "$url" -P /tmp/jars || exit $?
+
+    # Find the old jar that is being replaced
+    replaceable=$(find / -type f -regex "$SPARK_JARS/$artifact-[^-]*$classifier.jar" 2>/dev/null)
+    echo "Replacing '$replaceable'"
+    count=$(echo "$replaceable" | wc -w )
+    if [  "$count" -gt 1 ]; then
+      echo "Unexpected number of matches to replace!"
+      exit 1
+    fi
+
+    # Delete the old JAR and move the new one into the Spark classpath
+  if [ -n "$replaceable" ]; then
+      rm "$replaceable" || exit $?
+    fi
+    mv "/tmp/jars/$jar" "$SPARK_JARS" || exit $?
+    echo
+  done
+}
+
+#---
+## Updates Spark's jackson-mapper JAR to a RedHat version
+##
+## @param: the RedHat version name for the JAR
+#---
+update_jackson() {
+  ### The codehaus version of Jackson is defunct, but RedHat has published a patched version
+  JACKSON_VER=$1
+  echo "Updating Jackson to $JACKSON_VER"
+  jackson="https://maven.repository.redhat.com/ga/org/codehaus/jackson/jackson-mapper-asl/$JACKSON_VER/jackson-mapper-asl-$JACKSON_VER.jar"
+  wget -q "$jackson" -P /tmp/jars || exit $?
+  rm $SPARK_JARS/jackson-mapper-asl-*.jar || exit $?
+  mv "/tmp/jars/jackson-mapper-asl-$JACKSON_VER.jar" "$SPARK_JARS" || exit $?
+}
+
+#---
+## Removes all JARs supporting Mesos functionality from Spark's JARs
+#---
+remove_mesos() {
+  echo "Remove Mesos JARs"
+  # Mesos support is being dropped in 4.0.0: https://issues.apache.org/jira/browse/SPARK-44442
+  find $SPARK_JARS -name '*mesos*.jar' -exec echo "Deleting {}" \; -exec rm {} \; || exit $?
+}
+
+#---
+## Creates a Python package entry for the bundled PySpark installation
+##
+## @param: Spark's home directory
+## @param: the Spark version
+#---
+register_pyspark() {
+  echo "Register PySpark installation with PIP"
+  # Following approach mentioned in https://github.com/pypa/pip/issues/10458
+  echo "\
+from setuptools import setup
+
+setup(
+    name='pyspark',
+    version='$2',
+    description='A dummy package representing the provided PySpark installation',
+)" > "$1/python/setup.py"
+  python3 -m pip install "$1/python"
+}
+
+SPARK_JARS="$1/jars"
+SPARK_VERSION=$2
+
+update_maven_jars "com.google.code.gson:gson:2.8.9 \
+                   com.google.guava:guava:33.3.1-jre \
+                   com.squareup.okhttp3:okhttp:3.14.9 \
+                   io.netty:netty-codec-http2:4.1.116.Final \
+                   io.netty:netty-codec-http:4.1.116.Final \
+                   io.netty:netty-common:4.1.116.Final \
+                   org.apache.avro:avro-ipc:1.11.4 \
+                   org.apache.avro:avro-mapred:1.11.4 \
+                   org.apache.avro:avro:1.11.4 \
+                   org.apache.commons:commons-compress:1.27.1 \
+                   commons-io:commons-io:2.16.1 \
+                   commons-codec:commons-codec:1.17.2 \
+                   org.apache.derby:derby:10.16.1.1 \
+                   org.apache.derby:derbytools:10.16.1.1 \
+                   org.apache.derby:derbyshared:10.16.1.1 \
+                   org.apache.hadoop.thirdparty:hadoop-shaded-guava:1.3.0 \
+                   org.apache.hadoop:hadoop-client-runtime:3.4.1 \
+                   org.apache.hive:hive-exec:2.3.10:core \
+                   org.apache.ivy:ivy:2.5.3 \
+                   org.apache.thrift:libthrift:0.13.0 \
+                   org.apache.zookeeper:zookeeper-jute:3.9.3 \
+                   org.apache.zookeeper:zookeeper:3.9.3"
+update_jackson '1.9.14.jdk17-redhat-00001'
+remove_mesos
+register_pyspark $SPARK_HOME $SPARK_VERSION

--- a/extensions/extensions-helm/aissemble-spark-application-chart/tests/deployment_test.yaml
+++ b/extensions/extensions-helm/aissemble-spark-application-chart/tests/deployment_test.yaml
@@ -11,7 +11,7 @@ tests:
           value: "placeholder"
       - equal:
           path: spec.sparkVersion
-          value: 3.5.2
+          value: 3.5.4
       - equal:
           path: spec.dynamicAllocation.enabled
           value: true
@@ -44,7 +44,7 @@ tests:
           value: "512m"
       - equal:
           path: spec.executor.labels.version
-          value: 3.5.2
+          value: 3.5.4
 
   - it: Should set nodeSelector and gpu appropriately
     set:

--- a/extensions/extensions-helm/aissemble-spark-application-chart/values.yaml
+++ b/extensions/extensions-helm/aissemble-spark-application-chart/values.yaml
@@ -10,7 +10,7 @@ sparkApp:
     imagePullPolicy: IfNotPresent
     restartPolicy:
       type: Never
-    sparkVersion: "3.5.2"
+    sparkVersion: "3.5.4"
     sparkConf:
       spark.hive.server2.thrift.port: "10000"
       spark.hive.server2.thrift.http.port: "10001"
@@ -49,7 +49,7 @@ sparkApp:
       coreLimit: "1200m"
       memory: "512m"
       labels:
-        version: 3.5.2
+        version: 3.5.4
       volumeMounts:
         - name: ivy-cache
           mountPath: "/opt/spark/.ivy2"

--- a/extensions/extensions-helm/extensions-helm-spark-infrastructure/aissemble-spark-history-chart/templates/_helpers.tpl
+++ b/extensions/extensions-helm/extensions-helm-spark-infrastructure/aissemble-spark-history-chart/templates/_helpers.tpl
@@ -4,7 +4,7 @@ Create the list of ivy dependencies to be installed on the spark history server
 {{- define "deps.packages.ivy" -}}
 {{- if .Values.enable -}}
     {{- range .Values.dependencies.packages }}
-        {{- $dep := printf "-dependency, %s," . | replace ":" ", " -}}
+        {{- $dep := printf " -dependency %s" . | replace ":" " " -}}
         {{ default $dep -}}
     {{- end }}
 {{- else -}}

--- a/extensions/extensions-helm/extensions-helm-spark-infrastructure/aissemble-spark-history-chart/templates/deployment.yaml
+++ b/extensions/extensions-helm/extensions-helm-spark-infrastructure/aissemble-spark-history-chart/templates/deployment.yaml
@@ -59,7 +59,8 @@ spec:
           imagePullPolicy: {{ .Values.deployment.image.imagePullPolicy | default "IfNotPresent" }}
           # Uses the Ivy jar packaged with spark to download dependency packages (and their transitive dependencies) to /tmp/jars/...
           # Specifically downloads the binaries-- Does not download supplemental classifiers, ie sources
-          command: ["java", "-Divy.cache.dir=/tmp/", "-Divy.home=/tmp/", "-jar", "/opt/spark/jars/ivy-2.5.1.jar", "-confs", "default", "-retrieve", "/tmp/jars/[artifact].[ext]", {{ include "deps.packages.ivy" . }}]
+          command: ["sh", "-c"]
+          args: ["java -Divy.cache.dir=/tmp/ -Divy.home=/tmp/ -cp '/opt/spark/jars/*' org.apache.ivy.Main -confs default -retrieve /tmp/jars/[artifact].[ext] {{ include "deps.packages.ivy" . }}"]
           volumeMounts:
             - mountPath: /tmp/jars
               name: shs-jars

--- a/extensions/extensions-helm/extensions-helm-spark-infrastructure/aissemble-spark-history-chart/tests/deployment_test.yaml
+++ b/extensions/extensions-helm/extensions-helm-spark-infrastructure/aissemble-spark-history-chart/tests/deployment_test.yaml
@@ -215,8 +215,8 @@ tests:
           path: spec.template.spec.initContainers[1].volumeMounts[0].mountPath
           value: "/tmp/jars"
       - matchRegex:
-          path: spec.template.spec.initContainers[1].command[8]
-          pattern: /tmp/jars/.*
+          path: spec.template.spec.initContainers[1].args[0]
+          pattern: java .* -retrieve /tmp/jars/.*
 
   - it: The jar installation initContainer command appropriately references the mount point.
     set:
@@ -288,38 +288,22 @@ tests:
         - some_jar.jar
         - another_jar.jar
     asserts:
-# See https://github.com/helm-unittest/helm-unittest/issues/342
-#      - contains:
-#          path: spec.template.spec.initContainers[1].command
-#          any: true
-#          content: some_jar.jar
-#      - contains:
-#          path: spec.template.spec.initContainers[1].command
-#          any: true
-#          content: another_jar.jar
-#
-# Stopgap test until the above is rectified...
-      - equal:
-          path: spec.template.spec.initContainers[1].command[-2]
-          value: some_jar.jar
-      - equal:
-          path: spec.template.spec.initContainers[1].command[-1]
-          value: another_jar.jar
+      - contains:
+          path: spec.template.spec.initContainers[1].command
+          content: some_jar.jar
+      - contains:
+          path: spec.template.spec.initContainers[1].command
+          content: another_jar.jar
 
   - it: When specifying package dependencies, each dependency is properly listed for download
     set:
       dependencies.packages:
-        - group:artifact:version
+        - groupA:artifactA:versionA
+        - groupB:artifactB:versionB
     asserts:
-      - equal:
-          path: spec.template.spec.initContainers[1].command[-3]
-          value: group
-      - equal:
-          path: spec.template.spec.initContainers[1].command[-2]
-          value: artifact
-      - equal:
-          path: spec.template.spec.initContainers[1].command[-1]
-          value: version
+      - matchRegex:
+          path: spec.template.spec.initContainers[1].args[0]
+          pattern: .* -dependency groupA artifactA versionA -dependency groupB artifactB versionB$
 
   - it: When a command is unspecified, the default is applied
     asserts:

--- a/extensions/extensions-helm/extensions-helm-spark-infrastructure/aissemble-thrift-server-chart/templates/_helpers.tpl
+++ b/extensions/extensions-helm/extensions-helm-spark-infrastructure/aissemble-thrift-server-chart/templates/_helpers.tpl
@@ -4,7 +4,7 @@ Create the list of ivy dependencies to be installed on the spark history server
 {{- define "deps.packages.ivy" -}}
 {{- if .Values.enable -}}
     {{- range .Values.dependencies.packages }}
-        {{- $dep := printf "-dependency, %s," . | replace ":" ", " -}}
+        {{- $dep := printf " -dependency %s" . | replace ":" " " -}}
         {{ default $dep -}}
     {{- end }}
 {{- else -}}

--- a/extensions/extensions-helm/extensions-helm-spark-infrastructure/aissemble-thrift-server-chart/templates/deployment.yaml
+++ b/extensions/extensions-helm/extensions-helm-spark-infrastructure/aissemble-thrift-server-chart/templates/deployment.yaml
@@ -55,7 +55,8 @@ spec:
           imagePullPolicy: {{ .Values.deployment.image.imagePullPolicy | default "IfNotPresent" }}
           # Uses the Ivy jar packaged with spark to download dependency packages (and their transitive dependencies) to /tmp/jars/...
           # Specifically downloads the binaries-- Does not download supplemental classifiers, ie sources
-          command: ["java", "-Divy.cache.dir=/tmp/", "-Divy.home=/tmp/", "-jar", "/opt/spark/jars/ivy-2.5.1.jar", "-confs", "default", "-retrieve", "/tmp/jars/[artifact].[ext]", {{ include "deps.packages.ivy" . }}]
+          command: ["sh", "-c"]
+          args: ["java -Divy.cache.dir=/tmp/ -Divy.home=/tmp/ -cp '/opt/spark/jars/*' org.apache.ivy.Main -confs default -retrieve /tmp/jars/[artifact].[ext] {{ include "deps.packages.ivy" . }}"]
           volumeMounts:
             - mountPath: /tmp/jars
               name: sts-jars

--- a/extensions/extensions-helm/extensions-helm-spark-infrastructure/aissemble-thrift-server-chart/tests/deployment_test.yaml
+++ b/extensions/extensions-helm/extensions-helm-spark-infrastructure/aissemble-thrift-server-chart/tests/deployment_test.yaml
@@ -215,8 +215,8 @@ tests:
           path: spec.template.spec.initContainers[1].volumeMounts[0].mountPath
           value: "/tmp/jars"
       - matchRegex:
-          path: spec.template.spec.initContainers[1].command[8]
-          pattern: /tmp/jars/.*
+          path: spec.template.spec.initContainers[1].args[0]
+          pattern: java .* -retrieve /tmp/jars/.*
 
   - it: The jar installation initContainer command appropriately references the mount point.
     set:
@@ -288,27 +288,22 @@ tests:
         - some_jar.jar
         - another_jar.jar
     asserts:
-      - equal:
-          path: spec.template.spec.initContainers[1].command[-2]
-          value: some_jar.jar
-      - equal:
-          path: spec.template.spec.initContainers[1].command[-1]
-          value: another_jar.jar
+      - contains:
+          path: spec.template.spec.initContainers[1].command
+          content: some_jar.jar
+      - contains:
+          path: spec.template.spec.initContainers[1].command
+          content: another_jar.jar
 
   - it: When specifying package dependencies, each dependency is properly listed for download
     set:
       dependencies.packages:
-        - group:artifact:version
+        - groupA:artifactA:versionA
+        - groupB:artifactB:versionB
     asserts:
-      - equal:
-          path: spec.template.spec.initContainers[1].command[-3]
-          value: group
-      - equal:
-          path: spec.template.spec.initContainers[1].command[-2]
-          value: artifact
-      - equal:
-          path: spec.template.spec.initContainers[1].command[-1]
-          value: version
+      - matchRegex:
+          path: spec.template.spec.initContainers[1].args[0]
+          pattern: .* -dependency groupA artifactA versionA -dependency groupB artifactB versionB$
 
   - it: When a command is unspecified, the default is applied
     asserts:

--- a/extensions/extensions-transform/aissemble-extensions-transform-spark-python/pyproject.toml
+++ b/extensions/extensions-transform/aissemble-extensions-transform-spark-python/pyproject.toml
@@ -13,7 +13,7 @@ python = ">=3.8"
 krausening = ">=20"
 pydantic = ">=2.8.0"
 
-pyspark = "3.5.2"
+pyspark = "3.5.4"
 cryptography = ">=42.0.4"
 urllib3 = "^1.26.18"
 

--- a/test/test-mda-models/aissemble-test-data-delivery-pyspark-model-basic/pyproject.toml
+++ b/test/test-mda-models/aissemble-test-data-delivery-pyspark-model-basic/pyproject.toml
@@ -22,7 +22,7 @@ aissemble-extensions-encryption-vault-python = {path = "../../../extensions/exte
 kafka-python = "^2.0.2"
 python = ">=3.8"
 krausening = ">=20"
-pyspark = "3.5.2"
+pyspark = "3.5.4"
 jsonpickle = "^2.1.0"
 pyyaml = "^6.0"
 cryptography = ">=42.0.4"

--- a/test/test-mda-models/aissemble-test-data-delivery-pyspark-model/pyproject.toml
+++ b/test/test-mda-models/aissemble-test-data-delivery-pyspark-model/pyproject.toml
@@ -21,7 +21,7 @@ aissemble-extensions-encryption-vault-python = {path = "../../../extensions/exte
 kafka-python = "^2.0.2"
 python = ">=3.8"
 krausening = ">=20"
-pyspark = "3.5.2"
+pyspark = "3.5.4"
 jsonpickle = "^2.1.0"
 pyyaml = "^6.0"
 cryptography = ">=42.0.4"


### PR DESCRIPTION
Primarily, this changeset hardens the Spark images by upgrading libraries used by Spark to their highest compatible version. This included upgrading Spark from 3.5.2 to 3.5.4 (the latest version), and modifying the history and Thrift server charts to not hardcode the version of the Ivy jar used to load libraries at deploy time.

This changeset also includes a fix to the Helm version enforcment logic to properly detect/allow for non-standard release version (e.g. release candidate versions).