### PR TITLE
[#639] move spark, hive, hadoop jars out of pipeline shaded jar

### DIFF
--- a/DRAFT_RELEASE_NOTES.md
+++ b/DRAFT_RELEASE_NOTES.md
@@ -1,5 +1,8 @@
 # Major Additions
 
+## Reduced Spark Pipeline Size
+We have pulled the Spark, Hadoop and Hive dependencies out of the shaded pipeline jar since they are already provided by Spark. This change can reduce the spark worker Docker image size and help resolve future CVEs faster.
+
 # Breaking Changes
 _Note: instructions for adapting to these changes are outlined in the upgrade instructions below._
 
@@ -44,6 +47,7 @@ To reduce burden of upgrading aiSSEMBLE, the Baton project is used to automate t
 | upgrade-v1-chart-files-aissemble-version-migration | Updates the docker image tags within your project's deployment resources (`<YOUR_PROJECT>-deploy/src/main/resources/apps/`) to use the latest version of the aiSSEMBLE       |
 | data-encryption-removal-pom-migration              | Remove the data encryption dependencies from the pom file                                                                                                                    |
 | data-encryption-removal-pyproject-migration        | Remove the data encryption dependencies from the pyproject.toml file                                                                                                         |
+| spark-provided-dependency-migration                | Remove the Hadoop, Hive, and Spark dependencies from the pipeline shaded jar                                                                                                 |
 
 To deactivate any of these migrations, add the following configuration to the `baton-maven-plugin` within your root `pom.xml`:
 
@@ -119,9 +123,10 @@ values.yaml file to enable configuration store access vault:
 
 ## Final Steps - Required for All Projects
 ### Finalizing the Upgrade
-1. Run `./mvnw clean install` and resolve any manual actions that are suggested
+1. Run `./mvnw org.technologybrewery.baton:baton-maven-plugin:baton-migrate` to apply the automatic migrations
+2. Run `./mvnw clean install` and resolve any manual actions that are suggested
     - **NOTE:** This will update any aiSSEMBLE dependencies in 'pyproject.toml' files automatically
-2. Repeat the previous step until all manual actions are resolved
+3. Repeat the previous step until all manual actions are resolved
 
 # What's Changed
 _to be auto-generated when published_

--- a/extensions/extensions-data-delivery/extensions-data-delivery-spark-neo4j/pom.xml
+++ b/extensions/extensions-data-delivery/extensions-data-delivery-spark-neo4j/pom.xml
@@ -15,15 +15,21 @@
 
     <dependencies>
         <dependency>
-            <groupId>${project.groupId}</groupId>
-            <artifactId>extensions-data-delivery-spark</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-
-        <dependency>
             <groupId>org.neo4j</groupId>
             <artifactId>neo4j-connector-apache-spark_2.12</artifactId>
             <version>${version.neo4j}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.spark</groupId>
+            <artifactId>spark-sql-api_2.12</artifactId>
+            <version>${version.spark}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.spark</groupId>
+            <artifactId>spark-sql_2.12</artifactId>
+            <version>${version.spark}</version>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 

--- a/extensions/extensions-data-delivery/extensions-data-delivery-spark-postgres/pom.xml
+++ b/extensions/extensions-data-delivery/extensions-data-delivery-spark-postgres/pom.xml
@@ -15,12 +15,6 @@
 
     <dependencies>
         <dependency>
-            <groupId>${project.groupId}</groupId>
-            <artifactId>extensions-data-delivery-spark</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-
-        <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
             <version>${version.postgresql}</version>

--- a/extensions/extensions-data-delivery/extensions-data-delivery-spark/pom.xml
+++ b/extensions/extensions-data-delivery/extensions-data-delivery-spark/pom.xml
@@ -62,11 +62,13 @@
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-core_2.12</artifactId>
             <version>${version.spark}</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-hive_2.12</artifactId>
             <version>${version.spark}</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>mysql</groupId>
@@ -77,16 +79,19 @@
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-streaming_2.12</artifactId>
             <version>${version.spark}</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-sql_2.12</artifactId>
             <version>${version.spark}</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-catalyst_2.12</artifactId>
             <version>${version.spark}</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
@@ -110,6 +115,7 @@
             <groupId>io.delta</groupId>
             <artifactId>delta-spark_2.12</artifactId>
             <version>${version.delta}</version>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>

--- a/extensions/extensions-metadata-service/pom.xml
+++ b/extensions/extensions-metadata-service/pom.xml
@@ -113,6 +113,36 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.apache.spark</groupId>
+            <artifactId>spark-core_2.12</artifactId>
+            <version>${version.spark}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.spark</groupId>
+            <artifactId>spark-hive_2.12</artifactId>
+            <version>${version.spark}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.spark</groupId>
+            <artifactId>spark-streaming_2.12</artifactId>
+            <version>${version.spark}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.spark</groupId>
+            <artifactId>spark-sql_2.12</artifactId>
+            <version>${version.spark}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.spark</groupId>
+            <artifactId>spark-catalyst_2.12</artifactId>
+            <version>${version.spark}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <!-- Spark hasn't migrated to Jakarta packages yet. Will need to shade it if we want to fully migrate. -->
             <!-- See https://github.com/apache/incubator-hugegraph-toolchain/issues/464 -->
             <groupId>javax.servlet</groupId>

--- a/extensions/extensions-transform/extensions-transform-spark-java/pom.xml
+++ b/extensions/extensions-transform/extensions-transform-spark-java/pom.xml
@@ -37,9 +37,21 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>com.boozallen.aissemble</groupId>
+            <artifactId>foundation-core-java</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-sql_2.12</artifactId>
             <version>${version.spark}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.spark</groupId>
+            <artifactId>spark-sql-api_2.12</artifactId>
+            <version>${version.spark}</version>
+            <scope>provided</scope>
         </dependency>
 
         <!-- Test Dependencies -->
@@ -58,12 +70,6 @@
             <artifactId>foundation-core-java</artifactId>
             <version>${project.version}</version>
             <type>test-jar</type>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.boozallen.aissemble</groupId>
-            <artifactId>extensions-data-delivery-spark</artifactId>
-            <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/foundation/foundation-mda/src/main/resources/templates/data-delivery-data-records/data-delivery-combined-data-records-java.pom.xml.vm
+++ b/foundation/foundation-mda/src/main/resources/templates/data-delivery-data-records/data-delivery-combined-data-records-java.pom.xml.vm
@@ -36,5 +36,35 @@
             <artifactId>smallrye-reactive-messaging-kafka</artifactId>
             <version>${version.smallrye.reactive.messaging}</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.spark</groupId>
+            <artifactId>spark-sql_2.12</artifactId>
+            <version>${version.spark}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.spark</groupId>
+            <artifactId>spark-catalyst_2.12</artifactId>
+            <version>${version.spark}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.spark</groupId>
+            <artifactId>spark-hive_2.12</artifactId>
+            <version>${version.spark}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.spark</groupId>
+            <artifactId>spark-streaming_2.12</artifactId>
+            <version>${version.spark}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.spark</groupId>
+            <artifactId>spark-core_2.12</artifactId>
+            <version>${version.spark}</version>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/foundation/foundation-mda/src/main/resources/templates/data-delivery-data-records/data-delivery-data-spark.pom.xml.vm
+++ b/foundation/foundation-mda/src/main/resources/templates/data-delivery-data-records/data-delivery-data-spark.pom.xml.vm
@@ -36,5 +36,35 @@
             <artifactId>${javaDataRecords}</artifactId>
             <version>#[[${project.version}]]#</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.spark</groupId>
+            <artifactId>spark-sql_2.12</artifactId>
+            <version>${version.spark}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.spark</groupId>
+            <artifactId>spark-catalyst_2.12</artifactId>
+            <version>${version.spark}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.spark</groupId>
+            <artifactId>spark-hive_2.12</artifactId>
+            <version>${version.spark}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.spark</groupId>
+            <artifactId>spark-streaming_2.12</artifactId>
+            <version>${version.spark}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.spark</groupId>
+            <artifactId>spark-core_2.12</artifactId>
+            <version>${version.spark}</version>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/foundation/foundation-upgrade/src/main/java/com/boozallen/aissemble/upgrade/migration/version_specific/SparkProvidedDependenciesMigration.java
+++ b/foundation/foundation-upgrade/src/main/java/com/boozallen/aissemble/upgrade/migration/version_specific/SparkProvidedDependenciesMigration.java
@@ -1,0 +1,104 @@
+package com.boozallen.aissemble.upgrade.migration.version_specific;
+
+/*-
+ * #%L
+ * aiSSEMBLE::Foundation::Upgrade
+ * %%
+ * Copyright (C) 2021 Booz Allen
+ * %%
+ * This software package is licensed under the Booz Allen Public License. All Rights Reserved.
+ * #L%
+ */
+
+import com.boozallen.aissemble.upgrade.migration.AbstractPomMigration;
+import org.apache.maven.model.Dependency;
+import org.apache.maven.model.Model;
+import org.technologybrewery.baton.util.pom.PomHelper;
+import org.technologybrewery.baton.util.pom.PomModifications;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.apache.commons.lang3.StringUtils.repeat;
+import static org.technologybrewery.baton.util.pom.LocationAwareMavenReader.END;
+
+/**
+ * This migration accounts for the update to extensions-data-delivery-spark to set all dependencies provided by Spark to
+ * `<scope>provided</scope>`.  Because of this change, any project that was using those dependencies transitively must
+ * now explicitly declare them.  This migration assumes that any project with a dependency on `extensions-data-delivery`
+ * or any other baseline module that depended on `extensions-data-delivery` was using all the updated dependencies, as
+ * trying to be more accurate would be very complex with little benefit.
+ */
+public class SparkProvidedDependenciesMigration extends AbstractPomMigration {
+    private static final List<String> UPDATED_MODULES = List.of(
+            "extensions-data-delivery-spark",
+            "extensions-data-delivery-spark-neo4j",
+            "extensions-data-delivery-spark-postgres",
+            "extensions-transform-spark-java");
+
+    @Override
+    protected boolean shouldExecuteOnFile(File pomFile) {
+        Model model = PomHelper.getLocationAnnotatedModel(pomFile);
+        if (model.getPackaging().equals("jar")) {
+            return dependsOnUpdatedProject(model) && !getDependenciesToBeAdded(model).isEmpty();
+        }
+        return false;
+    }
+
+    @Override
+    protected boolean performMigration(File pomFile) {
+        Model model = PomHelper.getLocationAnnotatedModel(pomFile);
+        detectAndSetIndent(pomFile);
+        List<String> toAdd = getDependenciesToBeAdded(model);
+        PomModifications modifications = new PomModifications();
+        String content = getDependencies(toAdd);
+        modifications.add(new PomModifications.Insertion(model.getLocation("dependencies" + END), 2, ignore -> content));
+
+        return PomHelper.writeModifications(pomFile, modifications.finalizeMods());
+    }
+
+    private List<String> getDependenciesToBeAdded(Model model) {
+        List<String> depsToAdd = getAllNewDependencies();
+        for (Dependency dependency : model.getDependencies()) {
+            if ("org.apache.spark".equals(dependency.getGroupId())) {
+                depsToAdd.remove(dependency.getArtifactId());
+            }
+        }
+        return depsToAdd;
+    }
+
+    protected boolean dependsOnUpdatedProject(Model model) {
+        List<Dependency> dependencies = model.getDependencies();
+        for (Dependency dependency : dependencies) {
+            if ("com.boozallen.aissemble".equals(dependency.getGroupId()) &&
+                    UPDATED_MODULES.contains(dependency.getArtifactId())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private String getDependencies(List<String> dependencies) {
+        StringBuilder builder = new StringBuilder();
+        for (String depArtifactId : dependencies) {
+            builder.append(repeat(indent, 2)).append("<dependency>\n")
+                    .append(repeat(indent, 3)).append("<groupId>org.apache.spark</groupId>\n")
+                    .append(repeat(indent, 3)).append("<artifactId>").append(depArtifactId).append("</artifactId>\n")
+                    .append(repeat(indent, 3)).append("<version>${version.spark}</version>\n")
+                    .append(repeat(indent, 3)).append("<scope>provided</scope>\n")
+                    .append(repeat(indent, 2)).append("</dependency>\n");
+        }
+        return builder.toString();
+    }
+
+    private List<String> getAllNewDependencies() {
+        List<String> dependenciesList = new ArrayList<>();
+        dependenciesList.add("spark-core_2.12");
+        dependenciesList.add("spark-hive_2.12");
+        dependenciesList.add("spark-streaming_2.12");
+        dependenciesList.add("spark-sql_2.12");
+        dependenciesList.add("spark-catalyst_2.12");
+        return dependenciesList;
+    }
+}

--- a/foundation/foundation-upgrade/src/main/resources/migrations.json
+++ b/foundation/foundation-upgrade/src/main/resources/migrations.json
@@ -24,6 +24,17 @@
             ]
           }
         ]
+      },
+      {
+        "name": "spark-provided-dependency-migration",
+        "implementation": "com.boozallen.aissemble.upgrade.migration.version_specific.SparkProvidedDependenciesMigration",
+        "fileSets": [
+          {
+            "includes": [
+              "pom.xml"
+            ]
+          }
+        ]
       }
     ]
   },

