### PR TITLE
[#585] fix Nvidia ARM build

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -581,7 +581,7 @@
                                                 <builderName>maven</builderName>
                                                 <driverOpts>
                                                     <!-- Fully qualify build driver image name to ensure any configured credentials are used -->
-                                                    <image>docker.io/moby/buildkit:buildx-stable-1</image>
+                                                    <image>docker.io/moby/buildkit:v0.19.0</image>
                                                 </driverOpts>
                                                 <cacheTo>type=local,dest=${user.home}/.docker/cache</cacheTo>
                                                 <cacheFrom>type=local,src=${user.home}/.docker/cache</cacheFrom>

--- a/devops/ARC_README.md
+++ b/devops/ARC_README.md
@@ -50,6 +50,7 @@ helm install arc-runner-set-aissemble oci://ghcr.io/actions/actions-runner-contr
              --namespace gh-actions-aissemble \
              --create-namespace \
              --set githubConfigSecret.github_token="{TOKEN}" \
+             --post-renderer ./kustomize.sh \
              -f runnerset-values.yaml
 ```
 
@@ -72,5 +73,6 @@ the token may be required to achieve this.
 helm upgrade arc-runner-set-aissemble oci://ghcr.io/actions/actions-runner-controller-charts/gha-runner-scale-set \
              --namespace gh-actions-aissemble \
              --reuse-values \
+             --post-renderer ./kustomize.sh \
              -f runnerset-values.yaml
 ```

--- a/devops/kustomization.yaml
+++ b/devops/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - resources.yaml
+images:
+  - name: docker
+    newTag: 27.5.1-dind

--- a/devops/kustomize.sh
+++ b/devops/kustomize.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+cat > resources.yaml
+kubectl kustomize
+rm resources.yaml


### PR DESCRIPTION
This change set does two things:
 - Add a kustomization to fix the Docker `dind` image to a specific version (v27.5.1)
 - Update the buildkit image tag for the docker-maven-plugin to a fixed version (v0.19.0)

The original issue appeared like it might be caused by the updated `dind` image which corresponded with the release of Docker Engine 28.0. The actual cause ended up being the update to the `buildkit-stable-1` tag of the buildkit image we were using (also corresponding to the engine).