### PR TITLE
[#670] makes drift-detection client ITs build-cache compatible

### DIFF
--- a/foundation/foundation-drift-detection/foundation-drift-detection-client-java/pom.xml
+++ b/foundation/foundation-drift-detection/foundation-drift-detection-client-java/pom.xml
@@ -78,6 +78,8 @@
             <groupId>com.boozallen.aissemble</groupId>
             <artifactId>foundation-drift-detection-service</artifactId>
             <version>${project.version}</version>
+            <classifier>app</classifier>
+            <type>zip</type>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -123,6 +125,24 @@
             <build>
                 <plugins>
                     <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-dependency-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>unpack-service-app</id>
+                                <phase>pre-integration-test</phase>
+                                <goals>
+                                    <goal>unpack-dependencies</goal>
+                                </goals>
+                                <configuration>
+                                    <outputDirectory>${project.build.directory}</outputDirectory>
+                                    <failOnMissingClassifierArtifact>true</failOnMissingClassifierArtifact>
+                                    <includeClassifiers>app</includeClassifiers>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
                         <groupId>com.bazaarvoice.maven.plugins</groupId>
                         <artifactId>process-exec-maven-plugin</artifactId>
                         <version>0.7</version>
@@ -135,7 +155,6 @@
                                 </goals>
                                 <configuration>
                                     <name>DriftDetectionService</name>
-                                    <workingDir>target</workingDir>
                                     <waitForInterrupt>false</waitForInterrupt>
                                     <healthcheckUrl>http://localhost:8080/invoke-drift/healthcheck</healthcheckUrl>
                                     <arguments>
@@ -143,7 +162,7 @@
                                         <argument>-DKRAUSENING_BASE=${basedir}/src/test/resources/krausening/base</argument>
                                         <argument>-DDRIFT_DETECTION_POLICIES=${basedir}/src/test/resources/drift-policies</argument>
                                         <argument>-jar</argument>
-                                        <argument>${basedir}/../foundation-drift-detection-service/target/quarkus-app/quarkus-run.jar</argument>
+                                        <argument>${project.build.directory}/quarkus-app/quarkus-run.jar</argument>
                                     </arguments>
                                 </configuration>
                             </execution>

--- a/foundation/foundation-drift-detection/foundation-drift-detection-service/pom.xml
+++ b/foundation/foundation-drift-detection/foundation-drift-detection-service/pom.xml
@@ -126,6 +126,26 @@
                 <artifactId>quarkus-maven-plugin</artifactId>
                 <extensions>true</extensions>
             </plugin>
+            <!-- Packages the quarkus app and its dependencies into a zip-->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <descriptors>
+                        <descriptor>${project.basedir}/src/main/resources/quarkus-app.xml</descriptor>
+                    </descriptors>
+                    <finalName>quarkus</finalName>
+                    <appendAssemblyId>true</appendAssemblyId>
+                </configuration>
+            </plugin>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>

--- a/foundation/foundation-drift-detection/foundation-drift-detection-service/src/main/resources/quarkus-app.xml
+++ b/foundation/foundation-drift-detection/foundation-drift-detection-service/src/main/resources/quarkus-app.xml
@@ -1,0 +1,29 @@
+<!--
+  #%L
+  AIOps Docker Baseline::Versioning::Service
+  %%
+  Copyright (C) 2021 Booz Allen
+  %%
+  This software package is licensed under the Booz Allen Public License. All Rights Reserved.
+  #L%
+  -->
+<assembly
+    xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
+    <id>app</id>
+
+    <includeBaseDirectory>false</includeBaseDirectory>
+
+    <formats>
+        <format>zip</format>
+    </formats>
+
+    <fileSets>
+        <fileSet>
+            <directory>${project.build.directory}/quarkus-app/</directory>
+            <outputDirectory>quarkus-app/</outputDirectory>
+        </fileSet>
+    </fileSets>
+
+</assembly>


### PR DESCRIPTION
We were using a relative path to the drift detection service build output directory to start the quarkus-run jar for the ITs. This only works if the quarkus-app directory is present, which it is not if the build cache causes the service module to be skipped.

This uses the same Quarkus app pattern we've used for our dockerized Quarkus apps in order to ensure the fully-packaged app is available as an artifact, and thus restored by the build-cache and retrievable from the .m2 cache.

This became an issue after the removal of `quarkus-app` from the attached outputs in #665