--- a/foundation/foundation-upgrade/src/test/java/com/boozallen/aissemble/upgrade/migration/version_specific/SparkProvidedDependenciesMigrationStep.java
+++ b/foundation/foundation-upgrade/src/test/java/com/boozallen/aissemble/upgrade/migration/version_specific/SparkProvidedDependenciesMigrationStep.java
@@ -1,0 +1,52 @@
+package com.boozallen.aissemble.upgrade.migration.version_specific;
+
+/*-
+ * #%L
+ * aiSSEMBLE::Foundation::Upgrade
+ * %%
+ * Copyright (C) 2021 Booz Allen
+ * %%
+ * This software package is licensed under the Booz Allen Public License. All Rights Reserved.
+ * #L%
+ */
+
+import com.boozallen.aissemble.upgrade.migration.AbstractMigrationTest;
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
+
+public class SparkProvidedDependenciesMigrationStep extends AbstractMigrationTest {
+
+    @Given("a POM contains extensions-data-delivery-spark dependency and {string} hive, spark, hadoop dependencies")
+    public void aPomContainsExtensionsDataDeliverySparkDependencyAndPossibleHiveSparkHadoopDeps(String possible) {
+        String fileName = possible.equals("some")? "some-": "";
+        setTestFileToVersionMigration("SparkProvidedDependenciesMigration", String.format("%spom.xml", fileName));
+    }
+
+    @Given("a POM has no extensions-data-delivery-spark dependency")
+    public void aPomFileHasNoHiveSparkHadoopDependencies() {
+        setTestFileToVersionMigration("SparkProvidedDependenciesMigration", "skip-pom.xml");
+    }
+
+    @Given("a POM with extensions-data-delivery-spark, and hive, spark, hadoop dependencies defined correctly")
+    public void aPomFileHasExpectedHiveSparkHadoopDependencies() {
+        setTestFileToVersionMigration("SparkProvidedDependenciesMigration", "migrated-pom.xml");
+    }
+
+    @When("the 1.13.0 spark pipeline jar dependencies migration executes")
+    public void DataEncryptionRemovalPomMigrationExecutes() {
+        SparkProvidedDependenciesMigration migration = new SparkProvidedDependenciesMigration();
+        performMigration(migration);
+    }
+
+    @Then("the pom file is updated")
+    public void thePomFileIsUpdated() {
+        assertTestFileMatchesExpectedFile("The Pom file is not updated correctly");
+    }
+
+    @Then("the spark pipeline jar dependencies migration is skipped")
+    public void theSparkProvidedDependenciesMigrationIsSkipped() {
+        assertMigrationSkipped();
+    }
+
+}

--- a/foundation/foundation-upgrade/src/test/resources/specifications/version-specific/spark-provided-dependencies-migration.feature
+++ b/foundation/foundation-upgrade/src/test/resources/specifications/version-specific/spark-provided-dependencies-migration.feature
@@ -1,0 +1,21 @@
+Feature: Remove Hive, Spark, and Hadoop from the Spark Pipeline Shaded Jar Dependencies Migration
+
+  Scenario Outline: Migrate the pom files to exclude the hive, spark and hadoop dependencies from shaded jar
+    Given a POM contains extensions-data-delivery-spark dependency and "<includes>" hive, spark, hadoop dependencies
+    When the 1.13.0 spark pipeline jar dependencies migration executes
+    Then the pom file is updated
+
+    Examples:
+      | includes              |
+      | no                   |
+      | some                 |
+
+  Scenario: Skip migration with the pom which has no extensions-data-delivery-spark dependency file
+    Given a POM has no extensions-data-delivery-spark dependency
+    When the 1.13.0 spark pipeline jar dependencies migration executes
+    Then the spark pipeline jar dependencies migration is skipped
+
+  Scenario: Skip migration with the pom which has extensions-data-delivery-spark, hive, spark, hadoop dependencies
+    Given a POM with extensions-data-delivery-spark, and hive, spark, hadoop dependencies defined correctly
+    When the 1.13.0 spark pipeline jar dependencies migration executes
+    Then the spark pipeline jar dependencies migration is skipped

--- a/foundation/foundation-upgrade/src/test/resources/test-files/version-specific/SparkProvidedDependenciesMigration/migration/migrated-pom.xml
+++ b/foundation/foundation-upgrade/src/test/resources/test-files/version-specific/SparkProvidedDependenciesMigration/migration/migrated-pom.xml
@@ -1,19 +1,29 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  aiSSEMBLE::Foundation::Upgrade
+  %%
+  Copyright (C) 2021 Booz Allen
+  %%
+  This software package is licensed under the Booz Allen Public License. All Rights Reserved.
+  #L%
+  -->
+
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>${groupId}</groupId>
-        <artifactId>${parentArtifactId}</artifactId>
-        <version>${version}</version>
+        <groupId>org.test</groupId>
+        <artifactId>test-pipelines</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
     </parent>
 
-    <artifactId>${moduleArtifactId}</artifactId>
+    <artifactId>spark-pipeline</artifactId>
     <packaging>jar</packaging>
 
-    <name>${parentDescriptiveName}::${descriptiveName}</name>
+    <name>Test Project::Pipelines::Spark Pipeline</name>
     <description>${pipeline.description}</description>
 
     <build>
@@ -22,14 +32,14 @@
                 <groupId>org.technologybrewery.fermenter</groupId>
                 <artifactId>fermenter-mda</artifactId>
                 <configuration>
