### PR TITLE
[#653] set maxBuilds to 1 in build cache config

### DIFF
--- a/.mvn/maven-build-cache-config.xml
+++ b/.mvn/maven-build-cache-config.xml
@@ -37,20 +37,20 @@
         <attachedOutputs>
             <dirNames>
                 <dirName>../dist</dirName>
-                <dirName>quarkus-app</dirName>
                 <dirName>helm</dirName>
                 <dirName>../src/generated</dirName>
                 <dirName>../src/generated-test</dirName>
                 <!-- Needed for test-mda-models: -->
                 <dirName>../src/main/java</dirName>
                 <!-- Reports needed on CI to ensure consistent reporting of QA metrics: -->
+                <!-- Explicitly navigate to target since Habushu modules use dist as the project build directory -->
                 <dirName>../target/cucumber-reports</dirName>
                 <dirName>../target/surefire-reports</dirName>
                 <dirName>../target/failsafe-reports</dirName>
             </dirNames>
         </attachedOutputs>
         <local>
-            <!-- NB saving more than 1 build can cause issues because it does not restore the prior docker image to the docker daemon. -->
+            <!-- NB: saving more than 1 build can result in stale docker images, as build-cache restore does not restore images -->
             <maxBuildsCached>1</maxBuildsCached>
         </local>
         <projectVersioning adjustMetaInf="true"/>

--- a/DRAFT_RELEASE_NOTES.md
+++ b/DRAFT_RELEASE_NOTES.md
@@ -62,6 +62,7 @@ To reduce burden of upgrading aiSSEMBLE, the Baton project is used to automate t
 | helmfile-generation-migration                      | Generates an initial helmfile.yaml for manual actions to be added to. After its ran once, it will automatically be added to the deactivated list                             |
 | helmfile-aissemble-version-migration               | Updates the aiSSEMBLE version in the deployment values file. This version is used by the helmfile.yaml                                                                       |
 | spark-provided-dependency-migration                | Remove the Hadoop, Hive, and Spark dependencies from the pipeline shaded jar                                                                                                 |
+| maven-build-cache-migration                        | Updates build cache configuration to avoid stale Docker images                                                                                                               |
 
 To deactivate any of these migrations, add the following configuration to the `baton-maven-plugin` within your root `pom.xml`:
 

--- a/foundation/foundation-upgrade/src/main/java/com/boozallen/aissemble/upgrade/migration/version_specific/MavenBuildCacheMigration.java
+++ b/foundation/foundation-upgrade/src/main/java/com/boozallen/aissemble/upgrade/migration/version_specific/MavenBuildCacheMigration.java
@@ -1,0 +1,63 @@
+package com.boozallen.aissemble.upgrade.migration.version_specific;
+
+/*-
+ * #%L
+ * aiSSEMBLE::Foundation::Upgrade
+ * %%
+ * Copyright (C) 2021 Booz Allen
+ * %%
+ * This software package is licensed under the Booz Allen Public License. All Rights Reserved.
+ * #L%
+ */
+
+import com.boozallen.aissemble.upgrade.migration.AbstractAissembleMigration;
+import org.technologybrewery.baton.BatonException;
+import org.technologybrewery.baton.util.FileUtils;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+/**
+ * Updates the `maxBuilds` property of the `maven-build-cache-config.xml` file to 1 with an explanatory comment in order
+ * to avoid issues with stale Docker images when restoring builds from the build cache.x
+ */
+public class MavenBuildCacheMigration extends AbstractAissembleMigration {
+    private static final Pattern MAX_BUILDS = Pattern.compile("( *)<maxBuildsCached>(.*?)</maxBuildsCached>");
+    private static final int MAX_BUILD_COUNT_CAPTURE = 2;
+
+    @Override
+    protected boolean shouldExecuteOnFile(File file) {
+        if (file.getName().endsWith(".xml")) {
+            try (Stream<String> lines = Files.lines(file.toPath())) {
+                return lines.map(MAX_BUILDS::matcher)
+                        .filter(Matcher::find)
+                        .findFirst()
+                        .map(matcher -> matcher.group(MAX_BUILD_COUNT_CAPTURE))
+                        .map(count -> !count.equals("1")).orElse(false);
+            } catch (IOException e) {
+                throw new BatonException("Failed to read build cache config", e);
+            }
+        }
+        return false;
+    }
+
+    @Override
+    protected boolean performMigration(File file) {
+        try {
+            return FileUtils.replaceInFile(file, MAX_BUILDS.pattern(), getMaxBuildsWithComment());
+        } catch (IOException e) {
+            throw new BatonException("Failed to update <maxBuilds> to 1 in: " + file.getPath(), e);
+        }
+    }
+
+    private String getMaxBuildsWithComment() {
+        // note: first capture group of MAX_BUILDS regex is the leading space
+        return """
+$1<!-- NB: saving more than 1 build can result in stale docker images, as build-cache restore does not restore images -->
+$1<maxBuildsCached>1</maxBuildsCached>""";
+    }
+}

--- a/foundation/foundation-upgrade/src/main/resources/migrations.json
+++ b/foundation/foundation-upgrade/src/main/resources/migrations.json
@@ -55,6 +55,15 @@
             ]
           }
         ]
