### PR TITLE
[#636] add docker caches to long builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -112,18 +112,18 @@ jobs:
         if: ${{ !cancelled() && steps.cached-docker-build.outputs.cache-hit != 'true' }}
         with:
           path: ~/.docker/cache
-          key: docker-cache-${{ hashFiles('**/Dockerfile') }}
+          key: ${{ steps.cached-docker-build.outputs.cache-primary-key }}
       - name: Save m2 repository cache
         id: save-m2-repo
         uses: runs-on/cache/save@v4
         if: ${{ !cancelled() && steps.cached-m2-repo.outputs.cache-hit != 'true' }}
         with:
           path: ~/.m2/repository
-          key: maven-${{ hashFiles('**/pom.xml') }}
+          key: ${{ steps.cached-m2-repo.outputs.cache-primary-key }}
       - name: Save m2 build cache
         id: save-m2-build
         uses: runs-on/cache/save@v4
         if: ${{ !cancelled() && steps.cached-m2-build.outputs.cache-hit != 'true' }}
         with:
           path: ~/.m2/build-cache
-          key: maven-build-cache-${{ hashFiles('**/pom.xml') }}
+          key: ${{ steps.cached-m2-build.outputs.cache-primary-key }}

--- a/extensions/extensions-docker/aissemble-hive-service/src/main/resources/docker/Dockerfile
+++ b/extensions/extensions-docker/aissemble-hive-service/src/main/resources/docker/Dockerfile
@@ -28,8 +28,8 @@ RUN --mount=source=${BIN_DIR},target=/tmp/bin cd /tmp \
 
 # Update library jars used by Hive and Hadoop
 COPY --chmod=755 ./src/main/resources/scripts/setup.sh $HIVE_HOME/setup.sh
-ADD ${PATCH_DIR}/* /tmp/patch-jars
-RUN $HIVE_HOME/setup.sh /tmp/patch-jars && rm -rf /tmp/patch-jars
+RUN --mount=target=/tmp/patch-jars,type=bind,source=${PATCH_DIR} \
+    $HIVE_HOME/setup.sh /tmp/patch-jars
 
 # Hadoop ships with source jars, which aren't necessary and bloat the image, also remove YARN support as we only support K8s
 RUN rm -rf $HADOOP_HOME/share/hadoop/common/sources \

--- a/extensions/extensions-docker/aissemble-jenkins/aissemble-jenkins-agent/src/main/resources/docker/Dockerfile
+++ b/extensions/extensions-docker/aissemble-jenkins/aissemble-jenkins-agent/src/main/resources/docker/Dockerfile
@@ -2,9 +2,11 @@ FROM docker.io/jenkins/ssh-agent:latest-debian-jdk17
 
 LABEL org.opencontainers.image.source="https://github.com/boozallen/aissemble"
 
-USER root
-RUN apt --yes update && apt install --yes pipx && pipx ensurepath && apt clean
-RUN pipx install poetry
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt --yes update && apt install --yes pipx && pipx ensurepath
+RUN --mount=type=cache,target=/root/.cache/pip \
+    pipx install poetry
 
 RUN mkdir /var/pyenv
 RUN ls -l -a /var/pyenv

--- a/extensions/extensions-docker/aissemble-nvidia/src/main/resources/docker/Dockerfile
+++ b/extensions/extensions-docker/aissemble-nvidia/src/main/resources/docker/Dockerfile
@@ -9,9 +9,9 @@ RUN printf '#!/bin/bash\n\nif [[ "$1" == "-r" ]] ;then\n echo '4.9.250'\n exit\n
 RUN chmod 755 /bin/uname
 # Workaround for ubuntu fix end
 
-RUN apt-get update \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update \
     && apt-get upgrade -y \
     && apt-get install -y openjdk-17-jdk \
-    && update-ca-certificates \
-    && rm -rf /var/lib/apt/lists/* \
-    && apt-get clean
+    && update-ca-certificates

--- a/extensions/extensions-docker/aissemble-spark/pom.xml
+++ b/extensions/extensions-docker/aissemble-spark/pom.xml
@@ -14,49 +14,296 @@
 
     <packaging>docker-build</packaging>
 
+    <properties>
+        <dockerbuild.patch.directory>target/dockerbuild/patch</dockerbuild.patch.directory>
+        <version.netty>4.1.118.Final</version.netty>
+        <version.avro>1.11.4</version.avro>
+        <version.derby>10.16.1.1</version.derby>
+        <version.hive.client>2.3.10</version.hive.client>
+        <version.parquet>1.15.0</version.parquet>
+        <version.zookeeper>3.9.3</version.zookeeper>
+    </properties>
+
     <dependencies>
         <dependency>
-            <groupId>com.boozallen.aissemble</groupId>
-            <artifactId>foundation-messaging-python-service</artifactId>
-            <version>${project.version}</version>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>2.8.9</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>com.boozallen.aissemble</groupId>
-            <artifactId>foundation-messaging-java</artifactId>
-            <version>${project.version}</version>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>33.3.1-jre</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>${project.groupId}</groupId>
-            <artifactId>foundation-core-java</artifactId>
-            <version>${project.version}</version>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>okhttp</artifactId>
+            <version>3.14.9</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-codec-http2</artifactId>
+            <version>${version.netty}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-codec-http</artifactId>
+            <version>${version.netty}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-common</artifactId>
+            <version>${version.netty}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-handler</artifactId>
+            <version>${version.netty}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.avro</groupId>
+            <artifactId>avro-ipc</artifactId>
+            <version>${version.avro}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.avro</groupId>
+            <artifactId>avro-mapred</artifactId>
+            <version>${version.avro}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.avro</groupId>
+            <artifactId>avro</artifactId>
+            <version>${version.avro}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-compress</artifactId>
+            <version>1.27.1</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.16.1</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+            <version>1.17.2</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.derby</groupId>
+            <artifactId>derby</artifactId>
+            <version>${version.derby}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.derby</groupId>
+            <artifactId>derbyshared</artifactId>
+            <version>${version.derby}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.derby</groupId>
+            <artifactId>derbytools</artifactId>
+            <version>${version.derby}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.hadoop.thirdparty</groupId>
+            <artifactId>hadoop-shaded-guava</artifactId>
+            <version>1.3.0</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-client-api</artifactId>
+            <version>${version.hadoop}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-client-runtime</artifactId>
+            <version>${version.hadoop}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-yarn-server-web-proxy</artifactId>
+            <version>${version.hadoop}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.hive</groupId>
+            <artifactId>hive-beeline</artifactId>
+            <version>${version.hive.client}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.hive</groupId>
+            <artifactId>hive-cli</artifactId>
+            <version>${version.hive.client}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.hive</groupId>
+            <artifactId>hive-common</artifactId>
+            <version>${version.hive.client}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.hive</groupId>
+            <artifactId>hive-exec</artifactId>
+            <version>${version.hive.client}</version>
+            <classifier>core</classifier>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.hive</groupId>
+            <artifactId>hive-jdbc</artifactId>
+            <version>${version.hive.client}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.hive</groupId>
+            <artifactId>hive-llap-common</artifactId>
+            <version>${version.hive.client}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.hive</groupId>
+            <artifactId>hive-metastore</artifactId>
+            <version>${version.hive.client}</version>
+            <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>jdk.tools</groupId>
+                    <artifactId>jdk.tools</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.hive</groupId>
+            <artifactId>hive-serde</artifactId>
+            <version>${version.hive.client}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.hive</groupId>
+            <artifactId>hive-shims</artifactId>
+            <version>${version.hive.client}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.hive.shims</groupId>
+            <artifactId>hive-shims-0.23</artifactId>
+            <version>${version.hive.client}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.hive.shims</groupId>
+            <artifactId>hive-shims-common</artifactId>
+            <version>${version.hive.client}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.hive.shims</groupId>
+            <artifactId>hive-shims-scheduler</artifactId>
+            <version>${version.hive.client}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.thrift</groupId>
+            <artifactId>libthrift</artifactId>
+            <version>0.16.0</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.ivy</groupId>
+            <artifactId>ivy</artifactId>
+            <version>2.5.3</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.parquet</groupId>
+            <artifactId>parquet-column</artifactId>
+            <version>${version.parquet}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.parquet</groupId>
+            <artifactId>parquet-format-structures</artifactId>
+            <version>${version.parquet}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.parquet</groupId>
+            <artifactId>parquet-encoding</artifactId>
+            <version>${version.parquet}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.parquet</groupId>
+            <artifactId>parquet-jackson</artifactId>
+            <version>${version.parquet}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.parquet</groupId>
+            <artifactId>parquet-hadoop</artifactId>
+            <version>${version.parquet}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.parquet</groupId>
+            <artifactId>parquet-common</artifactId>
+            <version>${version.parquet}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.zookeeper</groupId>
+            <artifactId>zookeeper-jute</artifactId>
+            <version>${version.zookeeper}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.zookeeper</groupId>
+            <artifactId>zookeeper</artifactId>
+            <version>${version.zookeeper}</version>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 
     <build>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
                 <executions>
                     <execution>
-                        <id>copy-service-jar</id>
-                        <phase>generate-resources</phase>
+                        <id>get-patch-jars</id>
+                        <phase>prepare-package</phase>
                         <goals>
                             <goal>copy-dependencies</goal>
                         </goals>
                         <configuration>
-                            <stripVersion>true</stripVersion>
-                            <includeArtifactIds>foundation-messaging-python-service,foundation-messaging-java,foundation-core-java</includeArtifactIds>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>copy-dependencies</id>
-                        <phase>generate-resources</phase>
-                        <goals>
-                            <goal>copy-dependencies</goal>
-                        </goals>
-                        <configuration>
-                            <stripVersion>false</stripVersion>
-                            <excludeArtifactIds>jboss-annotations-api_1.3_spec,jakarta.activation-api,javax.annotation-api,jboss-jaxb-api_2.3_spec,foundation-messaging-python-service,foundation-messaging-java,foundation-core-java</excludeArtifactIds>
+                            <outputDirectory>${dockerbuild.patch.directory}</outputDirectory>
+                            <excludeTransitive>true</excludeTransitive>
+                            <includeTypes>jar</includeTypes>
+                            <excludeArtifactIds>fermenter-mda,baton-maven-plugin,habushu-maven-plugin,jdk.tools</excludeArtifactIds>
+                            <useRepositoryLayout>true</useRepositoryLayout>
                         </configuration>
                     </execution>
                 </executions>
@@ -64,6 +311,17 @@
             <plugin>
                 <groupId>${group.fabric8.plugin}</groupId>
                 <artifactId>docker-maven-plugin</artifactId>
+                <configuration>
+                    <images>
+                        <image>
+                            <build>
+                                <args>
+                                    <PATCH_DIR>${dockerbuild.patch.directory}</PATCH_DIR>
+                                </args>
+                            </build>
+                        </image>
+                    </images>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/extensions/extensions-docker/aissemble-spark/src/main/resources/docker/Dockerfile
+++ b/extensions/extensions-docker/aissemble-spark/src/main/resources/docker/Dockerfile
@@ -7,6 +7,7 @@ FROM docker.io/apache/spark:${SPARK_VERSION}-scala${SCALA_VERSION}-java17-python
 #pull var from global scope to build stage
 ARG SPARK_VERSION
 ARG HADOOP_VERSION
+ARG PATCH_DIR
 ARG PYTHON_VERSION=3.11
 
 LABEL org.opencontainers.image.source="https://github.com/boozallen/aissemble"
@@ -22,12 +23,16 @@ RUN mkdir $SPARK_HOME/checkpoint && \
   mkdir $SPARK_HOME/logs
 
 # Update repositories and add necessary ones
-RUN apt-get -y update \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get -y update \
     && apt-get install -y software-properties-common \
     && add-apt-repository ppa:deadsnakes/ppa
 
 # git and build-essential are used during pip install of some dependencies (e.g. python-deequ)
-RUN apt-get update -y && apt-get install --assume-yes \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+  apt-get update -y && apt-get install --assume-yes \
   build-essential \
   curl \
   python${PYTHON_VERSION} \
@@ -35,8 +40,6 @@ RUN apt-get update -y && apt-get install --assume-yes \
   python${PYTHON_VERSION}-distutils \
 #Patch for CVE-2023-4863: upgrade libwebp7 to 1.3.2+
   && apt-get upgrade -y libwebp7 \
-  && rm -rf /var/lib/apt/lists/* \
-  && apt-get clean \
   && ln -s /usr/bin/python${PYTHON_VERSION} /usr/bin/python \
 #Patch for CVE-2023-0286: upgrade cryptography to 39.0.1+ (https://github.com/advisories/GHSA-x4qr-2fvf-3mr5) \
   && apt-get remove python3-cryptography -y \
@@ -51,7 +54,8 @@ COPY --from=docker.io/tianon/gosu:1.17-debian /gosu /usr/sbin/gosu
 
 # Update library jars used by Spark and register PySpark as an available python package
 COPY --chmod=755 ./src/main/resources/scripts/setup.sh $SPARK_HOME/setup.sh
-RUN $SPARK_HOME/setup.sh $SPARK_HOME $SPARK_VERSION $HADOOP_VERSION
+RUN --mount=target=/tmp/patch-jars,type=bind,source=${PATCH_DIR} \
+    $SPARK_HOME/setup.sh /tmp/patch-jars $SPARK_HOME $SPARK_VERSION $HADOOP_VERSION
 
 ## Add spark configurations
 COPY ./src/main/resources/conf/ $SPARK_HOME/conf/

--- a/extensions/extensions-docker/aissemble-spark/src/main/resources/scripts/setup.sh
+++ b/extensions/extensions-docker/aissemble-spark/src/main/resources/scripts/setup.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 ###
 # #%L
 # aiSSEMBLE::Extensions::Docker::Spark
@@ -10,53 +10,82 @@
 ###
 
 #---
-## Updates a Spark's JARs based on a list of Maven coordinates
-##
-## @Arguments: list of maven coordinates in `group:artifact:version:classifier` format where `:classifier` is optional
+## Same as `cut` but reads fields from the end. E.g.:
+##     cutr -d : -f 2 <<< "one:two:three:four"
+##     > 'three'
+## Note that open-ended ranges might be opposite of intuition if you think of them as "before" and "after"
+##     cutr -d : -f -2 <<< "one:two:three:four"
+##     > 'three:four'
+##     cutr -d : -f 2- <<< "one:two:three:four"
+##     > 'one:two:three'
 #---
-update_maven_jars() {
-  echo
-  echo "Updating jars in $SPARK_JARS ($SPARK_VERSION)"
-  echo
-  mvnjars="$1"
+cutr() {
+  rev | cut "$@" | rev
+}
 
-  mkdir /tmp/jars || exit $?
-  for gav in $mvnjars; do
+#---
+## Patches a lib directory with given updated JARs by matching on base name. For example, given the replace directory has
+## the jar `commons-math-3.4.jar` and the target directory has `commons-math-2.1.jar`, the existing 2.1 JAR is deleted
+## and the updated 3.4 jar is copied into the directory.
+##
+## @Param: location of replacement JARs
+## @Param: location to search for JARs to replace
+#---
+update_jars() {
+  updated="$1"
+  target="$2"
+  echo
+  echo "Updating jars in $target with jars from $updated"
+  echo
+
+  while read -r jarpath; do
     #Parse GAV into separate variables, classifier may or may not be present as the last item
-    group=$(echo "$gav" | cut -d : -f 1)
-    artifact=$(echo "$gav" | cut -d : -f 2)
-    version=$(echo "$gav" | cut -d : -f 3)
-    classifier=$(echo "$gav" | cut -d : -f 4)
-    if [ -n "$classifier" ]; then
-      classifier="-$classifier"
-    fi
+    group=$(echo "$jarpath" | cutr -d / -f 4-)
+    group=$(echo "${group#$updated/}" | tr / .)
+    artifact=$(echo "$jarpath" | cutr -d / -f 3)
+    version=$(echo "$jarpath" | cutr -d / -f 2)
+    jar=$(echo "$jarpath" | cutr -d / -f 1)
+    classifier=${jar#$artifact-$version}
+    classifier=${classifier%\.jar}
     echo "-------------------------------------------"
-    echo "Replacing $group:$artifact with updated JAR"
-
-    # Fetch the updated JAR from Maven Central
-    jar="$artifact-$version$classifier.jar"
-    path=$(echo "$group" | sed 's|\.|/|g')
-    url="https://repo1.maven.org/maven2/$path/$artifact/$version/$jar"
-    echo "Fetching $url"
-    wget -q "$url" -P /tmp/jars || exit $?
+    echo "Replacing $group:$artifact with updated JAR ($artifact-$version$classifier.jar)"
 
     # Find the old jar that is being replaced
-    replaceable=$(find / -type f -regex "$SPARK_JARS/$artifact-[^-]*$classifier.jar" 2>/dev/null)
-    echo "Replacing '$replaceable'"
-    count=$(echo "$replaceable" | wc -w )
-    if [  "$count" -gt 1 ]; then
-      echo "Unexpected number of matches to replace!"
-      exit 1
-    fi
-
-    # Delete the old JAR and move the new one into the Spark classpath
-  if [ -n "$replaceable" ]; then
+    REPLACED=1
+    echo find "$target" -type f -regex ".*/$artifact-[^-]*$classifier.jar"
+     while read -r replaceable; do
+      echo "  replacing '$replaceable'"
       rm "$replaceable" || exit $?
+      cp "$jarpath" "$(dirname "$replaceable")" || exit $?
+      REPLACED=0
+    done < <(find "$target" -type f -regex ".*/$artifact-[^-]*$classifier.jar")
+    # Guava version sometimes includes `-jre` at the end
+    if [ "$artifact" = "guava" ]; then
+      #We could do something fancier/generic like count dashes in version and use sed regex like:
+      #find "$target" -type f -regextype sed -regex ".*/$artifact\(-[^-]*\)\{1,$(VER_DASH_COUNT+1)\}.jar"
+      # But only Guava has this issue so it's not worth it.
+      while read -r replaceable; do
+        echo "  replacing '$replaceable'"
+        rm "$replaceable" || exit $?
+        cp "$jarpath" "$(dirname "$replaceable")" || exit $?
+        REPLACED=0
+      done < <(find "$target" -type f -regex ".*/$artifact-[^-]*-jre.jar")
     fi
-    mv "/tmp/jars/$jar" "$SPARK_JARS" || exit $?
+    if [ $REPLACED -ne 0 ]; then
+      #derbyshared and derbytools provide classes that were extraced from derby in the newer version
+      if [ $artifact = "derbyshared" ] || [ $artifact = "derbytools" ]; then
+          echo "  no existing jars -- adding '$jar'"
+          cp "$jarpath" "$target" || exit $?
+      else
+        echo "No replacement candidates found for $jar"
+        exit 1
+      fi
+    fi
     echo
-  done
+  done < <(find "$updated" -type f -name '*.jar')
 }