-                    <basePackage>${pipeline.package}</basePackage>
+                    <basePackage>org.test</basePackage>
                     <profile>data-delivery-spark-pipeline</profile>
                     <propertyVariables>
-                        <targetPipeline>${pipeline.name}</targetPipeline>
+                        <targetPipeline>SparkPipeline</targetPipeline>
                         <aissembleVersion>${version.aissemble}</aissembleVersion>
                         <dockerProjectRepositoryUrl>${docker.project.repository.url}</dockerProjectRepositoryUrl>
                     </propertyVariables>
-                    <!-- see ${parentArtifactId} for base configuration settings -->
+                    <!-- see test-pipelines for base configuration settings -->
                 </configuration>
             </plugin>
             <plugin>
@@ -57,7 +67,7 @@
                                 you may need to add additional transformers depending on your implementation. -->
                                 <transformer
                                     implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-                                    <mainClass>${basePackage}.${pipeline.name}Driver</mainClass>
+                                    <mainClass>org.test.SparkPipelineDriver</mainClass>
                                 </transformer>
                                 <transformer
                                     implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
@@ -72,42 +82,81 @@
                                     <!-- It seems the shaded jar only has javax.* providers at the moment. Re-evaluate after JDK 17 upgrade is complete. -->
                                     <resource>META-INF/services/javax.ws.rs.ext.Providers</resource>
                                 </transformer>
-                                #if ($pipeline.fileStores)
-                                <transformer
-                                        implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
-                                    <resource>META-INF/services/org.jclouds.apis.ApiMetadata</resource>
-                                </transformer>
-                                <transformer
-                                        implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
-                                    <resource>META-INF/services/org.jclouds.providers.ProviderMetadata</resource>
-                                </transformer>
-                                #end
                             </transformers>
-                            #if ($pipeline.fileStores)
-                            <!-- Spark relies on older, incompatible versions of several of Google's libraries, but JClouds
-                            depends on newer versions, so re-package Guava, Guice, and Gson libraries under different package
-                            in the shaded JAR. This allows for older versions of these JARs to be on Spark's classpath while
-                            everything within the shaded uber JAR leverages the newer, repackaged versions.
-                            -->
-                            <relocations>
-                                <relocation>
-                                    <pattern>com.google</pattern>
-                                    <shadedPattern>repackaged.com.google</shadedPattern>
-                                    <includes>
-                                        <include>com.google.common.**</include>
-                                        <include>com.google.inject.**</include>
-                                        <include>com.google.gson.**</include>
-                                    </includes>
-                                </relocation>
-                            </relocations>
-                            #end
                         </configuration>
                     </execution>
                 </executions>
             </plugin>
-            #set($mainValuesPath = "src/main/resources/apps")
-            #set($testValuesPath = "src/test/resources/apps")
-            #parse("templates/data-delivery-common/pipeline.chart.pom.configuration.vm")
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>3.1.0</version>
+                <executions>
+                    <execution>
+                        <id>main-chart</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <executable>helm</executable>
+                            <arguments>
+                                <argument>template</argument>
+                                <argument>${aissemble.helm.repo.protocol}://${aissemble.helm.repo}/aissemble-spark-application-chart</argument>
+                                <argument>--version</argument>
+                                <argument>${version.aissemble}</argument>
+                                <argument>--values</argument>
+                                <argument>src/main/resources/apps/spark-pipeline-base-values.yaml,src/main/resources/apps/spark-pipeline-dev-values.yaml</argument>
+                                <argument>-s</argument>
+                                <argument>templates/deployment.yaml</argument>
+                            </arguments>
+                            <outputFile>target/apps/spark-pipeline-dev-chart.yaml</outputFile>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>test-chart</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <executable>helm</executable>
+                            <arguments>
+                                <argument>template</argument>
+                                <argument>${aissemble.helm.repo.protocol}://${aissemble.helm.repo}/aissemble-spark-application-chart</argument>
+                                <argument>--version</argument>
+                                <argument>${version.aissemble}</argument>
+                                <argument>--values</argument>
+                                <argument>src/main/resources/apps/spark-pipeline-base-values.yaml,src/test/resources/apps/spark-pipeline-test-values.yaml</argument>
+                                <argument>-s</argument>
+                                <argument>templates/deployment.yaml</argument>
+                            </arguments>
+                            <outputFile>target/apps/spark-pipeline-test-chart.yaml</outputFile>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>ci-chart</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <executable>helm</executable>
+                            <arguments>
+                                <argument>template</argument>
+                                <argument>${aissemble.helm.repo.protocol}://${aissemble.helm.repo}/aissemble-spark-application-chart</argument>
+                                <argument>--version</argument>
+                                <argument>${version.aissemble}</argument>
+                                <argument>--values</argument>
+                                <argument>src/main/resources/apps/spark-pipeline-base-values.yaml,src/main/resources/apps/spark-pipeline-ci-values.yaml</argument>
+                                <argument>-s</argument>
+                                <argument>templates/deployment.yaml</argument>
+                            </arguments>
+                            <outputFile>target/apps/spark-pipeline-ci-chart.yaml</outputFile>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>net.masterthought</groupId>
                 <artifactId>maven-cucumber-reporting</artifactId>
@@ -151,12 +200,6 @@
             <artifactId>javax.servlet-api</artifactId>
             <version>${version.javax.servlet}</version>
         </dependency>
-        #if ($pipeline.isAlertingSupportNeeded())
-        <dependency>
-            <groupId>com.boozallen.aissemble</groupId>
-            <artifactId>foundation-alerting</artifactId>
-        </dependency>
-        #end
         <dependency>
             <groupId>com.boozallen.aissemble</groupId>
             <artifactId>foundation-pdp-client-java</artifactId>
@@ -165,79 +208,16 @@
             <groupId>com.boozallen.aissemble</groupId>
             <artifactId>extensions-authzforce</artifactId>
         </dependency>
-        #if ($enableSedonaSupport)
-        <dependency>
-            <groupId>org.apache.sedona</groupId>
-            <artifactId>sedona-python-adapter-3.0_2.12</artifactId>
-            <version>${version.sedona}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.sedona</groupId>
-            <artifactId>sedona-viz-3.0_2.12</artifactId>
-            <version>${version.sedona}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.datasyslab</groupId>
-            <artifactId>geotools-wrapper</artifactId>
-            <version>${version.geotools.wrapper}</version>
-        </dependency>
-        #end
-        #if ($enablePostgresSupport)
-        <dependency>
-            <groupId>com.boozallen.aissemble</groupId>
-            <artifactId>extensions-data-delivery-spark-postgres</artifactId>
-        </dependency>
-        #end
-        #if ($enableElasticsearchSupport)
-        <!-- Version must match the version set in the elasticsearch helm chart-->
-        <dependency>
-            <groupId>org.elasticsearch</groupId>
-            <artifactId>elasticsearch-spark-30_2.12</artifactId>
-            <version>${version.elasticsearch}</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.codehaus.janino</groupId>
-            <artifactId>commons-compiler</artifactId>
-            <version>${version.janino}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.codehaus.janino</groupId>
-            <artifactId>janino</artifactId>
-            <version>${version.janino}</version>
-        </dependency>
-        #end
-        #if ($enableNeo4jSupport)
-        <dependency>
-            <groupId>com.boozallen.aissemble</groupId>
-            <artifactId>extensions-data-delivery-spark-neo4j</artifactId>
-        </dependency>
-        #end
-        #if ($pipeline.getDataLineage())
-        <dependency>
-            <groupId>com.boozallen.aissemble</groupId>
-            <artifactId>foundation-data-lineage-java</artifactId>
-        </dependency>
-        #end
         <dependency>
             <groupId>io.smallrye.reactive</groupId>
             <artifactId>smallrye-reactive-messaging-kafka</artifactId>
             <version>${version.smallrye.reactive.messaging}</version>
         </dependency>
-        #if ($pipeline.fileStores)
         <dependency>
-            <groupId>org.apache.jclouds</groupId>
-            <artifactId>jclouds-allblobstore</artifactId>
-            <version>${version.jclouds}</version>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>test-data-records-java</artifactId>
+            <version>${project.version}</version>
         </dependency>
-        #end
-        #if($enableSemanticDataSupport)
-        <dependency>
-            <groupId>#[[${project.groupId}]]#</groupId>
-            <artifactId>${javaDataRecords}</artifactId>
-            <version>#[[${project.version}]]#</version>
-        </dependency>
-        #end
         <!-- Test dependencies: -->
         <dependency>
             <groupId>io.cucumber</groupId>
@@ -271,14 +251,6 @@
             <artifactId>cucumber-reporting</artifactId>
             <scope>test</scope>
         </dependency>
-        #if ($pipeline.fileStores)
-        <dependency>
-            <groupId>org.apache.jclouds.api</groupId>
-            <artifactId>filesystem</artifactId>
-            <version>${version.jclouds}</version>
-            <scope>test</scope>
-        </dependency>
-        #end
         <dependency>
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-core_2.12</artifactId>