+      },
+      {
+        "name": "maven-build-cache-migration",
+        "implementation": "com.boozallen.aissemble.upgrade.migration.version_specific.MavenBuildCacheMigration",
+        "fileSets": [
+          {
+            "includes": [".mvn/maven-build-cache-config.xml"]
+          }
+        ]
       }
     ]
   },

--- a/foundation/foundation-upgrade/src/test/java/com/boozallen/aissemble/upgrade/migration/version_specific/MavenBuildCacheMigrationSteps.java
+++ b/foundation/foundation-upgrade/src/test/java/com/boozallen/aissemble/upgrade/migration/version_specific/MavenBuildCacheMigrationSteps.java
@@ -1,0 +1,45 @@
+package com.boozallen.aissemble.upgrade.migration.version_specific;
+
+/*-
+ * #%L
+ * aiSSEMBLE::Foundation::Upgrade
+ * %%
+ * Copyright (C) 2021 Booz Allen
+ * %%
+ * This software package is licensed under the Booz Allen Public License. All Rights Reserved.
+ * #L%
+ */
+
+import com.boozallen.aissemble.upgrade.migration.AbstractMigrationTest;
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
+
+public class MavenBuildCacheMigrationSteps extends AbstractMigrationTest {
+
+    @Given("a Maven build cache config with max builds set higher than one")
+    public void aMavenBuildCacheConfigWithMaxBuildsSetHigherThanOne() {
+        setTestFileToVersionMigration("MavenBuildCacheMigration", "multiple-cached-builds.xml");
+    }
+
+    @Given("a Maven build cache config with max builds set to one")
+    public void aMavenBuildCacheConfigWithMaxBuildsSetToOne() {
+        setTestFileToVersionMigration("MavenBuildCacheMigration", "one-max-build.xml");
+    }
+    @When("the 1.13.0 Maven build cache migration executes")
+    public void theMavenBuildCacheMigrationExecutes() {
+        performMigration(new MavenBuildCacheMigration());
+    }
+
+    @Then("the config is updated to set max builds to one")
+    public void theConfigIsUpdatedToSetMaxBuildsTo() {
+        assertMigrationSuccess();
+        assertTestFileMatchesExpectedFile("<maxBuilds> not correctly updated to 1!");
+    }
+
+    @Then("the build cache migration is skipped")
+    public void theBuildCacheMigrationIsSkipped() {
+        assertMigrationSkipped();
+    }
+
+}

--- a/foundation/foundation-upgrade/src/test/resources/specifications/version-specific/maven-build-cache-migration .feature
+++ b/foundation/foundation-upgrade/src/test/resources/specifications/version-specific/maven-build-cache-migration .feature
@@ -1,0 +1,15 @@
+Feature: Update Maven build cache configuration to avoid Docker bug
+
+  The Maven build cache configuration as it existed in 1.12 can result in stale docker images. The default number of
+  builds to save is 5, however restoring anything but the most recent build will result in Java artifacts rolling back,
+  but not the actual Docker image stored in the daemon. This can cause invalid/misleading testing.
+
+  Scenario: Run migration if max builds is not 1
+    Given a Maven build cache config with max builds set higher than one
+    When the 1.13.0 Maven build cache migration executes
+    Then the config is updated to set max builds to one
+
+  Scenario: Skip migration if max builds is already 1
+    Given a Maven build cache config with max builds set to one
+    When the 1.13.0 Maven build cache migration executes
+    Then the build cache migration is skipped

