### PR TITLE
[#540] exclude jdk.tools frome hive dependency

### DIFF
--- a/extensions/extensions-docker/aissemble-hive-service/pom.xml
+++ b/extensions/extensions-docker/aissemble-hive-service/pom.xml
@@ -32,6 +32,12 @@
             <version>${version.hive}</version>
             <classifier>bin</classifier>
             <type>tar.gz</type>
+            <exclusions>
+                <exclusion>
+                    <groupId>jdk.tools</groupId>
+                    <artifactId>jdk.tools</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- Patch JARs -->


### PR DESCRIPTION
I'm not sure why this occurs only sometimes, but I'm guessing it has to
do with Java versions.  Locally, jdk.tools is not listed as a transitive
dependency in `mvn dependency:tree`, however in Codespaces and
apparently in the CI build, the dependency is there and unsatisfied as
tools.jar and rt.jar were removed from the JDK in JDK 9. (See
[JEP 220](https://openjdk.org/jeps/220).)