--- a/foundation/foundation-upgrade/src/test/resources/test-files/version-specific/SparkProvidedDependenciesMigration/migration/pom.xml
+++ b/foundation/foundation-upgrade/src/test/resources/test-files/version-specific/SparkProvidedDependenciesMigration/migration/pom.xml
@@ -1,19 +1,29 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  aiSSEMBLE::Foundation::Upgrade
+  %%
+  Copyright (C) 2021 Booz Allen
+  %%
+  This software package is licensed under the Booz Allen Public License. All Rights Reserved.
+  #L%
+  -->
+
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>${groupId}</groupId>
-        <artifactId>${parentArtifactId}</artifactId>
-        <version>${version}</version>
+        <groupId>org.test</groupId>
+        <artifactId>test-pipelines</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
     </parent>
 
-    <artifactId>${moduleArtifactId}</artifactId>
+    <artifactId>spark-pipeline</artifactId>
     <packaging>jar</packaging>
 
-    <name>${parentDescriptiveName}::${descriptiveName}</name>
+    <name>Test Project::Pipelines::Spark Pipeline</name>
     <description>${pipeline.description}</description>
 
     <build>
@@ -22,14 +32,14 @@
                 <groupId>org.technologybrewery.fermenter</groupId>
                 <artifactId>fermenter-mda</artifactId>
                 <configuration>
-                    <basePackage>${pipeline.package}</basePackage>
+                    <basePackage>org.test</basePackage>
                     <profile>data-delivery-spark-pipeline</profile>
                     <propertyVariables>
-                        <targetPipeline>${pipeline.name}</targetPipeline>
+                        <targetPipeline>SparkPipeline</targetPipeline>
                         <aissembleVersion>${version.aissemble}</aissembleVersion>
                         <dockerProjectRepositoryUrl>${docker.project.repository.url}</dockerProjectRepositoryUrl>
                     </propertyVariables>
-                    <!-- see ${parentArtifactId} for base configuration settings -->
+                    <!-- see test-pipelines for base configuration settings -->
                 </configuration>
             </plugin>
             <plugin>
@@ -57,7 +67,7 @@
                                 you may need to add additional transformers depending on your implementation. -->
                                 <transformer
                                     implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-                                    <mainClass>${basePackage}.${pipeline.name}Driver</mainClass>
+                                    <mainClass>org.test.SparkPipelineDriver</mainClass>
                                 </transformer>
                                 <transformer
                                     implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
@@ -72,42 +82,81 @@
                                     <!-- It seems the shaded jar only has javax.* providers at the moment. Re-evaluate after JDK 17 upgrade is complete. -->
                                     <resource>META-INF/services/javax.ws.rs.ext.Providers</resource>
                                 </transformer>
-                                #if ($pipeline.fileStores)
-                                <transformer
-                                        implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
-                                    <resource>META-INF/services/org.jclouds.apis.ApiMetadata</resource>
-                                </transformer>
-                                <transformer
-                                        implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
-                                    <resource>META-INF/services/org.jclouds.providers.ProviderMetadata</resource>
-                                </transformer>
-                                #end
                             </transformers>
-                            #if ($pipeline.fileStores)
-                            <!-- Spark relies on older, incompatible versions of several of Google's libraries, but JClouds
-                            depends on newer versions, so re-package Guava, Guice, and Gson libraries under different package
-                            in the shaded JAR. This allows for older versions of these JARs to be on Spark's classpath while
-                            everything within the shaded uber JAR leverages the newer, repackaged versions.
-                            -->
-                            <relocations>
-                                <relocation>
-                                    <pattern>com.google</pattern>
-                                    <shadedPattern>repackaged.com.google</shadedPattern>
-                                    <includes>
-                                        <include>com.google.common.**</include>
-                                        <include>com.google.inject.**</include>
-                                        <include>com.google.gson.**</include>
-                                    </includes>
-                                </relocation>
-                            </relocations>
-                            #end
                         </configuration>
                     </execution>
                 </executions>
             </plugin>
-            #set($mainValuesPath = "src/main/resources/apps")
-            #set($testValuesPath = "src/test/resources/apps")
-            #parse("templates/data-delivery-common/pipeline.chart.pom.configuration.vm")
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>3.1.0</version>
+                <executions>
+                    <execution>
+                        <id>main-chart</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <executable>helm</executable>
+                            <arguments>
+                                <argument>template</argument>
+                                <argument>${aissemble.helm.repo.protocol}://${aissemble.helm.repo}/aissemble-spark-application-chart</argument>
+                                <argument>--version</argument>
+                                <argument>${version.aissemble}</argument>
+                                <argument>--values</argument>
+                                <argument>src/main/resources/apps/spark-pipeline-base-values.yaml,src/main/resources/apps/spark-pipeline-dev-values.yaml</argument>
+                                <argument>-s</argument>
+                                <argument>templates/deployment.yaml</argument>
+                            </arguments>
+                            <outputFile>target/apps/spark-pipeline-dev-chart.yaml</outputFile>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>test-chart</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <executable>helm</executable>
+                            <arguments>
+                                <argument>template</argument>
+                                <argument>${aissemble.helm.repo.protocol}://${aissemble.helm.repo}/aissemble-spark-application-chart</argument>
+                                <argument>--version</argument>
+                                <argument>${version.aissemble}</argument>
+                                <argument>--values</argument>
+                                <argument>src/main/resources/apps/spark-pipeline-base-values.yaml,src/test/resources/apps/spark-pipeline-test-values.yaml</argument>
+                                <argument>-s</argument>
+                                <argument>templates/deployment.yaml</argument>
+                            </arguments>
+                            <outputFile>target/apps/spark-pipeline-test-chart.yaml</outputFile>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>ci-chart</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <executable>helm</executable>
+                            <arguments>
+                                <argument>template</argument>
+                                <argument>${aissemble.helm.repo.protocol}://${aissemble.helm.repo}/aissemble-spark-application-chart</argument>
+                                <argument>--version</argument>
+                                <argument>${version.aissemble}</argument>
+                                <argument>--values</argument>
+                                <argument>src/main/resources/apps/spark-pipeline-base-values.yaml,src/main/resources/apps/spark-pipeline-ci-values.yaml</argument>
+                                <argument>-s</argument>
+                                <argument>templates/deployment.yaml</argument>
+                            </arguments>
+                            <outputFile>target/apps/spark-pipeline-ci-chart.yaml</outputFile>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>net.masterthought</groupId>
                 <artifactId>maven-cucumber-reporting</artifactId>
@@ -151,12 +200,6 @@
             <artifactId>javax.servlet-api</artifactId>
             <version>${version.javax.servlet}</version>
         </dependency>
-        #if ($pipeline.isAlertingSupportNeeded())
-        <dependency>
-            <groupId>com.boozallen.aissemble</groupId>
-            <artifactId>foundation-alerting</artifactId>
-        </dependency>
-        #end
         <dependency>
             <groupId>com.boozallen.aissemble</groupId>
             <artifactId>foundation-pdp-client-java</artifactId>
@@ -165,79 +208,16 @@
             <groupId>com.boozallen.aissemble</groupId>
             <artifactId>extensions-authzforce</artifactId>
         </dependency>
-        #if ($enableSedonaSupport)
-        <dependency>
-            <groupId>org.apache.sedona</groupId>
-            <artifactId>sedona-python-adapter-3.0_2.12</artifactId>
-            <version>${version.sedona}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.sedona</groupId>
-            <artifactId>sedona-viz-3.0_2.12</artifactId>
-            <version>${version.sedona}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.datasyslab</groupId>
-            <artifactId>geotools-wrapper</artifactId>
-            <version>${version.geotools.wrapper}</version>
-        </dependency>
-        #end
-        #if ($enablePostgresSupport)
-        <dependency>
-            <groupId>com.boozallen.aissemble</groupId>
-            <artifactId>extensions-data-delivery-spark-postgres</artifactId>
-        </dependency>
-        #end
-        #if ($enableElasticsearchSupport)
-        <!-- Version must match the version set in the elasticsearch helm chart-->
-        <dependency>
-            <groupId>org.elasticsearch</groupId>
-            <artifactId>elasticsearch-spark-30_2.12</artifactId>
-            <version>${version.elasticsearch}</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.codehaus.janino</groupId>
-            <artifactId>commons-compiler</artifactId>
-            <version>${version.janino}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.codehaus.janino</groupId>
-            <artifactId>janino</artifactId>
-            <version>${version.janino}</version>
-        </dependency>
-        #end
-        #if ($enableNeo4jSupport)
-        <dependency>
-            <groupId>com.boozallen.aissemble</groupId>
-            <artifactId>extensions-data-delivery-spark-neo4j</artifactId>
-        </dependency>
-        #end
-        #if ($pipeline.getDataLineage())
-        <dependency>
-            <groupId>com.boozallen.aissemble</groupId>
-            <artifactId>foundation-data-lineage-java</artifactId>
-        </dependency>
-        #end
         <dependency>
             <groupId>io.smallrye.reactive</groupId>
             <artifactId>smallrye-reactive-messaging-kafka</artifactId>
             <version>${version.smallrye.reactive.messaging}</version>
         </dependency>
-        #if ($pipeline.fileStores)
         <dependency>
-            <groupId>org.apache.jclouds</groupId>
-            <artifactId>jclouds-allblobstore</artifactId>
-            <version>${version.jclouds}</version>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>test-data-records-java</artifactId>
+            <version>${project.version}</version>
         </dependency>