--- a/foundation/foundation-upgrade/src/test/resources/test-files/version-specific/MavenBuildCacheMigration/migration/multiple-cached-builds.xml
+++ b/foundation/foundation-upgrade/src/test/resources/test-files/version-specific/MavenBuildCacheMigration/migration/multiple-cached-builds.xml
@@ -1,4 +1,14 @@
 <?xml version="1.0" encoding="UTF-8" ?>
+<!--
+  #%L
+  aiSSEMBLE::Foundation::Upgrade
+  %%
+  Copyright (C) 2021 Booz Allen
+  %%
+  This software package is licensed under the Booz Allen Public License. All Rights Reserved.
+  #L%
+  -->
+
 <!---
  Licensed to the Apache Software Foundation (ASF) under one or more
  contributor license agreements.  See the NOTICE file distributed with
@@ -37,16 +47,19 @@
         <attachedOutputs>
             <dirNames>
                 <dirName>../dist</dirName>
+                <dirName>quarkus-app</dirName>
+                <dirName>helm</dirName>
+                <dirName>docker</dirName>
+                <dirName>dockerbuild</dirName>
+                <dirName>krausening</dirName>
                 <!-- Reports needed on CI to ensure consistent reporting of QA metrics: -->
-                <!-- Explicitly navigate to target since Habushu modules use dist as the project build directory -->
                 <dirName>../target/cucumber-reports</dirName>
                 <dirName>../target/surefire-reports</dirName>
                 <dirName>../target/failsafe-reports</dirName>
             </dirNames>
         </attachedOutputs>
         <local>
-            <!-- NB: saving more than 1 build can result in stale docker images, as build-cache restore does not restore images -->
-            <maxBuildsCached>1</maxBuildsCached>
+            <maxBuildsCached>5</maxBuildsCached>
         </local>
         <projectVersioning adjustMetaInf="true"/>
     </configuration>
@@ -54,7 +67,7 @@
     <input>
         <global>
             <glob>
-                {*.java,*.json,*.groovy,*.yaml,*.svcd,*.proto,*.xml,*.vm,*.ini,*.jks,*.properties,*.sh,*.bat,*.py,Dockerfile,*.feature,*.lock}
+                {*.java,*.json,*.groovy,*.yaml,*.svcd,*.proto,*.xml,*.vm,*.ini,*.jks,*.properties,*.sh,*.bat,*.py,Dockerfile,*.feature}
             </glob>
             <includes>
                 <include>src/</include>
@@ -63,6 +76,10 @@
                 <include>pom.xml</include>
                 <include>pyproject.toml</include>
             </includes>
+            <excludes>
+                <exclude>poetry.lock</exclude>
+                <exclude>Chart.lock</exclude>
+            </excludes>
         </global>
     </input>
     <executionControl>

--- a/foundation/foundation-upgrade/src/test/resources/test-files/version-specific/MavenBuildCacheMigration/migration/one-max-build.xml
+++ b/foundation/foundation-upgrade/src/test/resources/test-files/version-specific/MavenBuildCacheMigration/migration/one-max-build.xml
@@ -1,4 +1,14 @@
 <?xml version="1.0" encoding="UTF-8" ?>
+<!--
+  #%L
+  aiSSEMBLE::Foundation::Upgrade
+  %%
+  Copyright (C) 2021 Booz Allen
+  %%
+  This software package is licensed under the Booz Allen Public License. All Rights Reserved.
+  #L%
+  -->
+
 <!---
  Licensed to the Apache Software Foundation (ASF) under one or more
  contributor license agreements.  See the NOTICE file distributed with
@@ -37,15 +47,18 @@
         <attachedOutputs>
             <dirNames>
                 <dirName>../dist</dirName>
