### PR TITLE
[#602] improve Hadoop download for aissemble-hive-service

### DIFF
--- a/extensions/extensions-docker/aissemble-hive-service/pom.xml
+++ b/extensions/extensions-docker/aissemble-hive-service/pom.xml
@@ -184,6 +184,26 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>wagon-maven-plugin</artifactId>
+                <version>2.0.2</version>
+                <executions>
+                    <execution>
+                        <id>get-hadoop</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>download-single</goal>
+                        </goals>
+                        <configuration>
+                            <url>https://dlcdn.apache.org</url>
+                            <fromFile>hadoop/common/hadoop-${version.hadoop}/hadoop-${version.hadoop}.tar.gz</fromFile>
+                            <toFile>${dockerbuild.bin.directory}/hadoop.tar.gz</toFile>
+                            <skipIfExists>true</skipIfExists>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 

--- a/extensions/extensions-docker/aissemble-hive-service/src/main/resources/docker/Dockerfile
+++ b/extensions/extensions-docker/aissemble-hive-service/src/main/resources/docker/Dockerfile
@@ -17,17 +17,14 @@ RUN set -eux; \
     microdnf install -y gzip util-linux
 
 # Install hadoop
-RUN cd /tmp \
-    && curl https://archive.apache.org/dist/hadoop/common/hadoop-${HADOOP_VERSION}/hadoop-${HADOOP_VERSION}.tar.gz \
-       | tar -xzf - \
+RUN --mount=source=${BIN_DIR},target=/tmp/bin cd /tmp \
+    && tar -xzf /tmp/bin/hadoop.tar.gz \
     && mv hadoop-${HADOOP_VERSION} $HADOOP_HOME
 
 # Use standalone binary instead of full-service version on original image
-COPY ${BIN_DIR}/hive-standalone-metastore-server-bin.tar.gz /tmp
-RUN cd /tmp \
-    && tar -xf /tmp/hive-standalone-metastore-server-bin.tar.gz \
-    && mv apache-hive-metastore-${METASTORE_VERSION}-bin $HIVE_HOME \
-    && rm /tmp/hive-standalone-metastore-server-bin.tar.gz
+RUN --mount=source=${BIN_DIR},target=/tmp/bin cd /tmp \
+    && tar -xf /tmp/bin/hive-standalone-metastore-server-bin.tar.gz \
+    && mv apache-hive-metastore-${METASTORE_VERSION}-bin $HIVE_HOME
 
 # Update library jars used by Hive and Hadoop
 COPY --chmod=755 ./src/main/resources/scripts/setup.sh $HIVE_HOME/setup.sh


### PR DESCRIPTION
- Switches to main download mirror for Hadoop package
- Downloads Hadoop with Maven so the same package can be reused
- Uses a bind mount to save on Docker cache usage