-        #end
-        #if($enableSemanticDataSupport)
-        <dependency>
-            <groupId>#[[${project.groupId}]]#</groupId>
-            <artifactId>${javaDataRecords}</artifactId>
-            <version>#[[${project.version}]]#</version>
-        </dependency>
-        #end
         <!-- Test dependencies: -->
         <dependency>
             <groupId>io.cucumber</groupId>
@@ -270,44 +250,6 @@
             <groupId>net.masterthought</groupId>
             <artifactId>cucumber-reporting</artifactId>
             <scope>test</scope>
-        </dependency>
-        #if ($pipeline.fileStores)
-        <dependency>
-            <groupId>org.apache.jclouds.api</groupId>
-            <artifactId>filesystem</artifactId>
-            <version>${version.jclouds}</version>
-            <scope>test</scope>
-        </dependency>
-        #end
-        <dependency>
-            <groupId>org.apache.spark</groupId>
-            <artifactId>spark-core_2.12</artifactId>
-            <version>${version.spark}</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.spark</groupId>
-            <artifactId>spark-hive_2.12</artifactId>
-            <version>${version.spark}</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.spark</groupId>
-            <artifactId>spark-streaming_2.12</artifactId>
-            <version>${version.spark}</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.spark</groupId>
-            <artifactId>spark-sql_2.12</artifactId>
-            <version>${version.spark}</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.spark</groupId>
-            <artifactId>spark-catalyst_2.12</artifactId>
-            <version>${version.spark}</version>
-            <scope>provided</scope>
         </dependency>
     </dependencies>
 

--- a/foundation/foundation-upgrade/src/test/resources/test-files/version-specific/SparkProvidedDependenciesMigration/migration/skip-pom.xml
+++ b/foundation/foundation-upgrade/src/test/resources/test-files/version-specific/SparkProvidedDependenciesMigration/migration/skip-pom.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  aiSSEMBLE::Foundation::Upgrade
+  %%
+  Copyright (C) 2021 Booz Allen
+  %%
+  This software package is licensed under the Booz Allen Public License. All Rights Reserved.
+  #L%
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.test</groupId>
+        <artifactId>test</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>test-pipelines</artifactId>
+
+    <name>Test Project::Pipelines</name>
+    <description>Contains the pipelines for this Test Project</description>
+    <packaging>pom</packaging>
+
+    <modules>        <module>spark-pipeline</module>
+        <module>pyspark-pipeline</module>
+
+        <!-- TODO: replace with your pipeline-specific modules here -->
+    </modules>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.technologybrewery.fermenter</groupId>
+                    <artifactId>fermenter-mda</artifactId>
+                    <configuration>
+                        <!-- Reference models from test-pipelines-pipeline-models. See the following
+                            page for more detailed information: https://bit.ly/3tJRk3r -->
+                        <metadataDependencies>
+                            <metadataDependency>test-pipeline-models</metadataDependency>
+                        </metadataDependencies>
+                        <targetModelInstances>
+                            <targetModelInstance>test-pipeline-models</targetModelInstance>
+                        </targetModelInstances>
+                    </configuration>
+                    <dependencies>
+                        <dependency>
+                            <groupId>${project.groupId}</groupId>
+                            <artifactId>test-pipeline-models</artifactId>
+                            <version>${project.version}</version>
+                        </dependency>
+                    </dependencies>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+        <plugins>
+            <plugin>
+                <groupId>org.technologybrewery.fermenter</groupId>
+                <artifactId>fermenter-mda</artifactId>
+                <configuration>
+                    <basePackage>org.test</basePackage>
+                    <profile>aissemble-maven-modules</profile>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/foundation/foundation-upgrade/src/test/resources/test-files/version-specific/SparkProvidedDependenciesMigration/migration/some-pom.xml
+++ b/foundation/foundation-upgrade/src/test/resources/test-files/version-specific/SparkProvidedDependenciesMigration/migration/some-pom.xml
@@ -1,19 +1,29 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  aiSSEMBLE::Foundation::Upgrade
+  %%
+  Copyright (C) 2021 Booz Allen
+  %%
+  This software package is licensed under the Booz Allen Public License. All Rights Reserved.
+  #L%
+  -->
+
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>${groupId}</groupId>
-        <artifactId>${parentArtifactId}</artifactId>
-        <version>${version}</version>
+        <groupId>org.test</groupId>
+        <artifactId>test-pipelines</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
     </parent>
 
-    <artifactId>${moduleArtifactId}</artifactId>
+    <artifactId>spark-pipeline</artifactId>
     <packaging>jar</packaging>
 
-    <name>${parentDescriptiveName}::${descriptiveName}</name>
+    <name>Test Project::Pipelines::Spark Pipeline</name>
     <description>${pipeline.description}</description>
 
     <build>
@@ -22,14 +32,14 @@
                 <groupId>org.technologybrewery.fermenter</groupId>
                 <artifactId>fermenter-mda</artifactId>
                 <configuration>
-                    <basePackage>${pipeline.package}</basePackage>
+                    <basePackage>org.test</basePackage>
                     <profile>data-delivery-spark-pipeline</profile>
                     <propertyVariables>
-                        <targetPipeline>${pipeline.name}</targetPipeline>
+                        <targetPipeline>SparkPipeline</targetPipeline>
                         <aissembleVersion>${version.aissemble}</aissembleVersion>
                         <dockerProjectRepositoryUrl>${docker.project.repository.url}</dockerProjectRepositoryUrl>
                     </propertyVariables>
-                    <!-- see ${parentArtifactId} for base configuration settings -->
+                    <!-- see test-pipelines for base configuration settings -->
                 </configuration>
             </plugin>
             <plugin>
@@ -57,7 +67,7 @@
                                 you may need to add additional transformers depending on your implementation. -->
                                 <transformer
                                     implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-                                    <mainClass>${basePackage}.${pipeline.name}Driver</mainClass>
+                                    <mainClass>org.test.SparkPipelineDriver</mainClass>
                                 </transformer>
                                 <transformer
                                     implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
@@ -72,42 +82,81 @@
                                     <!-- It seems the shaded jar only has javax.* providers at the moment. Re-evaluate after JDK 17 upgrade is complete. -->
                                     <resource>META-INF/services/javax.ws.rs.ext.Providers</resource>
                                 </transformer>
-                                #if ($pipeline.fileStores)
-                                <transformer
-                                        implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
-                                    <resource>META-INF/services/org.jclouds.apis.ApiMetadata</resource>
-                                </transformer>
-                                <transformer
-                                        implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
-                                    <resource>META-INF/services/org.jclouds.providers.ProviderMetadata</resource>
-                                </transformer>
-                                #end
                             </transformers>
-                            #if ($pipeline.fileStores)
-                            <!-- Spark relies on older, incompatible versions of several of Google's libraries, but JClouds
-                            depends on newer versions, so re-package Guava, Guice, and Gson libraries under different package
-                            in the shaded JAR. This allows for older versions of these JARs to be on Spark's classpath while
-                            everything within the shaded uber JAR leverages the newer, repackaged versions.
-                            -->
-                            <relocations>
-                                <relocation>
-                                    <pattern>com.google</pattern>
-                                    <shadedPattern>repackaged.com.google</shadedPattern>
-                                    <includes>
-                                        <include>com.google.common.**</include>
-                                        <include>com.google.inject.**</include>
-                                        <include>com.google.gson.**</include>
-                                    </includes>
-                                </relocation>
-                            </relocations>
-                            #end
                         </configuration>
                     </execution>
                 </executions>
             </plugin>
-            #set($mainValuesPath = "src/main/resources/apps")
-            #set($testValuesPath = "src/test/resources/apps")
-            #parse("templates/data-delivery-common/pipeline.chart.pom.configuration.vm")
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>3.1.0</version>
+                <executions>
+                    <execution>
+                        <id>main-chart</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <executable>helm</executable>
+                            <arguments>
+                                <argument>template</argument>
+                                <argument>${aissemble.helm.repo.protocol}://${aissemble.helm.repo}/aissemble-spark-application-chart</argument>
+                                <argument>--version</argument>
+                                <argument>${version.aissemble}</argument>
+                                <argument>--values</argument>
+                                <argument>src/main/resources/apps/spark-pipeline-base-values.yaml,src/main/resources/apps/spark-pipeline-dev-values.yaml</argument>
+                                <argument>-s</argument>
+                                <argument>templates/deployment.yaml</argument>
+                            </arguments>
+                            <outputFile>target/apps/spark-pipeline-dev-chart.yaml</outputFile>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>test-chart</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <executable>helm</executable>
+                            <arguments>
+                                <argument>template</argument>
+                                <argument>${aissemble.helm.repo.protocol}://${aissemble.helm.repo}/aissemble-spark-application-chart</argument>
+                                <argument>--version</argument>
+                                <argument>${version.aissemble}</argument>
+                                <argument>--values</argument>
+                                <argument>src/main/resources/apps/spark-pipeline-base-values.yaml,src/test/resources/apps/spark-pipeline-test-values.yaml</argument>
+                                <argument>-s</argument>
+                                <argument>templates/deployment.yaml</argument>
+                            </arguments>
+                            <outputFile>target/apps/spark-pipeline-test-chart.yaml</outputFile>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>ci-chart</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <executable>helm</executable>
+                            <arguments>
+                                <argument>template</argument>
+                                <argument>${aissemble.helm.repo.protocol}://${aissemble.helm.repo}/aissemble-spark-application-chart</argument>
+                                <argument>--version</argument>
+                                <argument>${version.aissemble}</argument>
+                                <argument>--values</argument>
+                                <argument>src/main/resources/apps/spark-pipeline-base-values.yaml,src/main/resources/apps/spark-pipeline-ci-values.yaml</argument>
+                                <argument>-s</argument>
+                                <argument>templates/deployment.yaml</argument>
+                            </arguments>
+                            <outputFile>target/apps/spark-pipeline-ci-chart.yaml</outputFile>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>net.masterthought</groupId>
                 <artifactId>maven-cucumber-reporting</artifactId>