+
+
 
 #---
 ## Updates Spark's jackson-mapper JAR to a RedHat version
@@ -89,7 +118,7 @@ remove_mesos() {
 ## @param: the Spark version
 #---
 register_pyspark() {
-  echo "Register PySpark installation with PIP"
+  echo "Register PySpark installation with PIP (ver. $2)"
   # Following approach mentioned in https://github.com/pypa/pip/issues/10458
   echo "\
 from setuptools import setup
@@ -102,52 +131,12 @@ setup(
   python3 -m pip install "$1/python"
 }
 
-SPARK_JARS="$1/jars"
-SPARK_VERSION=$2
-HADOOP_VERSION=$3
+PATCH_JARS="$1"
+SPARK_JARS="$2/jars"
+SPARK_VERSION=$3
+HADOOP_VERSION=$4
 
-update_maven_jars "com.google.code.gson:gson:2.8.9 \
-                   com.google.guava:guava:33.3.1-jre \
-                   com.squareup.okhttp3:okhttp:3.14.9 \
-                   io.netty:netty-codec-http2:4.1.116.Final \
-                   io.netty:netty-codec-http:4.1.116.Final \
-                   io.netty:netty-common:4.1.116.Final \
-                   io.netty:netty-handler:4.1.118.Final \
-                   org.apache.avro:avro-ipc:1.11.4 \
-                   org.apache.avro:avro-mapred:1.11.4 \
-                   org.apache.avro:avro:1.11.4 \
-                   org.apache.commons:commons-compress:1.27.1 \
-                   commons-io:commons-io:2.16.1 \
-                   commons-codec:commons-codec:1.17.2 \
-                   org.apache.derby:derby:10.16.1.1 \
-                   org.apache.derby:derbytools:10.16.1.1 \
-                   org.apache.derby:derbyshared:10.16.1.1 \
-                   org.apache.hadoop.thirdparty:hadoop-shaded-guava:1.3.0 \
-                   org.apache.hadoop:hadoop-client-api:$HADOOP_VERSION \
-                   org.apache.hadoop:hadoop-client-runtime:$HADOOP_VERSION \
-                   org.apache.hadoop:hadoop-yarn-server-web-proxy:$HADOOP_VERSION \
-                   org.apache.hive:hive-beeline:2.3.10 \
-                   org.apache.hive:hive-cli:2.3.10 \
-                   org.apache.hive:hive-common:2.3.10 \
-                   org.apache.hive:hive-exec:2.3.10:core \
-                   org.apache.hive:hive-jdbc:2.3.10 \
-                   org.apache.hive:hive-llap-common:2.3.10 \
-                   org.apache.hive:hive-metastore:2.3.10 \
-                   org.apache.hive:hive-serde:2.3.10 \
-                   org.apache.hive:hive-shims:2.3.10 \
-                   org.apache.hive.shims:hive-shims-0.23:2.3.10 \
-                   org.apache.hive.shims:hive-shims-common:2.3.10 \
-                   org.apache.hive.shims:hive-shims-scheduler:2.3.10 \
-                   org.apache.thrift:libthrift:0.16.0 \
-                   org.apache.ivy:ivy:2.5.3 \
-                   org.apache.parquet:parquet-column:1.15.0 \
-                   org.apache.parquet:parquet-format-structures:1.15.0 \
-                   org.apache.parquet:parquet-encoding:1.15.0 \
-                   org.apache.parquet:parquet-jackson:1.15.0 \
-                   org.apache.parquet:parquet-hadoop:1.15.0 \
-                   org.apache.parquet:parquet-common:1.15.0 \
-                   org.apache.zookeeper:zookeeper-jute:3.9.3 \
-                   org.apache.zookeeper:zookeeper:3.9.3"
+update_jars "$PATCH_JARS" "$SPARK_JARS"
 update_jackson '1.9.14.jdk17-redhat-00001'
 remove_mesos
-register_pyspark $SPARK_HOME $SPARK_VERSION
+register_pyspark "$SPARK_HOME" "$SPARK_VERSION"

--- a/extensions/extensions-docker/aissemble-versioning/pom.xml
+++ b/extensions/extensions-docker/aissemble-versioning/pom.xml
@@ -19,6 +19,9 @@
             <plugin>
                 <groupId>org.technologybrewery.habushu</groupId>
                 <artifactId>habushu-maven-plugin</artifactId>
+                <configuration>
+                  <updateDockerfile>false</updateDockerfile>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>${group.fabric8.plugin}</groupId>

--- a/extensions/extensions-docker/aissemble-versioning/src/main/resources/docker/Dockerfile
+++ b/extensions/extensions-docker/aissemble-versioning/src/main/resources/docker/Dockerfile
@@ -1,7 +1,12 @@
 #HABUSHU_BUILDER_STAGE - HABUSHU GENERATED CODE (DO NOT MODIFY)
 FROM docker.io/python:3.11 AS habushu_builder
+
+ENV POETRY_CACHE_DIR="/.cache/pypoetry"
+
 # Poetry and supporting plugin installations
-RUN python -m ensurepip --upgrade && \
+RUN --mount=type=cache,target=/root/.cache/pip \
+    --mount=type=cache,target=/.cache/pypoetry/ \
+    python -m ensurepip --upgrade && \
     pip install poetry && \
     poetry self add poetry-monorepo-dependency-plugin && \
     poetry self add poetry-plugin-bundle
@@ -12,7 +17,6 @@ RUN find . -type f -name pyproject.toml -exec sed -i 's|develop[[:blank:]]*=[[:b
 
 USER root
 WORKDIR /work-dir/containerize-support/foundation/aissemble-foundation-versioning-service
-ENV POETRY_CACHE_DIR="/.cache/pypoetry"
 
 # export target project's virtual environment to /opt/venv
 RUN --mount=type=cache,target=/.cache/pypoetry/ \
@@ -43,11 +47,11 @@ WORKDIR /app
 
 # Install Java (needed for Maven)
 RUN mkdir -p /usr/share/man/man1
-RUN echo "deb http://deb.debian.org/debian bullseye main" >> /etc/apt/sources.list  \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    echo "deb http://deb.debian.org/debian bullseye main" >> /etc/apt/sources.list  \
     && apt-get update -y \
-    && apt-get install -y openjdk-11-jre-headless \
-    && rm -rf /var/lib/apt/lists/* \
-    && apt-get clean
+    && apt-get install -y openjdk-11-jre-headless
 
 # Copy over Maven
 COPY --from=builder /opt/apache-maven-* /opt/apache-maven


### PR DESCRIPTION
Updates the images with the longest build-times to layer in a mounted Docker cache for apt, poetry, and pip.  Also updates the Spark jars update logic to follow the `aissemble-hive-service` pattern of downloading the updated jars during the Maven build to utilize the m2 cache instead of using `wget` during the image build itself.

Updated build workflow to use the cache key calculated at start, since the generated `target` directories throw off the hash calculation.