### PR TITLE
[#622] fix default configmap value for hive chart

### DIFF
--- a/extensions/extensions-helm/extensions-helm-spark-infrastructure/aissemble-hive-metastore-service-chart/values.yaml
+++ b/extensions/extensions-helm/extensions-helm-spark-infrastructure/aissemble-hive-metastore-service-chart/values.yaml
@@ -70,4 +70,4 @@ configMap:
       - name: javax.jdo.option.ConnectionURL
         value: jdbc:mysql://hive-metastore-db:3306/metastore?createDatabaseIfNotExist=true&amp;allowPublicKeyRetrieval=true&amp;useSSL=false
         description: JDBC connect string for a JDBC metastore
-    properties: {}
+    properties: []


### PR DESCRIPTION
The property `configMap.metastoreServiceConfig.properties` is intended to be a list of objects representing additional configs' name/value/descriptions. However, the default value in `values.yaml` was an empty object/map causing a warning when the chart was used as intended: _cannot overwrite table with non table_.

Unfortunately, the `helm-unittest` plugin does not pick up this scenario, so our automated tests did not catch this and it is unclear why.