@@ -151,12 +200,6 @@
             <artifactId>javax.servlet-api</artifactId>
             <version>${version.javax.servlet}</version>
         </dependency>
-        #if ($pipeline.isAlertingSupportNeeded())
-        <dependency>
-            <groupId>com.boozallen.aissemble</groupId>
-            <artifactId>foundation-alerting</artifactId>
-        </dependency>
-        #end
         <dependency>
             <groupId>com.boozallen.aissemble</groupId>
             <artifactId>foundation-pdp-client-java</artifactId>
@@ -165,79 +208,16 @@
             <groupId>com.boozallen.aissemble</groupId>
             <artifactId>extensions-authzforce</artifactId>
         </dependency>
-        #if ($enableSedonaSupport)
-        <dependency>
-            <groupId>org.apache.sedona</groupId>
-            <artifactId>sedona-python-adapter-3.0_2.12</artifactId>
-            <version>${version.sedona}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.sedona</groupId>
-            <artifactId>sedona-viz-3.0_2.12</artifactId>
-            <version>${version.sedona}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.datasyslab</groupId>
-            <artifactId>geotools-wrapper</artifactId>
-            <version>${version.geotools.wrapper}</version>
-        </dependency>
-        #end
-        #if ($enablePostgresSupport)
-        <dependency>
-            <groupId>com.boozallen.aissemble</groupId>
-            <artifactId>extensions-data-delivery-spark-postgres</artifactId>
-        </dependency>
-        #end
-        #if ($enableElasticsearchSupport)
-        <!-- Version must match the version set in the elasticsearch helm chart-->
-        <dependency>
-            <groupId>org.elasticsearch</groupId>
-            <artifactId>elasticsearch-spark-30_2.12</artifactId>
-            <version>${version.elasticsearch}</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.codehaus.janino</groupId>
-            <artifactId>commons-compiler</artifactId>
-            <version>${version.janino}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.codehaus.janino</groupId>
-            <artifactId>janino</artifactId>
-            <version>${version.janino}</version>
-        </dependency>
-        #end
-        #if ($enableNeo4jSupport)
-        <dependency>
-            <groupId>com.boozallen.aissemble</groupId>
-            <artifactId>extensions-data-delivery-spark-neo4j</artifactId>
-        </dependency>
-        #end
-        #if ($pipeline.getDataLineage())
-        <dependency>
-            <groupId>com.boozallen.aissemble</groupId>
-            <artifactId>foundation-data-lineage-java</artifactId>
-        </dependency>
-        #end
         <dependency>
             <groupId>io.smallrye.reactive</groupId>
             <artifactId>smallrye-reactive-messaging-kafka</artifactId>
             <version>${version.smallrye.reactive.messaging}</version>
         </dependency>
-        #if ($pipeline.fileStores)
         <dependency>
-            <groupId>org.apache.jclouds</groupId>
-            <artifactId>jclouds-allblobstore</artifactId>
-            <version>${version.jclouds}</version>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>test-data-records-java</artifactId>
+            <version>${project.version}</version>
         </dependency>
-        #end
-        #if($enableSemanticDataSupport)
-        <dependency>
-            <groupId>#[[${project.groupId}]]#</groupId>
-            <artifactId>${javaDataRecords}</artifactId>
-            <version>#[[${project.version}]]#</version>
-        </dependency>
-        #end
         <!-- Test dependencies: -->
         <dependency>
             <groupId>io.cucumber</groupId>
@@ -270,32 +250,6 @@
             <groupId>net.masterthought</groupId>
             <artifactId>cucumber-reporting</artifactId>
             <scope>test</scope>
-        </dependency>
-        #if ($pipeline.fileStores)
-        <dependency>
-            <groupId>org.apache.jclouds.api</groupId>
-            <artifactId>filesystem</artifactId>
-            <version>${version.jclouds}</version>
-            <scope>test</scope>
-        </dependency>
-        #end
-        <dependency>
-            <groupId>org.apache.spark</groupId>
-            <artifactId>spark-core_2.12</artifactId>
-            <version>${version.spark}</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.spark</groupId>
-            <artifactId>spark-hive_2.12</artifactId>
-            <version>${version.spark}</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.spark</groupId>
-            <artifactId>spark-streaming_2.12</artifactId>
-            <version>${version.spark}</version>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>

--- a/foundation/foundation-upgrade/src/test/resources/test-files/version-specific/SparkProvidedDependenciesMigration/validation/pom.xml
+++ b/foundation/foundation-upgrade/src/test/resources/test-files/version-specific/SparkProvidedDependenciesMigration/validation/pom.xml
@@ -1,19 +1,29 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  aiSSEMBLE::Foundation::Upgrade
+  %%
+  Copyright (C) 2021 Booz Allen
+  %%
+  This software package is licensed under the Booz Allen Public License. All Rights Reserved.
+  #L%
+  -->
+
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>${groupId}</groupId>
-        <artifactId>${parentArtifactId}</artifactId>
-        <version>${version}</version>
+        <groupId>org.test</groupId>
+        <artifactId>test-pipelines</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
     </parent>
 
-    <artifactId>${moduleArtifactId}</artifactId>
+    <artifactId>spark-pipeline</artifactId>
     <packaging>jar</packaging>
 
-    <name>${parentDescriptiveName}::${descriptiveName}</name>
+    <name>Test Project::Pipelines::Spark Pipeline</name>
     <description>${pipeline.description}</description>
 
     <build>
@@ -22,14 +32,14 @@
                 <groupId>org.technologybrewery.fermenter</groupId>
                 <artifactId>fermenter-mda</artifactId>
                 <configuration>
-                    <basePackage>${pipeline.package}</basePackage>
+                    <basePackage>org.test</basePackage>
                     <profile>data-delivery-spark-pipeline</profile>
                     <propertyVariables>
-                        <targetPipeline>${pipeline.name}</targetPipeline>
+                        <targetPipeline>SparkPipeline</targetPipeline>
                         <aissembleVersion>${version.aissemble}</aissembleVersion>
                         <dockerProjectRepositoryUrl>${docker.project.repository.url}</dockerProjectRepositoryUrl>
                     </propertyVariables>
-                    <!-- see ${parentArtifactId} for base configuration settings -->
+                    <!-- see test-pipelines for base configuration settings -->
                 </configuration>
             </plugin>
             <plugin>
@@ -57,7 +67,7 @@
                                 you may need to add additional transformers depending on your implementation. -->
                                 <transformer
                                     implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-                                    <mainClass>${basePackage}.${pipeline.name}Driver</mainClass>
+                                    <mainClass>org.test.SparkPipelineDriver</mainClass>
                                 </transformer>
                                 <transformer
                                     implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
@@ -72,42 +82,81 @@
                                     <!-- It seems the shaded jar only has javax.* providers at the moment. Re-evaluate after JDK 17 upgrade is complete. -->
                                     <resource>META-INF/services/javax.ws.rs.ext.Providers</resource>
                                 </transformer>
-                                #if ($pipeline.fileStores)
-                                <transformer
-                                        implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
-                                    <resource>META-INF/services/org.jclouds.apis.ApiMetadata</resource>
-                                </transformer>
-                                <transformer
-                                        implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
-                                    <resource>META-INF/services/org.jclouds.providers.ProviderMetadata</resource>
-                                </transformer>
-                                #end
                             </transformers>
-                            #if ($pipeline.fileStores)
-                            <!-- Spark relies on older, incompatible versions of several of Google's libraries, but JClouds
-                            depends on newer versions, so re-package Guava, Guice, and Gson libraries under different package
-                            in the shaded JAR. This allows for older versions of these JARs to be on Spark's classpath while
-                            everything within the shaded uber JAR leverages the newer, repackaged versions.
-                            -->
-                            <relocations>
-                                <relocation>
-                                    <pattern>com.google</pattern>
-                                    <shadedPattern>repackaged.com.google</shadedPattern>
-                                    <includes>
-                                        <include>com.google.common.**</include>
-                                        <include>com.google.inject.**</include>
-                                        <include>com.google.gson.**</include>
-                                    </includes>
-                                </relocation>
-                            </relocations>
-                            #end
                         </configuration>
                     </execution>
                 </executions>
             </plugin>
