### PR TITLE
[#540] update jars/libs in hive image

### DIFF
--- a/DRAFT_RELEASE_NOTES.md
+++ b/DRAFT_RELEASE_NOTES.md
@@ -24,6 +24,7 @@ _Note: instructions for adapting to these changes are outlined in the upgrade in
    | `AIOpsModelInstanceRepostory` | `AissembleModelInstanceRepository` |
    | `AiopsMdaJsonUtils`           | `AissembleMdaJsonUtils`            |
  - To improve the development cycle and docker build consistency, we have deprecated the docker_build() and local_resources() functions in the Tilt and enable maven docker build for the docker modules. Follow the instruction in the `Finalizing the Upgrade` to avoid duplicated docker image build.
+ - In an attempt to harden the `aissemble-hive-service` image, several changes were made that may impact projects with Hive customization
 
 
 # Known Issues
@@ -104,7 +105,14 @@ To avoid duplicate docker builds, remove all the related `docker_build()` and `l
 
 ## Conditional Steps
 
-## AWS IRSA (IAM Roles Service Account) Authentication
+### For projects that have customized the Hive service
+Several changes were made to both the Hive service Docker image and the Hive service chart included as part of the Spark Infrastructure chart of a project. The defaults have been adjusted so that these changes should be transparent, however due to the nature of some possible customizations this may not always hold true. The following changes may impact the function of your customizations and may need to be accounted for:
+ - The image is now only the Hive Standalone Metastore service and cannot function as a full [Hive Server](https://hive.apache.org/development/quickstart/)
+ - The Java installation at `/opt/java` is no longer symlinked to `/opt/jre` -- `JAVA_HOME` has been adjusted accordingly by default
+ - The default working directory for the `aissemble-hive-service` image was changed from `/opt` to `/opt/hive`
+ - Schema initialization is no longer done as part of an `initContainer` in the `aissemble-hive-service-chart` and is instead done in a new `entrypoint` script. This is consistent with the [official `apache/hive` Docker image](https://hub.docker.com/r/apache/hive).
+
+### AWS IRSA (IAM Roles Service Account) Authentication
 This is not a required step but a recommended way to authenticate AWS service
 1. [Create an IAM OIDC provider for your cluster](https://docs.aws.amazon.com/eks/latest/userguide/enable-iam-roles-for-service-accounts.html)
 2. Follow the [Assign IAM roles to Kubernetes service accounts](https://docs.aws.amazon.com/eks/latest/userguide/associate-service-account-role.html) document but **skip** the step that creates the service account

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -35,6 +35,7 @@
         <version.fermenter>2.10.5</version.fermenter>
         <version.fermenter.legacy.tools>2.8.0</version.fermenter.legacy.tools>
         <version.habushu.plugin>2.17.0</version.habushu.plugin>
+        <version.hive>4.0.0</version.hive>
         <version.python>3.11.4</version.python>
         <version.help.plugin>3.5.0</version.help.plugin>
         <version.krausening>20</version.krausening>
@@ -87,9 +88,9 @@
         <version.sedona>1.4.0</version.sedona>
         <version.geotools.wrapper>1.4.0-28.2</version.geotools.wrapper>
         <version.mysql-connector>8.0.30</version.mysql-connector>
-        <version.hadoop>3.3.4</version.hadoop>
+        <version.hadoop>3.4.1</version.hadoop>
         <version.neo4j>4.1.5_for_spark_3</version.neo4j>
-        <version.aws.sdk.bundle>1.12.262</version.aws.sdk.bundle>
+        <version.aws.sdk.bundle>1.12.780</version.aws.sdk.bundle>
         <version.baton>1.1.1</version.baton>
         <version.quarkus.cucumber>1.0.0</version.quarkus.cucumber>
         <version.quarkus.cucumber.java>${version.cucumber}</version.quarkus.cucumber.java>

--- a/extensions/extensions-docker/aissemble-hive-service/pom.xml
+++ b/extensions/extensions-docker/aissemble-hive-service/pom.xml
@@ -15,8 +15,9 @@
     <packaging>docker-build</packaging>
 
     <properties>
-        <dockerbuild.jars.directory>target/dockerbuild/jars</dockerbuild.jars.directory>
-        <version.hive.metastore>4.0.0</version.hive.metastore>
+        <dockerbuild.jars.directory>target/dockerbuild/lib</dockerbuild.jars.directory>
+        <dockerbuild.bin.directory>target/dockerbuild/bin</dockerbuild.bin.directory>
+        <dockerbuild.patch.directory>target/dockerbuild/patch</dockerbuild.patch.directory>
     </properties>
 
     <dependencies>
@@ -26,9 +27,73 @@
             <version>3.2.0</version>
         </dependency>
         <dependency>
-            <groupId>mysql</groupId>
-            <artifactId>mysql-connector-java</artifactId>
-            <version>${version.mysql-connector}</version>
+            <groupId>org.apache.hive</groupId>
+            <artifactId>hive-standalone-metastore-server</artifactId>
+            <version>${version.hive}</version>
+            <classifier>bin</classifier>
+            <type>tar.gz</type>
+        </dependency>
+
+        <!-- Patch JARs -->
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>aircompressor</artifactId>
+            <version>0.27</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.avro</groupId>
+            <artifactId>avro</artifactId>
+            <version>1.11.4</version>
+        </dependency>
+        <dependency>
+            <groupId>dnsjava</groupId>
+            <artifactId>dnsjava</artifactId>
+            <version>3.6.2</version>
+        </dependency>
+        <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-protobuf</artifactId>
+            <version>1.70.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>33.4.0-jre</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.2</version>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-io</artifactId>
+            <version>9.4.57.v20241219</version>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-codec-http2</artifactId>
+            <version>4.1.117.Final</version>
+        </dependency>
+        <dependency>
+            <groupId>com.nimbusds</groupId>
+            <artifactId>nimbus-jose-jwt</artifactId>
+            <version>9.48</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protobuf-java</artifactId>
+            <version>3.25.5</version>
+        </dependency>
+        <dependency>
+            <groupId>org.xerial.snappy</groupId>
+            <artifactId>snappy-java</artifactId>
+            <version>1.1.10.7</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.zookeeper</groupId>
+            <artifactId>zookeeper</artifactId>
+            <version>3.9.3</version>
         </dependency>
     </dependencies>
 
@@ -42,34 +107,99 @@
                         <image>
                             <build>
                                 <args>
-                                    <METASTORE_VERSION>${version.hive.metastore}</METASTORE_VERSION>
+                                    <METASTORE_VERSION>${version.hive}</METASTORE_VERSION>
+                                    <HADOOP_VERSION>${version.hadoop}</HADOOP_VERSION>
                                     <JARS_DIR>${dockerbuild.jars.directory}</JARS_DIR>
+                                    <BIN_DIR>${dockerbuild.bin.directory}</BIN_DIR>
+                                    <PATCH_DIR>${dockerbuild.patch.directory}</PATCH_DIR>
                                 </args>
                             </build>
                         </image>
                     </images>
                 </configuration>
+                <executions>
+                    <execution>
+                        <id>test-image</id>
+                        <phase>integration-test</phase>
+                        <configuration>
+                            <images>
+                                <image>
+                                    <run>
+                                        <network>
+                                            <!-- bridged mode (the default) does not work reliably for direct tcp verification.
+                                            See https://github.com/fabric8io/docker-maven-plugin/issues/1234#issuecomment-2609924715 -->
+                                            <mode>host</mode>
+                                        </network>
+                                        <wait>
+                                            <tcp>
+                                                <ports>
+                                                    <port>9083</port>
+                                                </ports>
+                                            </tcp>
+                                        </wait>
+                                    </run>
+                                </image>
+                            </images>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>test-image-cleanup</id>
+                        <phase>post-integration-test</phase>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
                 <configuration>
-                    <outputDirectory>${dockerbuild.jars.directory}</outputDirectory>
-                    <includeTypes>jar</includeTypes>
                     <excludeTransitive>true</excludeTransitive>
-                    <includeArtifactIds>delta-hive_2.12,mysql-connector-java</includeArtifactIds>
                 </configuration>
                 <executions>
                     <execution>
-                        <id>unpack</id>
+                        <id>get-extra-libs</id>
                         <phase>prepare-package</phase>
                         <goals>
                             <goal>copy-dependencies</goal>
                         </goals>
+                        <configuration>
+                            <outputDirectory>${dockerbuild.jars.directory}</outputDirectory>
+                            <includeTypes>jar</includeTypes>
+                            <includeArtifactIds>delta-hive_2.12</includeArtifactIds>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>get-patch-jars</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>copy-dependencies</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${dockerbuild.patch.directory}</outputDirectory>
+                            <includeTypes>jar</includeTypes>
+                            <excludeArtifactIds>delta-hive_2.12,fermenter-mda,baton-maven-plugin,habushu-maven-plugin</excludeArtifactIds>
+                            <useRepositoryLayout>true</useRepositoryLayout>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>get-metastore</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>copy-dependencies</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${dockerbuild.bin.directory}</outputDirectory>
+                            <includeArtifactIds>hive-standalone-metastore-server</includeArtifactIds>
+                            <stripVersion>true</stripVersion>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>
         </plugins>
     </build>
-
 </project>

--- a/extensions/extensions-docker/aissemble-hive-service/src/main/resources/docker/Dockerfile
+++ b/extensions/extensions-docker/aissemble-hive-service/src/main/resources/docker/Dockerfile
@@ -1,5 +1,45 @@
 ARG METASTORE_VERSION
-FROM docker.io/apache/hive:${METASTORE_VERSION} AS appsource
+FROM docker.io/eclipse-temurin:17-jre AS builder
+
+ARG METASTORE_VERSION
+ARG HADOOP_VERSION
+ARG JARS_DIR
+ARG BIN_DIR
+ARG PATCH_DIR
+
+ENV HADOOP_HOME=/opt/hadoop
+ENV HIVE_HOME=/opt/hive
+ENV HIVE_VER=$METASTORE_VERSION
+
+# Install hadoop
+RUN cd /tmp \
+    && wget https://archive.apache.org/dist/hadoop/common/hadoop-${HADOOP_VERSION}/hadoop-${HADOOP_VERSION}-lean.tar.gz -O - \
+       | tar -xzf - \
+    && mv hadoop-${HADOOP_VERSION} $HADOOP_HOME
+
+# Use standalone binary instead of full-service version on original image
+COPY ${BIN_DIR}/hive-standalone-metastore-server-bin.tar.gz /tmp
+RUN cd /tmp \
+    && tar -xf /tmp/hive-standalone-metastore-server-bin.tar.gz \
+    && mv apache-hive-metastore-${METASTORE_VERSION}-bin $HIVE_HOME \
+    && rm /tmp/hive-standalone-metastore-server-bin.tar.gz
+
+# Update library jars used by Hive and Hadoop
+COPY --chmod=755 ./src/main/resources/scripts/setup.sh $HIVE_HOME/setup.sh
+ADD ${PATCH_DIR}/* /tmp/patch-jars
+RUN $HIVE_HOME/setup.sh /tmp/patch-jars && rm -rf /tmp/patch-jars
+
+# Hadoop ships with source jars, which aren't necessary and bloat the image, also remove YARN support as we only support K8s
+RUN rm -rf $HADOOP_HOME/share/hadoop/common/sources \
+           $HADOOP_HOME/share/hadoop/hdfs/sources \
+           $HADOOP_HOME/share/hadoop/mapreduce/sources \
+           $HADOOP_HOME/share/hadoop/tools/sources \
+           $HADOOP_HOME/share/hadoop/yarn/*
+
+# Patch for HIVE-28487: https://github.com/apache/hive/pull/5419
+RUN sed -i \
+    's/org.apache.hadoop.hive.metastore.tools.MetastoreSchemaTool/org.apache.hadoop.hive.metastore.tools.schematool.MetastoreSchemaTool/' \
+    "$HIVE_HOME/bin/ext/schemaTool.sh"
 
 FROM docker.io/eclipse-temurin:17-jre AS final
 
@@ -7,26 +47,29 @@ LABEL org.opencontainers.image.source="https://github.com/boozallen/aissemble"
 
 WORKDIR /opt
 
+ARG METASTORE_VERSION
+ARG HADOOP_VERSION
 ARG JARS_DIR
+ARG BIN_DIR
+ARG PATCH_DIR
 
 ENV HADOOP_HOME=/opt/hadoop
 ENV HIVE_HOME=/opt/hive
+ENV HIVE_VER=$METASTORE_VERSION
 
-COPY --from=appsource /opt/hadoop $HADOOP_HOME
-COPY --from=appsource /opt/hive $HIVE_HOME
+COPY --from=builder $HADOOP_HOME $HADOOP_HOME
+COPY --from=builder $HIVE_HOME $HIVE_HOME
+
+COPY --chmod=755 src/main/resources/scripts/entrypoint.sh /entrypoint.sh
 
 RUN groupadd -rf hive --gid=1000 && \
     useradd --home $HIVE_HOME -g hive --shell /usr/sbin/nologin --uid 1000 hive -o && \
-    chown hive:hive -R $HIVE_HOME && \
-    ln -s $JAVA_HOME /opt/jre
+    chown hive:hive -R $HIVE_HOME
 
 ADD ${JARS_DIR}/* $HIVE_HOME/lib/
 
-# Remove jars with open vulnerabilities. These jars are included in the apache hive image but not necessary
-# when running the hive metastore only
-RUN rm ${HIVE_HOME}/lib/avatica-1.12.0.jar ${HIVE_HOME}/lib/htrace-core-3.1.0-incubating.jar \
-    ${HADOOP_HOME}/share/hadoop/yarn/timelineservice/lib/htrace-core-3.1.0-incubating.jar  
-
 USER hive
+WORKDIR $HIVE_HOME
 
-ENTRYPOINT ["/opt/hive/bin/hive", "--skiphadoopversion", "--skiphbasecp", "--verbose", "--service", "metastore"]
+ENV VERBOSE=true
+ENTRYPOINT ["/entrypoint.sh"]

--- a/extensions/extensions-docker/aissemble-hive-service/src/main/resources/scripts/entrypoint.sh
+++ b/extensions/extensions-docker/aissemble-hive-service/src/main/resources/scripts/entrypoint.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+###
+# #%L
+# aiSSEMBLE::Extensions::Docker::Hive Service
+# %%
+# Copyright (C) 2021 Booz Allen
+# %%
+# This software package is licensed under the Booz Allen Public License. All Rights Reserved.
+# #L%
+###
+
+
+# DERIVED FROM apache/spark image entrypoint script
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+
+set -x
+
+DB_DRIVER=${DB_DRIVER:-derby}
+if [[ $VERBOSE = "true" ]]; then
+  VERBOSE_MODE="--verbose"
+else
+  VERBOSE_MODE=""
+fi
+
+function initialize_hive {
+  COMMAND="-initOrUpgradeSchema"
+  if [ "$(echo "$HIVE_VER" | cut -d '.' -f1)" -lt "4" ]; then
+     COMMAND="-initSchema"
+  fi
+  # Don't honor verbose mode and dump errors because the 4.0.0 mysql schema generates a ton of deprecation warnings
+  if "$HIVE_HOME/bin/schematool" -dbType $DB_DRIVER $COMMAND; then
+    echo "Initialized schema successfully.."
+  else
+    echo "Schema initialization failed!"
+    exit 1
+  fi
+}
+
+export HIVE_CONF_DIR=$HIVE_HOME/conf
+if [ -d "${HIVE_CUSTOM_CONF_DIR:-}" ]; then
+  find "${HIVE_CUSTOM_CONF_DIR}" -type f -exec \
+    ln -sfn {} "${HIVE_CONF_DIR}"/ \;
+  export HADOOP_CONF_DIR=$HIVE_CONF_DIR
+  export TEZ_CONF_DIR=$HIVE_CONF_DIR
+fi
+
+export HADOOP_CLIENT_OPTS="$HADOOP_CLIENT_OPTS -Xmx1G $SERVICE_OPTS"
+
+if [ -z "$IS_RESUME" ]; then
+  echo "Initializing (or upgrading) schema"
+  initialize_hive
+else
+  echo "Skip schema initialization ($IS_RESUME)"
+fi
+
+export METASTORE_PORT=${METASTORE_PORT:-9083}
+exec "$HIVE_HOME/bin/base" --skiphadoopversion $VERBOSE_MODE --service metastore

--- a/extensions/extensions-docker/aissemble-hive-service/src/main/resources/scripts/setup.sh
+++ b/extensions/extensions-docker/aissemble-hive-service/src/main/resources/scripts/setup.sh
@@ -1,0 +1,99 @@
+#!/bin/bash
+###
+# #%L
+# aiSSEMBLE::Extensions::Docker::Spark
+# %%
+# Copyright (C) 2021 Booz Allen
+# %%
+# This software package is licensed under the Booz Allen Public License. All Rights Reserved.
+# #L%
+###
+
+#---
+## Same as `cut` but reads fields from the end. E.g.:
+##     cutr -d : -f 2 <<< "one:two:three:four"
+##     > 'three'
+## Note that open-ended ranges might be opposite of intuition if you think of them as "before" and "after"
+##     cutr -d : -f -2 <<< "one:two:three:four"
+##     > 'three:four'
+##     cutr -d : -f 2- <<< "one:two:three:four"
+##     > 'one:two:three'
+#---
+cutr() {
+  rev | cut "$@" | rev
+}
+
+#---
+## Patches a lib directory with given updated JARs by matching on base name. For example, given the replace directory has
+## the jar `commons-math-3.4.jar` and the target directory has `commons-math-2.1.jar`, the existing 2.1 JAR is deleted
+## and the updated 3.4 jar is copied into the directory.
+##
+## @Param: location of replacement JARs
+## @Param: location to search for JARs to replace
+#---
+update_jars() {
+  updated="$1"
+  target="$2"
+  echo
+  echo "Updating jars in $target with jars from $updated"
+  echo
+
+  find "$updated" -type f -name '*.jar' | while read -r jarpath; do
+    #Parse GAV into separate variables, classifier may or may not be present as the last item
+    group=$(echo "$jarpath" | cutr -d / -f 4-)
+    group=$(echo "${group#$updated/}" | tr / .)
+    artifact=$(echo "$jarpath" | cutr -d / -f 3)
+    version=$(echo "$jarpath" | cutr -d / -f 2)
+    jar=$(echo "$jarpath" | cutr -d / -f 1)
+    classifier=${jar#$artifact-$version}
+    classifier=${classifier%\.jar}
+    echo "-------------------------------------------"
+    echo "Replacing $group:$artifact with updated JAR ($artifact-$version$classifier.jar)"
+
+    # Find the old jar that is being replaced
+    REPLACED=1
+    echo find "$target" -type f -regex ".*/$artifact-[^-]*$classifier.jar"
+     while read -r replaceable; do
+      echo "  replacing '$replaceable'"
+      rm "$replaceable" || exit $?
+      cp "$jarpath" "$(dirname "$replaceable")" || exit $?
+      REPLACED=0
+    done < <(find "$target" -type f -regex ".*/$artifact-[^-]*$classifier.jar")
+    # Guava version sometimes includes `-jre` at the end
+    if [ "$artifact" = "guava" ]; then
+      #We could do something fancier/generic like count dashes in version and use sed regex like:
+      #find "$target" -type f -regextype sed -regex ".*/$artifact\(-[^-]*\)\{1,$(VER_DASH_COUNT+1)\}.jar"
+      # But only Guava has this issue so it's not worth it.
+      while read -r replaceable; do
+        echo "  replacing '$replaceable'"
+        rm "$replaceable" || exit $?
+        cp "$jarpath" "$(dirname "$replaceable")" || exit $?
+        REPLACED=0
+      done < <(find "$target" -type f -regex ".*/$artifact-[^-]*-jre.jar")
+    fi
+    echo
+    if [ $REPLACED -ne 0 ]; then
+      echo "$jar" >> /tmp/FAILED.txt
+    fi
+  done
+}
+
+#---
+## Downloads jackson-mapper JAR from RedHat
+##
+## @param: destination directory for downloaded JAR
+#---
+download_jackson() {
+  ### The codehaus version of Jackson is defunct, but RedHat has published a patched version
+  JACKSON_VER='1.9.14.jdk17-redhat-00001'
+  echo "Downloading Jackson $JACKSON_VER"
+  jackson="https://maven.repository.redhat.com/ga/org/codehaus/jackson/jackson-mapper-asl/$JACKSON_VER/jackson-mapper-asl-$JACKSON_VER.jar"
+  wget -q "$jackson" -P "$1/org/codehaus/jackson/jackson-mapper-asl/$JACKSON_VER" || exit $?
+}
+
+update_jars "$1" "/opt"
+if [ -f /tmp/FAILED.txt ]; then
+  echo 'ERROR: The following jars were not patched into the image'
+  cat /tmp/FAILED.txt
+  exit 1
+fi

--- a/extensions/extensions-docker/aissemble-spark-infrastructure/pom.xml
+++ b/extensions/extensions-docker/aissemble-spark-infrastructure/pom.xml
@@ -74,20 +74,12 @@
                     <execution>
                         <id>test-image</id>
                         <phase>integration-test</phase>
-                        <goals>
-                            <goal>start</goal>
-                        </goals>
                         <configuration>
-                            <showLogs>true</showLogs>
                             <images>
                                 <image>
                                     <run>
-                                        <containerNamePattern>${project.artifactId}-test</containerNamePattern>
-                                        <!-- If autoRemove is true and wait is specified, the build will fail. See https://github.com/fabric8io/docker-maven-plugin/issues/1622 -->
-                                        <autoRemove>false</autoRemove>
                                         <entrypoint>sh -c /tmp/test/image-test.sh</entrypoint>
                                         <wait>
-                                            <time>60000</time>
                                             <http>
                                                 <!-- History server check -->
                                                 <url>http://localhost:18080</url>
@@ -114,15 +106,15 @@
                     <execution>
                         <id>test-image-cleanup</id>
                         <phase>post-integration-test</phase>
-                        <goals>
-                            <goal>exec</goal>
-                        </goals>
+                    </execution>
+                    <execution>
+                        <id>test-image-cleanup-db</id>
+                        <phase>post-integration-test</phase>
                         <configuration>
                             <executable>docker</executable>
                             <arguments>
                                 <argument>rm</argument>
                                 <argument>-f</argument>
-                                <argument>${project.artifactId}-test</argument>
                                 <argument>hive-metastore-db</argument>
                             </arguments>
                         </configuration>

--- a/extensions/extensions-docker/aissemble-spark/pom.xml
+++ b/extensions/extensions-docker/aissemble-spark/pom.xml
@@ -72,16 +72,11 @@
                             <goal>start</goal>
                         </goals>
                         <configuration>
-                            <showLogs>true</showLogs>
                             <images>
                                 <image>
                                     <run>
-                                        <containerNamePattern>${project.artifactId}-test</containerNamePattern>
-                                        <!-- If autoRemove is true, the build will fail. See https://github.com/fabric8io/docker-maven-plugin/issues/1622 -->
-                                        <autoRemove>false</autoRemove>
                                         <cmd>/opt/spark/bin/spark-submit /opt/spark/examples/src/main/python/pi.py</cmd>
                                         <wait>
-                                            <time>60000</time>
                                             <exit>0</exit>
                                         </wait>
                                     </run>
@@ -98,13 +93,6 @@
                     <execution>
                         <id>test-image-cleanup</id>
                         <phase>post-integration-test</phase>
-                        <goals>
-                            <goal>exec</goal>
-                        </goals>
-                        <configuration>
-                            <executable>docker</executable>
-                            <commandlineArgs>rm ${project.artifactId}-test</commandlineArgs>
-                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/extensions/extensions-docker/pom.xml
+++ b/extensions/extensions-docker/pom.xml
@@ -86,6 +86,58 @@
                         </execution>
                     </executions>
                 </plugin>
+                <plugin>
+                    <groupId>${group.fabric8.plugin}</groupId>
+                    <artifactId>docker-maven-plugin</artifactId>
+                    <executions>
+                        <execution>
+                            <id>test-image</id>
+                            <!-- Images with tests should set the phase of this execution to `integration-test` to activate it -->
+                            <phase>none</phase>
+                            <goals>
+                                <goal>start</goal>
+                            </goals>
+                            <configuration>
+                                <showLogs>true</showLogs>
+                                <images>
+                                    <image>
+                                        <run>
+                                            <containerNamePattern>${project.artifactId}-test</containerNamePattern>
+                                            <!-- If autoRemove is true, the build will fail.
+                                            See https://github.com/fabric8io/docker-maven-plugin/issues/1622 -->
+                                            <autoRemove>false</autoRemove>
+                                            <wait>
+                                                <time>60000</time>
+                                            </wait>
+                                        </run>
+                                    </image>
+                                </images>
+                            </configuration>
+                        </execution>
+                    </executions>
+                </plugin>
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>exec-maven-plugin</artifactId>
+                    <executions>
+                        <execution>
+                            <id>test-image-cleanup</id>
+                            <!-- Images with tests should set the phase of this execution to `post-integration-test` to activate it -->
+                            <phase>none</phase>
+                            <goals>
+                                <goal>exec</goal>
+                            </goals>
+                            <configuration>
+                                <executable>docker</executable>
+                                <arguments>
+                                    <argument>rm</argument>
+                                    <argument>-f</argument>
+                                    <argument>${project.artifactId}-test</argument>
+                                </arguments>
+                            </configuration>
+                        </execution>
+                    </executions>
+                </plugin>
             </plugins>
         </pluginManagement>
     </build>

--- a/extensions/extensions-helm/extensions-helm-spark-infrastructure/aissemble-hive-metastore-service-chart/templates/deployment.yaml
+++ b/extensions/extensions-helm/extensions-helm-spark-infrastructure/aissemble-hive-metastore-service-chart/templates/deployment.yaml
@@ -33,25 +33,13 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 12}}
       {{- end }}
-      initContainers:
-        - name: "init-or-upgrade-schema"
-          image: {{ .Values.image.dockerRepo }}{{ .Values.image.name }}:{{ .Values.image.tag | default .Chart.AppVersion }}
-          imagePullPolicy: IfNotPresent
-          command:
-            - "/opt/hive/bin/schematool"
-            - "-dbType"
-            - {{ .Values.hive.dbType }}
-            - "-initOrUpgradeSchema"
-            - "--verbose"
-          volumeMounts:
-          - name: metastore-service-config
-            mountPath: /opt/hive/conf/metastore-site.xml
-            subPath: metastore-site.xml
       containers:
         - name: {{ .Values.app.name | default .Chart.Name }}
           image: {{ .Values.image.dockerRepo }}{{ .Values.image.name }}:{{ .Values.image.tag | default .Chart.AppVersion }}
           imagePullPolicy: {{ .Values.image.imagePullPolicy }}
           env:
+            - name: DB_DRIVER
+              value: {{ .Values.hive.dbType }}
             {{- toYaml .Values.deployment.baseEnv | nindent 12}}
           {{- if .Values.deployment.env}}
             {{- toYaml .Values.deployment.env | nindent 12 }}

--- a/extensions/extensions-helm/extensions-helm-spark-infrastructure/aissemble-hive-metastore-service-chart/tests/deployment_test.yaml
+++ b/extensions/extensions-helm/extensions-helm-spark-infrastructure/aissemble-hive-metastore-service-chart/tests/deployment_test.yaml
@@ -29,8 +29,8 @@ tests:
       - contains:
           path: spec.template.spec.containers[0].env
           content:
-            name: JAVA_HOME
-            value: /opt/jre
+            name: DB_DRIVER
+            value: mysql
       - contains:
           path: spec.template.spec.containers[0].volumeMounts
           content:

--- a/extensions/extensions-helm/extensions-helm-spark-infrastructure/aissemble-hive-metastore-service-chart/values.yaml
+++ b/extensions/extensions-helm/extensions-helm-spark-infrastructure/aissemble-hive-metastore-service-chart/values.yaml
@@ -32,8 +32,6 @@ deployment:
   baseEnv:
     - name: HADOOP_CLASSPATH
       value: $HADOOP_CLASSPATH:/opt/hadoop/share/hadoop/tools/lib/*.jar
-    - name: JAVA_HOME
-      value: /opt/jre
   env: []
   restartPolicy: Always
   volumeMounts:

--- a/foundation/foundation-data-access/pom.xml
+++ b/foundation/foundation-data-access/pom.xml
@@ -54,7 +54,7 @@
         <dependency>
             <groupId>org.apache.hive</groupId>
             <artifactId>hive-jdbc</artifactId>
-            <version>2.3.5</version>
+            <version>${version.hive}</version>
             <!-- hive jdbc dependency is extremely bloated - excluding a number of
                  dependencies within it that conflict with quarkus and logging -->
             <exclusions>
@@ -113,10 +113,10 @@
             </exclusions>
         </dependency>
         <dependency>
-            <!-- Upgrade to 3.7.2 to fix CVE-2023-44981 -->
+            <!-- Upgrade to 3.9.3 to fix CVE-2023-44981 -->
             <groupId>org.apache.zookeeper</groupId>
             <artifactId>zookeeper</artifactId>
-            <version>3.7.2</version>
+            <version>3.9.3</version>
         </dependency>
     </dependencies>
 

--- a/foundation/foundation-mda/src/main/resources/templates/deployment/spark-infrastructure/v2/spark.infrastructure.values.yaml.vm
+++ b/foundation/foundation-mda/src/main/resources/templates/deployment/spark-infrastructure/v2/spark.infrastructure.values.yaml.vm
@@ -9,9 +9,6 @@ aissemble-spark-history-chart:
 aissemble-thrift-server-chart:
   app:
     name: "thrift-server"
-  dependencies:
-    packages:
-      - org.apache.hadoop:hadoop-aws:3.3.4
 
   sparkConf: |
     spark.hadoop.fs.s3a.endpoint=http://s3-local:4566

--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,6 @@
         <ossrh.repo.url>https://oss.sonatype.org/content/repositories</ossrh.repo.url>
         <s01.ossrh.repo.url>https://s01.oss.sonatype.org/content/repositories</s01.ossrh.repo.url>
         <ghcr.io.repo.url>https://maven.pkg.github.com/boozallen/aissemble</ghcr.io.repo.url>
-        <version.avro>1.10.1</version.avro>
         <version.camel>2.7.0</version.camel>
         <version.cucumber>7.4.1</version.cucumber>
         <version.feature.discovery>1.2.0</version.feature.discovery>


### PR DESCRIPTION
 - Add automated tests to ensure the hive metastore can start
 - Better support using the Hive image as a standalone artifact by moving logic buried in the Helm chart into the base image
 - Switch to the standalone-metastore version of Hive
 - Update Hadoop from 3.3.6 to 3.4.1
 - Patch in compatible updated library jars to fix issues