### PR TITLE
[#671] add empty metadata object to correct linting issues

### DIFF
--- a/extensions/extensions-helm/aissemble-spark-application-chart/values.yaml
+++ b/extensions/extensions-helm/aissemble-spark-application-chart/values.yaml
@@ -1,6 +1,7 @@
 ########################################
 ## CONFIG | Spark Configs
 ########################################
+metadata: {}
 sparkApp:
   spec:
     type: "placeholder" #required for a dry run test to pass, this should always be overridden


### PR DESCRIPTION
This ensures that `.Values.metadata.name` and `.Values.metadata.namespace` don't fail with a NPE