-            #set($mainValuesPath = "src/main/resources/apps")
-            #set($testValuesPath = "src/test/resources/apps")
-            #parse("templates/data-delivery-common/pipeline.chart.pom.configuration.vm")
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>3.1.0</version>
+                <executions>
+                    <execution>
+                        <id>main-chart</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <executable>helm</executable>
+                            <arguments>
+                                <argument>template</argument>
+                                <argument>${aissemble.helm.repo.protocol}://${aissemble.helm.repo}/aissemble-spark-application-chart</argument>
+                                <argument>--version</argument>
+                                <argument>${version.aissemble}</argument>
+                                <argument>--values</argument>
+                                <argument>src/main/resources/apps/spark-pipeline-base-values.yaml,src/main/resources/apps/spark-pipeline-dev-values.yaml</argument>
+                                <argument>-s</argument>
+                                <argument>templates/deployment.yaml</argument>
+                            </arguments>
+                            <outputFile>target/apps/spark-pipeline-dev-chart.yaml</outputFile>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>test-chart</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <executable>helm</executable>
+                            <arguments>
+                                <argument>template</argument>
+                                <argument>${aissemble.helm.repo.protocol}://${aissemble.helm.repo}/aissemble-spark-application-chart</argument>
+                                <argument>--version</argument>
+                                <argument>${version.aissemble}</argument>
+                                <argument>--values</argument>
+                                <argument>src/main/resources/apps/spark-pipeline-base-values.yaml,src/test/resources/apps/spark-pipeline-test-values.yaml</argument>
+                                <argument>-s</argument>
+                                <argument>templates/deployment.yaml</argument>
+                            </arguments>
+                            <outputFile>target/apps/spark-pipeline-test-chart.yaml</outputFile>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>ci-chart</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <executable>helm</executable>
+                            <arguments>
+                                <argument>template</argument>
+                                <argument>${aissemble.helm.repo.protocol}://${aissemble.helm.repo}/aissemble-spark-application-chart</argument>
+                                <argument>--version</argument>
+                                <argument>${version.aissemble}</argument>
+                                <argument>--values</argument>
+                                <argument>src/main/resources/apps/spark-pipeline-base-values.yaml,src/main/resources/apps/spark-pipeline-ci-values.yaml</argument>
+                                <argument>-s</argument>
+                                <argument>templates/deployment.yaml</argument>
+                            </arguments>
+                            <outputFile>target/apps/spark-pipeline-ci-chart.yaml</outputFile>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>net.masterthought</groupId>
                 <artifactId>maven-cucumber-reporting</artifactId>
@@ -151,12 +200,6 @@
             <artifactId>javax.servlet-api</artifactId>
             <version>${version.javax.servlet}</version>
         </dependency>
-        #if ($pipeline.isAlertingSupportNeeded())
-        <dependency>
-            <groupId>com.boozallen.aissemble</groupId>
-            <artifactId>foundation-alerting</artifactId>
-        </dependency>
-        #end
         <dependency>
             <groupId>com.boozallen.aissemble</groupId>
             <artifactId>foundation-pdp-client-java</artifactId>
@@ -165,79 +208,16 @@
             <groupId>com.boozallen.aissemble</groupId>
             <artifactId>extensions-authzforce</artifactId>
         </dependency>
-        #if ($enableSedonaSupport)
-        <dependency>
-            <groupId>org.apache.sedona</groupId>
-            <artifactId>sedona-python-adapter-3.0_2.12</artifactId>
-            <version>${version.sedona}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.sedona</groupId>
-            <artifactId>sedona-viz-3.0_2.12</artifactId>
-            <version>${version.sedona}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.datasyslab</groupId>
-            <artifactId>geotools-wrapper</artifactId>
-            <version>${version.geotools.wrapper}</version>
-        </dependency>
-        #end
-        #if ($enablePostgresSupport)
-        <dependency>
-            <groupId>com.boozallen.aissemble</groupId>
-            <artifactId>extensions-data-delivery-spark-postgres</artifactId>
-        </dependency>
-        #end
-        #if ($enableElasticsearchSupport)
-        <!-- Version must match the version set in the elasticsearch helm chart-->
-        <dependency>
-            <groupId>org.elasticsearch</groupId>
-            <artifactId>elasticsearch-spark-30_2.12</artifactId>
-            <version>${version.elasticsearch}</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.codehaus.janino</groupId>
-            <artifactId>commons-compiler</artifactId>
-            <version>${version.janino}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.codehaus.janino</groupId>
-            <artifactId>janino</artifactId>
-            <version>${version.janino}</version>
-        </dependency>
-        #end
-        #if ($enableNeo4jSupport)
-        <dependency>
-            <groupId>com.boozallen.aissemble</groupId>
-            <artifactId>extensions-data-delivery-spark-neo4j</artifactId>
-        </dependency>
-        #end
-        #if ($pipeline.getDataLineage())
-        <dependency>
-            <groupId>com.boozallen.aissemble</groupId>
-            <artifactId>foundation-data-lineage-java</artifactId>
-        </dependency>
-        #end
         <dependency>
             <groupId>io.smallrye.reactive</groupId>
             <artifactId>smallrye-reactive-messaging-kafka</artifactId>
             <version>${version.smallrye.reactive.messaging}</version>
         </dependency>
-        #if ($pipeline.fileStores)
         <dependency>
-            <groupId>org.apache.jclouds</groupId>
-            <artifactId>jclouds-allblobstore</artifactId>
-            <version>${version.jclouds}</version>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>test-data-records-java</artifactId>
+            <version>${project.version}</version>
         </dependency>
-        #end
-        #if($enableSemanticDataSupport)
-        <dependency>
-            <groupId>#[[${project.groupId}]]#</groupId>
-            <artifactId>${javaDataRecords}</artifactId>
-            <version>#[[${project.version}]]#</version>
-        </dependency>
-        #end
         <!-- Test dependencies: -->
         <dependency>
             <groupId>io.cucumber</groupId>
@@ -271,14 +251,6 @@
             <artifactId>cucumber-reporting</artifactId>
             <scope>test</scope>
         </dependency>
-        #if ($pipeline.fileStores)
-        <dependency>
-            <groupId>org.apache.jclouds.api</groupId>
-            <artifactId>filesystem</artifactId>
-            <version>${version.jclouds}</version>
-            <scope>test</scope>
-        </dependency>
-        #end
         <dependency>
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-core_2.12</artifactId>

--- a/foundation/foundation-upgrade/src/test/resources/test-files/version-specific/SparkProvidedDependenciesMigration/validation/some-pom.xml
+++ b/foundation/foundation-upgrade/src/test/resources/test-files/version-specific/SparkProvidedDependenciesMigration/validation/some-pom.xml
@@ -1,19 +1,29 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  aiSSEMBLE::Foundation::Upgrade
+  %%
+  Copyright (C) 2021 Booz Allen
+  %%
+  This software package is licensed under the Booz Allen Public License. All Rights Reserved.
+  #L%
+  -->
+
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>${groupId}</groupId>
-        <artifactId>${parentArtifactId}</artifactId>
-        <version>${version}</version>
+        <groupId>org.test</groupId>
+        <artifactId>test-pipelines</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
     </parent>
 
-    <artifactId>${moduleArtifactId}</artifactId>
+    <artifactId>spark-pipeline</artifactId>
     <packaging>jar</packaging>
 
-    <name>${parentDescriptiveName}::${descriptiveName}</name>
+    <name>Test Project::Pipelines::Spark Pipeline</name>
     <description>${pipeline.description}</description>
 
     <build>
@@ -22,14 +32,14 @@
                 <groupId>org.technologybrewery.fermenter</groupId>
                 <artifactId>fermenter-mda</artifactId>
                 <configuration>
-                    <basePackage>${pipeline.package}</basePackage>
+                    <basePackage>org.test</basePackage>
                     <profile>data-delivery-spark-pipeline</profile>
                     <propertyVariables>
-                        <targetPipeline>${pipeline.name}</targetPipeline>
+                        <targetPipeline>SparkPipeline</targetPipeline>
                         <aissembleVersion>${version.aissemble}</aissembleVersion>
                         <dockerProjectRepositoryUrl>${docker.project.repository.url}</dockerProjectRepositoryUrl>
                     </propertyVariables>
-                    <!-- see ${parentArtifactId} for base configuration settings -->
+                    <!-- see test-pipelines for base configuration settings -->
                 </configuration>
             </plugin>
             <plugin>
@@ -57,7 +67,7 @@
                                 you may need to add additional transformers depending on your implementation. -->
                                 <transformer
                                     implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-                                    <mainClass>${basePackage}.${pipeline.name}Driver</mainClass>
+                                    <mainClass>org.test.SparkPipelineDriver</mainClass>
                                 </transformer>
                                 <transformer
                                     implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
@@ -72,42 +82,81 @@
                                     <!-- It seems the shaded jar only has javax.* providers at the moment. Re-evaluate after JDK 17 upgrade is complete. -->
                                     <resource>META-INF/services/javax.ws.rs.ext.Providers</resource>
                                 </transformer>
-                                #if ($pipeline.fileStores)
-                                <transformer
-                                        implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
-                                    <resource>META-INF/services/org.jclouds.apis.ApiMetadata</resource>
-                                </transformer>
-                                <transformer
-                                        implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
-                                    <resource>META-INF/services/org.jclouds.providers.ProviderMetadata</resource>
-                                </transformer>
-                                #end
                             </transformers>
-                            #if ($pipeline.fileStores)
-                            <!-- Spark relies on older, incompatible versions of several of Google's libraries, but JClouds
-                            depends on newer versions, so re-package Guava, Guice, and Gson libraries under different package
-                            in the shaded JAR. This allows for older versions of these JARs to be on Spark's classpath while
-                            everything within the shaded uber JAR leverages the newer, repackaged versions.
-                            -->
-                            <relocations>
-                                <relocation>
-                                    <pattern>com.google</pattern>
-                                    <shadedPattern>repackaged.com.google</shadedPattern>
-                                    <includes>
-                                        <include>com.google.common.**</include>
-                                        <include>com.google.inject.**</include>
-                                        <include>com.google.gson.**</include>
-                                    </includes>
-                                </relocation>
-                            </relocations>
-                            #end
                         </configuration>
                     </execution>
                 </executions>
             </plugin>
