### PR TITLE
[#642] various build optimizations

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,6 +27,7 @@ jobs:
     env:
       DOCKER_CONFIG: /home/runner/.docker
       RUNS_ON_S3_BUCKET_CACHE: aissemble-github-cache
+      DOCKER_BUILDER_NAME: k8s-multiarch
     steps:
       - uses: actions/checkout@v4
         with:
@@ -61,18 +62,14 @@ jobs:
         if: ${{ ! github.event.schedule }}
         with:
           path: ~/.m2/repository
-          key: maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            maven-
+          key: maven-repo-cache
       - name: Load m2 build cache
         id: cached-m2-build
         uses: runs-on/cache/restore@v4
         if: ${{ ! github.event.schedule }}
         with:
           path: ~/.m2/build-cache
-          key: maven-build-cache-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            maven-build-cache-
+          key: maven-build-cache
       #NB: Not saving poetry cache on failure in case it's a failure caused by an in-flight python package release
       - name: Poetry cache
         id: cached-poetry
@@ -83,6 +80,26 @@ jobs:
           key: poetry-cache-${{ hashFiles('**/pyproject.toml') }}
           restore-keys: |
             poetry-cache-
+      - name: Hash starting Docker cache
+        id: docker-cache-start
+        uses: actions/github-script@v7
+        with:
+          result-encoding: string
+          script: await glob.hashFiles(`~/.docker/cache/**`, require('os').homedir())
+      - name: Provision Docker builder
+        id: provision-docker-builder
+        run: |
+          docker builder create --name=$DOCKER_BUILDER_NAME \
+                                --bootstrap \
+                                --driver=kubernetes \
+                                --platform=linux/amd64 \
+                                --driver-opt="nodeselector=kubernetes.io/arch=amd64","image=docker.io/moby/buildkit:v0.19.0"
+          docker builder create --name=$DOCKER_BUILDER_NAME \
+                                --append \
+                                --bootstrap \
+                                --driver=kubernetes \
+                                --platform=linux/arm64 \
+                                --driver-opt="nodeselector=kubernetes.io/arch=arm64","image=docker.io/moby/buildkit:v0.19.0"
       # Generate the settings.xml for ghcr.io, pypi, & dev-pypi server profiles
       - name: Create settings.xml
         id: create-settings-xml
@@ -106,24 +123,35 @@ jobs:
         uses: advanced-security/maven-dependency-submission-action@v4
         with:
           settings-file: ${{ steps.create-settings-xml.outputs.HOME_DIR }}/.m2/settings.xml
+      - name: Teardown Docker builder
+        id: teardown-docker-builder
+        if: always()
+        run: |
+          docker builder rm -f $DOCKER_BUILDER_NAME
+      - name: Hash final Docker cache
+        id: docker-cache-final
+        uses: actions/github-script@v7
+        with:
+          result-encoding: string
+          script: await glob.hashFiles(`~/.docker/cache/**`, require('os').homedir())
       - name: Save docker build cache
         id: save-docker-build
         uses: runs-on/cache/save@v4
-        if: ${{ !cancelled() && steps.cached-docker-build.outputs.cache-hit != 'true' }}
+        if: ${{ !cancelled() && steps.docker-cache-start.outputs.result != steps.docker-cache-final.outputs.result }}
         with:
           path: ~/.docker/cache
           key: ${{ steps.cached-docker-build.outputs.cache-primary-key }}
       - name: Save m2 repository cache
         id: save-m2-repo
         uses: runs-on/cache/save@v4
-        if: ${{ !cancelled() && steps.cached-m2-repo.outputs.cache-hit != 'true' }}
+        if: ${{ !cancelled() }}
         with:
           path: ~/.m2/repository
-          key: ${{ steps.cached-m2-repo.outputs.cache-primary-key }}
+          key: maven-repo-cache
       - name: Save m2 build cache
         id: save-m2-build
         uses: runs-on/cache/save@v4
-        if: ${{ !cancelled() && steps.cached-m2-build.outputs.cache-hit != 'true' }}
+        if: ${{ !cancelled() }}
         with:
           path: ~/.m2/build-cache
-          key: ${{ steps.cached-m2-build.outputs.cache-primary-key }}
+          key: maven-build-cache

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -551,7 +551,7 @@
                                                 </driverOpts>
                                                 <!-- When performing multi-platform builds on k8s driver with local external cache, some ADD/COPY layers end up with
                                                      colliding hashes between the two architectures. This results in a cache export error that should be ignored. -->
-                                                <cacheTo>type=local,dest=${user.home}/.docker/cache,mode=max,ignore-error=true</cacheTo>
+                                                <cacheTo>type=local,dest=${user.home}/.docker/cache,ignore-error=true</cacheTo>
                                                 <cacheFrom>type=local,src=${user.home}/.docker/cache</cacheFrom>
                                             </buildx>
                                         </build>
@@ -968,6 +968,13 @@ To suppress enforce-helm-version rule, you must add following plugin to the root
                                 <rewriteLocalPathDepsInArchives>true</rewriteLocalPathDepsInArchives>
                                 <addPypiRepoAsPackageSources>false</addPypiRepoAsPackageSources>
                                 <useDevRepository>true</useDevRepository>
+                            </configuration>
+                        </plugin>
+                        <plugin>
+                            <groupId>${group.fabric8.plugin}</groupId>
+                            <artifactId>docker-maven-plugin</artifactId>
+                            <configuration>
+                                <buildArchiveOnly>true</buildArchiveOnly>
                             </configuration>
                         </plugin>
                     </plugins>

--- a/extensions/extensions-docker/aissemble-fastapi/pom.xml
+++ b/extensions/extensions-docker/aissemble-fastapi/pom.xml
@@ -30,6 +30,9 @@
                     <plugin>
                         <groupId>${group.fabric8.plugin}</groupId>
                         <artifactId>docker-maven-plugin</artifactId>
+                        <configuration>
+                            <buildArchiveOnly>false</buildArchiveOnly>
+                        </configuration>
                         <executions>
                             <execution>
                                 <id>test-image</id>

--- a/extensions/extensions-docker/aissemble-hive-service/pom.xml
+++ b/extensions/extensions-docker/aissemble-hive-service/pom.xml
@@ -226,6 +226,9 @@
                     <plugin>
                         <groupId>${group.fabric8.plugin}</groupId>
                         <artifactId>docker-maven-plugin</artifactId>
+                        <configuration>
+                            <buildArchiveOnly>false</buildArchiveOnly>
+                        </configuration>
                         <executions>
                             <execution>
                                 <id>test-image</id>

--- a/extensions/extensions-docker/aissemble-pipeline-invocation/pom.xml
+++ b/extensions/extensions-docker/aissemble-pipeline-invocation/pom.xml
@@ -62,13 +62,13 @@
                     <plugin>
                         <groupId>${group.fabric8.plugin}</groupId>
                         <artifactId>docker-maven-plugin</artifactId>
+                        <configuration>
+                            <buildArchiveOnly>false</buildArchiveOnly>
+                        </configuration>
                         <executions>
                             <execution>
                                 <id>test-image</id>
                                 <phase>integration-test</phase>
-                                <goals>
-                                    <goal>start</goal>
-                                </goals>
                                 <configuration>
                                     <images>
                                         <image>

--- a/extensions/extensions-docker/aissemble-spark-infrastructure/pom.xml
+++ b/extensions/extensions-docker/aissemble-spark-infrastructure/pom.xml
@@ -100,6 +100,9 @@
                     <plugin>
                         <groupId>${group.fabric8.plugin}</groupId>
                         <artifactId>docker-maven-plugin</artifactId>
+                        <configuration>
+                            <buildArchiveOnly>false</buildArchiveOnly>
+                        </configuration>
                         <executions>
                             <execution>
                                 <id>test-image</id>

--- a/extensions/extensions-docker/aissemble-spark/pom.xml
+++ b/extensions/extensions-docker/aissemble-spark/pom.xml
@@ -334,13 +334,13 @@
                     <plugin>
                         <groupId>${group.fabric8.plugin}</groupId>
                         <artifactId>docker-maven-plugin</artifactId>
+                        <configuration>
+                            <buildArchiveOnly>false</buildArchiveOnly>
+                        </configuration>
                         <executions>
                             <execution>
                                 <id>test-image</id>
                                 <phase>integration-test</phase>
-                                <goals>
-                                    <goal>start</goal>
-                                </goals>
                                 <configuration>
                                     <images>
                                         <image>

--- a/extensions/extensions-docker/pom.xml
+++ b/extensions/extensions-docker/pom.xml
@@ -150,78 +150,36 @@
         <profile>
             <id>gh-build</id>
             <properties>
-                <docker.builder.name>k8s-multiarch</docker.builder.name>
-                <!-- Ideally, we'd pass this in with `config` flag while provisioning the builder, but it doesn't appear to be working. -->
+                <docker.builder.name>${env.DOCKER_BUILDER_NAME}</docker.builder.name>
                 <docker.builder.stateDir>~/.docker</docker.builder.stateDir>
             </properties>
             <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.codehaus.mojo</groupId>
-                        <artifactId>exec-maven-plugin</artifactId>
-                        <inherited>false</inherited>
-                        <executions>
-                            <execution>
-                                <id>provision-docker-builder-amd</id>
-                                <phase>initialize</phase>
-                                <goals>
-                                    <goal>exec</goal>
-                                </goals>
-                                <configuration>
-                                    <executable>docker</executable>
-                                    <arguments>
-                                        <argument>builder</argument>
-                                        <argument>create</argument>
-                                        <argument>--name=${docker.builder.name}</argument>
-                                        <argument>--bootstrap</argument>
-                                        <argument>--driver=kubernetes</argument>
-                                        <argument>--platform=linux/amd64</argument>
-                                        <argument>--driver-opt="nodeselector=kubernetes.io/arch=amd64","image=docker.io/moby/buildkit:v0.19.0"</argument>
-                                    </arguments>
-                                </configuration>
-                            </execution>
-                            <execution>
-                                <id>provision-docker-builder-arm</id>
-                                <phase>initialize</phase>
-                                <goals>
-                                    <goal>exec</goal>
-                                </goals>
-                                <configuration>
-                                    <executable>docker</executable>
-                                    <arguments>
-                                        <argument>builder</argument>
-                                        <argument>create</argument>
-                                        <argument>--name=${docker.builder.name}</argument>
-                                        <argument>--bootstrap</argument>
-                                        <argument>--append</argument>
-                                        <argument>--driver=kubernetes</argument>
-                                        <argument>--platform=linux/arm64</argument>
-                                        <argument>--driver-opt="nodeselector=kubernetes.io/arch=arm64","image=docker.io/moby/buildkit:v0.19.0"</argument>
-                                    </arguments>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
                 <pluginManagement>
                     <plugins>
                         <plugin>
                             <groupId>${group.fabric8.plugin}</groupId>
                             <artifactId>docker-maven-plugin</artifactId>
+                            <configuration>
+                                <images>
+                                    <image>
+                                        <build>
+                                            <buildx>
+                                                <builderName>${docker.builder.name}</builderName>
+                                                <dockerStateDir>${docker.builder.stateDir}</dockerStateDir>
+                                            </buildx>
+                                        </build>
+                                    </image>
+                                </images>
+                            </configuration>
                             <executions>
                                 <execution>
                                     <id>default-push</id>
-                                    <phase>deploy</phase>
-                                    <goals>
-                                        <goal>push</goal>
-                                    </goals>
                                     <configuration>
                                         <images>
                                             <image>
                                                 <build>
                                                     <buildx>
                                                         <builderName>${docker.builder.name}</builderName>
-                                                        <dockerStateDir>${docker.builder.stateDir}</dockerStateDir>
                                                     </buildx>
                                                 </build>
                                             </image>

--- a/foundation/foundation-archetype/test-project-archetype.sh
+++ b/foundation/foundation-archetype/test-project-archetype.sh
@@ -269,6 +269,10 @@ echo "{
 # Thus not updating it with file contents with manual actions
 echo -e "\n# maven-suppress-warnings" >> Tiltfile
 
+echo -e "\nINFO: updating the test-generator-deploy/pom.xml based on static code as it's hard to predict\n"
+plugins=$(esc < ../../../plugins-to-add-to-archetype_test-generator-deploy_pom.xml)
+sub "s/ *<\/plugins>/$plugins        <\/plugins>/" test-generator-deploy/pom.xml
+
 echo -e "\nINFO: Running full build to generate project structure\n"
 updates=false
 if runBuildAndUpdateDeploy; then
@@ -308,13 +312,12 @@ cd ../..
 echo -e "\nINFO: Generating project structure for ml pipelines\n"
 runBuildAndUpdateDeploy
 
-echo -e "\nINFO: updating the test-generator-deploy/pom.xml based on static code as it's hard to predict\n"
-plugins=$(esc < ../../../plugins-to-add-to-archetype_test-generator-deploy_pom.xml)
-sub "s/ *<\/plugins>/$plugins        <\/plugins>/" test-generator-deploy/pom.xml
+echo -e "\nINFO: Running final build to ensure success"
+./mvnw clean install || { echo -e '\n\n\t**** MAVEN BUILD FAILED ****\n\n' ; exit 1; }
 
-echo -e "\nINFO: Running full build to check that the build passes w/o any manual actions needed\n"
+echo -e "\nINFO: Running fermenter generation to check for left over manual actions\n"
 # NOTE: because fermenter results are cached, the build-cache will hide remaining manual actions that were missed in previous steps
-./mvnw clean install -Dmaven.build.cache.skipCache -Dfermenter.display.message.keys=true | tee >(awk '/WARNING/ {print}' > maven-build.log) \
+./mvnw clean generate-sources -Dmaven.build.cache.skipCache -Dfermenter.display.message.keys=true | tee >(awk '/WARNING/ {print}' > maven-build.log) \
     || { echo -e '\n\n\t**** MAVEN BUILD FAILED ****\n\n' ; exit 1; }
 if grep -iq 'Manual action' maven-build.log; then
   echo -e "\n\n **** ERROR: Manual action still found in build **** \n    Look at **archetype/target/temp/test-generator/maven-build.log** to see what the problem was. \n\n"


### PR DESCRIPTION
### Docker Improvements:
Moves the provisioning and teardown of the k8s docker builder to the GH action to avoid the Maven build cache skipping the logic. Reduces the cache level to the default `min` instead of max, as it _appears_ that the layer cache isn't really working with the k8s builder, just the base image cache. Skips the image build in CI by default (like the previous behavior) with images that have tests specifically turning the image build back on to ensure the tests are run against the latest image.

### Archetype Improvements:
Uses generate-sources for final check in archetype test. We still do a final build to verify the project builds successfully, but the check for manual actions is done separately to avoid a full rebuild. This should save about 9-10 minutes.

### GH Cache Improvements:
Uses the `github-script` action to call the same hashing function used by the `runs-on/cache` action to detect whether caches actually had their contents modified, regardless of cache-hit. This saves time when some POM or Dockerfile change did not actually result in new dependencies, or new layers. Because of the inherent limitations of the way the gh runner logic parses [`hashFiles`](https://github.com/actions/runner/blob/c1095ae2d100886a7865f466357f09ef30dec1b9/src/Runner.Worker/Expressions/HashFilesFunction.cs#L44) we aren't able to directly call `hashFiles` with a [different working directory](https://github.com/actions/toolkit/issues/1035#issuecomment-1678272606) so instead, we use the `github-script` action to call `glob.hashFiles` directly.