### PR TITLE
[#540] fix hive persistence

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -88,7 +88,7 @@
         <version.sedona>1.4.0</version.sedona>
         <version.geotools.wrapper>1.4.0-28.2</version.geotools.wrapper>
         <version.mysql-connector>8.0.30</version.mysql-connector>
-        <version.hadoop>3.4.1</version.hadoop>
+        <version.hadoop>3.3.4</version.hadoop>
         <version.neo4j>4.1.5_for_spark_3</version.neo4j>
         <version.aws.sdk.bundle>1.12.780</version.aws.sdk.bundle>
         <version.baton>1.1.1</version.baton>

--- a/extensions/extensions-docker/aissemble-hive-service/pom.xml
+++ b/extensions/extensions-docker/aissemble-hive-service/pom.xml
@@ -18,6 +18,8 @@
         <dockerbuild.jars.directory>target/dockerbuild/lib</dockerbuild.jars.directory>
         <dockerbuild.bin.directory>target/dockerbuild/bin</dockerbuild.bin.directory>
         <dockerbuild.patch.directory>target/dockerbuild/patch</dockerbuild.patch.directory>
+        <!-- Hadoop Version can be safely updated in this image, but not in Spark images -->
+        <version.hadoop>3.4.1</version.hadoop>
     </properties>
 
     <dependencies>
@@ -77,6 +79,11 @@
             <version>9.4.57.v20241219</version>
         </dependency>
         <dependency>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
+            <version>8.2.0</version>
+        </dependency>
+        <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-codec-http2</artifactId>
             <version>4.1.117.Final</version>
@@ -87,6 +94,11 @@
             <version>9.48</version>
         </dependency>
         <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+            <version>42.5.5</version>
+        </dependency>
+        <dependency>
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java</artifactId>
             <version>3.25.5</version>
@@ -95,6 +107,11 @@
             <groupId>org.xerial.snappy</groupId>
             <artifactId>snappy-java</artifactId>
             <version>1.1.10.7</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-core</artifactId>
+            <version>5.3.26</version>
         </dependency>
         <dependency>
             <groupId>org.apache.zookeeper</groupId>

--- a/extensions/extensions-docker/aissemble-hive-service/src/main/resources/docker/Dockerfile
+++ b/extensions/extensions-docker/aissemble-hive-service/src/main/resources/docker/Dockerfile
@@ -13,7 +13,7 @@ ENV HIVE_VER=$METASTORE_VERSION
 
 # Install hadoop
 RUN cd /tmp \
-    && wget https://archive.apache.org/dist/hadoop/common/hadoop-${HADOOP_VERSION}/hadoop-${HADOOP_VERSION}-lean.tar.gz -O - \
+    && wget https://archive.apache.org/dist/hadoop/common/hadoop-${HADOOP_VERSION}/hadoop-${HADOOP_VERSION}.tar.gz -O - \
        | tar -xzf - \
     && mv hadoop-${HADOOP_VERSION} $HADOOP_HOME
 

--- a/extensions/extensions-docker/aissemble-hive-service/src/main/resources/scripts/entrypoint.sh
+++ b/extensions/extensions-docker/aissemble-hive-service/src/main/resources/scripts/entrypoint.sh
@@ -36,7 +36,7 @@ function initialize_hive {
      COMMAND="-initSchema"
   fi
   # Don't honor verbose mode and dump errors because the 4.0.0 mysql schema generates a ton of deprecation warnings
-  if "$HIVE_HOME/bin/schematool" -dbType $DB_DRIVER $COMMAND; then
+  if "$HIVE_HOME/bin/schematool" -dbType $DB_DRIVER $COMMAND 2>/dev/null; then
     echo "Initialized schema successfully.."
   else
     echo "Schema initialization failed!"

--- a/extensions/extensions-docker/aissemble-hive-service/src/main/resources/scripts/setup.sh
+++ b/extensions/extensions-docker/aissemble-hive-service/src/main/resources/scripts/setup.sh
@@ -38,7 +38,7 @@ update_jars() {
   echo "Updating jars in $target with jars from $updated"
   echo
 
-  find "$updated" -type f -name '*.jar' | while read -r jarpath; do
+  while read -r jarpath; do
     #Parse GAV into separate variables, classifier may or may not be present as the last item
     group=$(echo "$jarpath" | cutr -d / -f 4-)
     group=$(echo "${group#$updated/}" | tr / .)
@@ -73,9 +73,10 @@ update_jars() {
     fi
     echo
     if [ $REPLACED -ne 0 ]; then
-      echo "$jar" >> /tmp/FAILED.txt
+      echo "No replacement candidates found for $jar"
+      exit 1
     fi
-  done
+  done < <(find "$updated" -type f -name '*.jar')
 }
 
 #---
@@ -92,8 +93,3 @@ download_jackson() {
 }
 
 update_jars "$1" "/opt"
-if [ -f /tmp/FAILED.txt ]; then
-  echo 'ERROR: The following jars were not patched into the image'
-  cat /tmp/FAILED.txt
-  exit 1
-fi

--- a/extensions/extensions-docker/aissemble-spark/src/main/resources/scripts/setup.sh
+++ b/extensions/extensions-docker/aissemble-spark/src/main/resources/scripts/setup.sh
@@ -121,7 +121,7 @@ update_maven_jars "com.google.code.gson:gson:2.8.9 \
                    org.apache.derby:derbytools:10.16.1.1 \
                    org.apache.derby:derbyshared:10.16.1.1 \
                    org.apache.hadoop.thirdparty:hadoop-shaded-guava:1.3.0 \
-                   org.apache.hadoop:hadoop-client-runtime:3.4.1 \
+                   org.apache.hadoop:hadoop-client-runtime:3.3.6 \
                    org.apache.hive:hive-exec:2.3.10:core \
                    org.apache.ivy:ivy:2.5.3 \
                    org.apache.thrift:libthrift:0.13.0 \

--- a/extensions/extensions-helm/extensions-helm-spark-infrastructure/aissemble-hive-metastore-service-chart/templates/deployment.yaml
+++ b/extensions/extensions-helm/extensions-helm-spark-infrastructure/aissemble-hive-metastore-service-chart/templates/deployment.yaml
@@ -63,6 +63,14 @@ spec:
           {{- if .Values.deployment.command }}
           command: {{ .Values.deployment.command }}
           {{- end }}
+          {{- with (index .Values.deployment.ports 0) }}
+          readinessProbe:
+            tcpSocket:
+              port: {{ .containerPort }}
+            initialDelaySeconds: 15
+            periodSeconds: 5
+            failureThreshold: 0
+          {{- end }}
       hostname: {{ .Values.hostname }}
       restartPolicy: {{ .Values.deployment.restartPolicy }}
       {{- with .Values.deployment.securityContext }}

--- a/extensions/extensions-helm/extensions-helm-spark-infrastructure/aissemble-thrift-server-chart/values.yaml
+++ b/extensions/extensions-helm/extensions-helm-spark-infrastructure/aissemble-thrift-server-chart/values.yaml
@@ -11,7 +11,7 @@ deployment:
   labels: {}
   replicas: 1
   image:
-    repository: "ghcr.io/boozallen/aissemble-spark"
+    repository: "ghcr.io/boozallen/aissemble-spark-infrastructure"
     imagePullPolicy: IfNotPresent
     tag: ""
   command: ["/opt/spark/sbin/start-thriftserver.sh"]


### PR DESCRIPTION
Key Changes:
 - Change Hadoop client version back to 3.3.6 for Spark
 - Switch from the Hadoop lean package to the full package

Other Changes:
 - Add readiness probe for hive service chart
 - Use spark-infrastructure image for thrift server chart Includes necessary connector JARs like hadoop-aws, delta-lake, etc.
 - Route stderr to /dev/null for Hive image startup Speeds start up since current 4.0 schema tool dumps a ton of errors
 - Improve failure detection in patch script