-            #set($mainValuesPath = "src/main/resources/apps")
-            #set($testValuesPath = "src/test/resources/apps")
-            #parse("templates/data-delivery-common/pipeline.chart.pom.configuration.vm")
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>3.1.0</version>
+                <executions>
+                    <execution>
+                        <id>main-chart</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <executable>helm</executable>
+                            <arguments>
+                                <argument>template</argument>
+                                <argument>${aissemble.helm.repo.protocol}://${aissemble.helm.repo}/aissemble-spark-application-chart</argument>
+                                <argument>--version</argument>
+                                <argument>${version.aissemble}</argument>
+                                <argument>--values</argument>
+                                <argument>src/main/resources/apps/spark-pipeline-base-values.yaml,src/main/resources/apps/spark-pipeline-dev-values.yaml</argument>
+                                <argument>-s</argument>
+                                <argument>templates/deployment.yaml</argument>
+                            </arguments>
+                            <outputFile>target/apps/spark-pipeline-dev-chart.yaml</outputFile>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>test-chart</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <executable>helm</executable>
+                            <arguments>
+                                <argument>template</argument>
+                                <argument>${aissemble.helm.repo.protocol}://${aissemble.helm.repo}/aissemble-spark-application-chart</argument>
+                                <argument>--version</argument>
+                                <argument>${version.aissemble}</argument>
+                                <argument>--values</argument>
+                                <argument>src/main/resources/apps/spark-pipeline-base-values.yaml,src/test/resources/apps/spark-pipeline-test-values.yaml</argument>
+                                <argument>-s</argument>
+                                <argument>templates/deployment.yaml</argument>
+                            </arguments>
+                            <outputFile>target/apps/spark-pipeline-test-chart.yaml</outputFile>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>ci-chart</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <executable>helm</executable>
+                            <arguments>
+                                <argument>template</argument>
+                                <argument>${aissemble.helm.repo.protocol}://${aissemble.helm.repo}/aissemble-spark-application-chart</argument>
+                                <argument>--version</argument>
+                                <argument>${version.aissemble}</argument>
+                                <argument>--values</argument>
+                                <argument>src/main/resources/apps/spark-pipeline-base-values.yaml,src/main/resources/apps/spark-pipeline-ci-values.yaml</argument>
+                                <argument>-s</argument>
+                                <argument>templates/deployment.yaml</argument>
+                            </arguments>
+                            <outputFile>target/apps/spark-pipeline-ci-chart.yaml</outputFile>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>net.masterthought</groupId>
                 <artifactId>maven-cucumber-reporting</artifactId>
@@ -151,12 +200,6 @@
             <artifactId>javax.servlet-api</artifactId>
             <version>${version.javax.servlet}</version>
         </dependency>
-        #if ($pipeline.isAlertingSupportNeeded())
-        <dependency>
-            <groupId>com.boozallen.aissemble</groupId>
-            <artifactId>foundation-alerting</artifactId>
-        </dependency>
-        #end
         <dependency>
             <groupId>com.boozallen.aissemble</groupId>
             <artifactId>foundation-pdp-client-java</artifactId>
@@ -165,79 +208,16 @@
             <groupId>com.boozallen.aissemble</groupId>
             <artifactId>extensions-authzforce</artifactId>
         </dependency>
-        #if ($enableSedonaSupport)
-        <dependency>
-            <groupId>org.apache.sedona</groupId>
-            <artifactId>sedona-python-adapter-3.0_2.12</artifactId>
-            <version>${version.sedona}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.sedona</groupId>
-            <artifactId>sedona-viz-3.0_2.12</artifactId>
-            <version>${version.sedona}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.datasyslab</groupId>
-            <artifactId>geotools-wrapper</artifactId>
-            <version>${version.geotools.wrapper}</version>
-        </dependency>
-        #end
-        #if ($enablePostgresSupport)
-        <dependency>
-            <groupId>com.boozallen.aissemble</groupId>
-            <artifactId>extensions-data-delivery-spark-postgres</artifactId>
-        </dependency>
-        #end
-        #if ($enableElasticsearchSupport)
-        <!-- Version must match the version set in the elasticsearch helm chart-->
-        <dependency>
-            <groupId>org.elasticsearch</groupId>
-            <artifactId>elasticsearch-spark-30_2.12</artifactId>
-            <version>${version.elasticsearch}</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.codehaus.janino</groupId>
-            <artifactId>commons-compiler</artifactId>
-            <version>${version.janino}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.codehaus.janino</groupId>
-            <artifactId>janino</artifactId>
-            <version>${version.janino}</version>
-        </dependency>
-        #end
-        #if ($enableNeo4jSupport)
-        <dependency>
-            <groupId>com.boozallen.aissemble</groupId>
-            <artifactId>extensions-data-delivery-spark-neo4j</artifactId>
-        </dependency>
-        #end
-        #if ($pipeline.getDataLineage())
-        <dependency>
-            <groupId>com.boozallen.aissemble</groupId>
-            <artifactId>foundation-data-lineage-java</artifactId>
-        </dependency>
-        #end
         <dependency>
             <groupId>io.smallrye.reactive</groupId>
             <artifactId>smallrye-reactive-messaging-kafka</artifactId>
             <version>${version.smallrye.reactive.messaging}</version>
         </dependency>
-        #if ($pipeline.fileStores)
         <dependency>
-            <groupId>org.apache.jclouds</groupId>
-            <artifactId>jclouds-allblobstore</artifactId>
-            <version>${version.jclouds}</version>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>test-data-records-java</artifactId>
+            <version>${project.version}</version>
         </dependency>
-        #end
-        #if($enableSemanticDataSupport)
-        <dependency>
-            <groupId>#[[${project.groupId}]]#</groupId>
-            <artifactId>${javaDataRecords}</artifactId>
-            <version>#[[${project.version}]]#</version>
-        </dependency>
-        #end
         <!-- Test dependencies: -->
         <dependency>
             <groupId>io.cucumber</groupId>
@@ -271,14 +251,18 @@
             <artifactId>cucumber-reporting</artifactId>
             <scope>test</scope>
         </dependency>
-        #if ($pipeline.fileStores)
         <dependency>
-            <groupId>org.apache.jclouds.api</groupId>
-            <artifactId>filesystem</artifactId>
-            <version>${version.jclouds}</version>
-            <scope>test</scope>
+            <groupId>org.apache.spark</groupId>
+            <artifactId>spark-sql_2.12</artifactId>
+            <version>${version.spark}</version>
+            <scope>provided</scope>
         </dependency>
-        #end
+        <dependency>
+            <groupId>org.apache.spark</groupId>
+            <artifactId>spark-catalyst_2.12</artifactId>
+            <version>${version.spark}</version>
+            <scope>provided</scope>
+        </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-core_2.12</artifactId>
@@ -294,18 +278,6 @@
         <dependency>
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-streaming_2.12</artifactId>
-            <version>${version.spark}</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.spark</groupId>
-            <artifactId>spark-sql_2.12</artifactId>
-            <version>${version.spark}</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.spark</groupId>
-            <artifactId>spark-catalyst_2.12</artifactId>
             <version>${version.spark}</version>
             <scope>provided</scope>
         </dependency>

--- a/test/test-mda-models/test-data-delivery-spark-model-basic/pom.xml
+++ b/test/test-mda-models/test-data-delivery-spark-model-basic/pom.xml
@@ -190,5 +190,17 @@
             <artifactId>cucumber-reporting</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.spark</groupId>
+            <artifactId>spark-hive_2.12</artifactId>
+            <version>${version.spark}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.spark</groupId>
+            <artifactId>spark-sql_2.12</artifactId>
+            <version>${version.spark}</version>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/test/test-mda-models/test-data-delivery-spark-model/pom.xml
+++ b/test/test-mda-models/test-data-delivery-spark-model/pom.xml
@@ -270,5 +270,35 @@
             <version>${version.jclouds}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.spark</groupId>
+            <artifactId>spark-sql_2.12</artifactId>
+            <version>${version.spark}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.spark</groupId>
+            <artifactId>spark-catalyst_2.12</artifactId>
+            <version>${version.spark}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.spark</groupId>
+            <artifactId>spark-hive_2.12</artifactId>
+            <version>${version.spark}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.spark</groupId>
+            <artifactId>spark-core_2.12</artifactId>
+            <version>${version.spark}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.spark</groupId>
+            <artifactId>spark-streaming_2.12</artifactId>
+            <version>${version.spark}</version>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
This goal is accomplished by setting the Spark dependencies in `extensions-data-delivery-spark` to `provided` scope.  Because they are now provided, the only guaranteed way to ensure all projects which depend on this module build successfully is to add these 5 (now-`provided`) dependencies explicitly to the respective dependent projects.  The vast majority of the changes in this PR do just that, including the Baton migration.

Technically, a project using `extensions-data-delivery-spark` may not need all 5, but it is nearly impossible to tell without running and parsing `dependency:analyze`.