### PR TITLE
[#626] delete test project cache on test script failure

### DIFF
--- a/foundation/foundation-archetype/test-project-archetype.sh
+++ b/foundation/foundation-archetype/test-project-archetype.sh
@@ -23,6 +23,17 @@ mkdir -p target/temp
 cd target/temp
 
 #---
+## Capture non-zero exits and clear the build-cache. This prevents the cache from hiding failures.
+#---
+function exit {
+  if [ "$1" -ne 0 ]; then
+    rm -rf ~/.m2/build-cache/v1/com.bah.aiops
+  fi
+  POSIXLY_CORRECT=1; unset exit
+  exit "$1"
+}
+
+#---
 ## Replacement for `sed -i` that formats the command correctly for MacOS and Linux
 ##
 ## @args: $1 and $2 are passed in unchanged to `sed`


### PR DESCRIPTION
Because we now exit with success if the build-cache triggers for the first build of the archetype-test, we must ensure the build cache is cleared on failure. Otherwise a successful first build with a subsequent failure would be covered up by the cache for anything beyond the initial build.