### PR TITLE
#610 fix ci build - disable vault ci cucumber test report

### DIFF
--- a/extensions/extensions-encryption/extensions-encryption-vault-java/src/test/java/com/boozallen/aissemble/data/encryption/CucumberIT.java
+++ b/extensions/extensions-encryption/extensions-encryption-vault-java/src/test/java/com/boozallen/aissemble/data/encryption/CucumberIT.java
@@ -20,8 +20,10 @@ import org.junit.runner.RunWith;
 @RunWith(Cucumber.class)
 @CucumberOptions(
         features = "src/test/resources/specifications",
-        plugin = {"json:target/cucumber-reports/cucumber.json"},
-        tags = "@integration")
+        // TODO: re-enable or remove when vault encryption is ready or removed
+        // Disable cucumber report for integration test since we only have vault for integration test, which is disabled for now
+        // plugin = {"json:target/cucumber-reports/cucumber.json"},
+        tags = "@integration and not @disabled")
 public class CucumberIT {
 
 }

--- a/extensions/extensions-encryption/extensions-encryption-vault-java/src/test/resources/specifications/vault-hashing.feature
+++ b/extensions/extensions-encryption/extensions-encryption-vault-java/src/test/resources/specifications/vault-hashing.feature
@@ -1,7 +1,6 @@
-@integration @vaulthashing
+@disabled @integration @vaulthashing
 Feature: Convert data element to hash
 
-  @disabled
   Scenario Outline: encrypt a given data element and decrypt it using Hashicorp Vault
     Given a data element is provided
     When the data element is encrypted with vault


### PR DESCRIPTION
Cucumber test requires at least one feature to be tested. However, since we are disabling the vault encryption and its unit tests, there is no more integration test left for this feature. We are disabling the cucumber report for now.