+                <dirName>quarkus-app</dirName>
+                <dirName>helm</dirName>
+                <dirName>docker</dirName>
+                <dirName>dockerbuild</dirName>
+                <dirName>krausening</dirName>
                 <!-- Reports needed on CI to ensure consistent reporting of QA metrics: -->
-                <!-- Explicitly navigate to target since Habushu modules use dist as the project build directory -->
                 <dirName>../target/cucumber-reports</dirName>
                 <dirName>../target/surefire-reports</dirName>
                 <dirName>../target/failsafe-reports</dirName>
             </dirNames>
         </attachedOutputs>
         <local>
-            <!-- NB: saving more than 1 build can result in stale docker images, as build-cache restore does not restore images -->
             <maxBuildsCached>1</maxBuildsCached>
         </local>
         <projectVersioning adjustMetaInf="true"/>
@@ -54,7 +67,7 @@
     <input>
         <global>
             <glob>
-                {*.java,*.json,*.groovy,*.yaml,*.svcd,*.proto,*.xml,*.vm,*.ini,*.jks,*.properties,*.sh,*.bat,*.py,Dockerfile,*.feature,*.lock}
+                {*.java,*.json,*.groovy,*.yaml,*.svcd,*.proto,*.xml,*.vm,*.ini,*.jks,*.properties,*.sh,*.bat,*.py,Dockerfile,*.feature}
             </glob>
             <includes>
                 <include>src/</include>
@@ -63,6 +76,10 @@
                 <include>pom.xml</include>
                 <include>pyproject.toml</include>
             </includes>
+            <excludes>
+                <exclude>poetry.lock</exclude>
+                <exclude>Chart.lock</exclude>
+            </excludes>
         </global>
     </input>
     <executionControl>

--- a/foundation/foundation-upgrade/src/test/resources/test-files/version-specific/MavenBuildCacheMigration/validation/multiple-cached-builds.xml
+++ b/foundation/foundation-upgrade/src/test/resources/test-files/version-specific/MavenBuildCacheMigration/validation/multiple-cached-builds.xml
@@ -1,4 +1,14 @@
 <?xml version="1.0" encoding="UTF-8" ?>
+<!--
+  #%L
+  aiSSEMBLE::Foundation::Upgrade
+  %%
+  Copyright (C) 2021 Booz Allen
+  %%
+  This software package is licensed under the Booz Allen Public License. All Rights Reserved.
+  #L%
+  -->
+
 <!---
  Licensed to the Apache Software Foundation (ASF) under one or more
  contributor license agreements.  See the NOTICE file distributed with
@@ -37,8 +47,12 @@
         <attachedOutputs>
             <dirNames>
                 <dirName>../dist</dirName>
+                <dirName>quarkus-app</dirName>
+                <dirName>helm</dirName>
+                <dirName>docker</dirName>
+                <dirName>dockerbuild</dirName>
+                <dirName>krausening</dirName>
                 <!-- Reports needed on CI to ensure consistent reporting of QA metrics: -->
-                <!-- Explicitly navigate to target since Habushu modules use dist as the project build directory -->
                 <dirName>../target/cucumber-reports</dirName>
                 <dirName>../target/surefire-reports</dirName>
                 <dirName>../target/failsafe-reports</dirName>
@@ -54,7 +68,7 @@
     <input>
         <global>
             <glob>
-                {*.java,*.json,*.groovy,*.yaml,*.svcd,*.proto,*.xml,*.vm,*.ini,*.jks,*.properties,*.sh,*.bat,*.py,Dockerfile,*.feature,*.lock}
+                {*.java,*.json,*.groovy,*.yaml,*.svcd,*.proto,*.xml,*.vm,*.ini,*.jks,*.properties,*.sh,*.bat,*.py,Dockerfile,*.feature}
             </glob>
             <includes>
                 <include>src/</include>
@@ -63,6 +77,10 @@
                 <include>pom.xml</include>
                 <include>pyproject.toml</include>
             </includes>
+            <excludes>
+                <exclude>poetry.lock</exclude>
+                <exclude>Chart.lock</exclude>
+            </excludes>
         </global>
     </input>
     <executionControl>


### PR DESCRIPTION
Also cleans up unnecessary attached outputs and ensures rebuilds are triggered if lock files change (i.e. an update lock file is checked in by someone else).