### PR TITLE
#662 - Remove Apache Derby from compile dependencies

### DIFF
--- a/extensions/extensions-data-delivery/extensions-data-delivery-spark/pom.xml
+++ b/extensions/extensions-data-delivery/extensions-data-delivery-spark/pom.xml
@@ -69,6 +69,12 @@
             <artifactId>spark-hive_2.12</artifactId>
             <version>${version.spark}</version>
             <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.derby</groupId>
+                    <artifactId>derby</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.mysql</groupId>

--- a/extensions/extensions-docker/aissemble-hive-service/pom.xml
+++ b/extensions/extensions-docker/aissemble-hive-service/pom.xml
@@ -331,6 +331,32 @@
             <id>integration-test</id>
             <build>
                 <plugins>
+                    <!-- download Apache Derby jars -->
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-dependency-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>copy-derby-jars</id>
+                                <phase>pre-integration-test</phase>
+                                <goals>
+                                    <goal>copy</goal>
+                                </goals>
+                                <configuration>
+                                    <stripVersion>true</stripVersion>
+                                    <artifactItems>
+                                        <artifactItem>
+                                            <groupId>org.apache.derby</groupId>
+                                            <artifactId>derby</artifactId>
+                                            <version>10.14.2.0</version>
+                                            <destFileName>derby.jar</destFileName>
+                                            <outputDirectory>${project.build.directory}</outputDirectory>
+                                        </artifactItem>
+                                    </artifactItems>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
                     <plugin>
                         <groupId>${group.fabric8.plugin}</groupId>
                         <artifactId>docker-maven-plugin</artifactId>
@@ -358,6 +384,11 @@
                                                         </ports>
                                                     </tcp>
                                                 </wait>
+                                                <volumes>
+                                                    <bind>
+                                                        <volume>${project.build.directory}/derby.jar:/opt/hive/lib/derby.jar</volume>
+                                                    </bind>
+                                                </volumes>
                                             </run>
                                         </image>
                                     </images>

--- a/extensions/extensions-docker/aissemble-hive-service/src/main/resources/docker/Dockerfile
+++ b/extensions/extensions-docker/aissemble-hive-service/src/main/resources/docker/Dockerfile
@@ -43,6 +43,8 @@ RUN sed -i \
     's/org.apache.hadoop.hive.metastore.tools.MetastoreSchemaTool/org.apache.hadoop.hive.metastore.tools.schematool.MetastoreSchemaTool/' \
     "$HIVE_HOME/bin/ext/schemaTool.sh"
 
+RUN find / -type f -name '*derby*.jar' -delete
+
 FROM registry.access.redhat.com/ubi9/openjdk-17-runtime:1.21 as final
 
 LABEL org.opencontainers.image.source="https://github.com/boozallen/aissemble"

--- a/extensions/extensions-docker/aissemble-spark-infrastructure/pom.xml
+++ b/extensions/extensions-docker/aissemble-spark-infrastructure/pom.xml
@@ -97,6 +97,32 @@
             <id>integration-test</id>
             <build>
                 <plugins>
+                    <!-- download Apache Derby jars -->
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-dependency-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>copy-derby-jars</id>
+                                <phase>pre-integration-test</phase>
+                                <goals>
+                                    <goal>copy</goal>
+                                </goals>
+                                <configuration>
+                                    <stripVersion>true</stripVersion>
+                                    <artifactItems>
+                                        <artifactItem>
+                                            <groupId>org.apache.derby</groupId>
+                                            <artifactId>derby</artifactId>
+                                            <version>10.14.2.0</version>
+                                            <destFileName>derby.jar</destFileName>
+                                            <outputDirectory>${project.build.directory}</outputDirectory>
+                                        </artifactItem>
+                                    </artifactItems>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
                     <plugin>
                         <groupId>${group.fabric8.plugin}</groupId>
                         <artifactId>docker-maven-plugin</artifactId>
@@ -123,6 +149,7 @@
                                                 <volumes>
                                                     <bind>
                                                         <volume>${project.basedir}/src/test/resources:/tmp/test</volume>
+                                                        <volume>${project.build.directory}/derby.jar:/opt/spark/jars/derby.jar</volume>
                                                     </bind>
                                                 </volumes>
                                             </run>

--- a/extensions/extensions-docker/aissemble-spark/pom.xml
+++ b/extensions/extensions-docker/aissemble-spark/pom.xml
@@ -18,7 +18,6 @@
         <dockerbuild.patch.directory>target/dockerbuild/patch</dockerbuild.patch.directory>
         <version.netty>4.1.118.Final</version.netty>
         <version.avro>1.11.4</version.avro>
-        <version.derby>10.16.1.1</version.derby>
         <version.hive.client>2.3.10</version.hive.client>
         <version.parquet>1.15.0</version.parquet>
         <version.zookeeper>3.9.3</version.zookeeper>
@@ -185,42 +184,6 @@
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
             <version>1.17.2</version>
-            <scope>provided</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.derby</groupId>
-            <artifactId>derby</artifactId>
-            <version>${version.derby}</version>
-            <scope>provided</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.derby</groupId>
-            <artifactId>derbyshared</artifactId>
-            <version>${version.derby}</version>
-            <scope>provided</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.derby</groupId>
-            <artifactId>derbytools</artifactId>
-            <version>${version.derby}</version>
             <scope>provided</scope>
             <exclusions>
                 <exclusion>

--- a/extensions/extensions-docker/aissemble-spark/src/main/resources/docker/Dockerfile
+++ b/extensions/extensions-docker/aissemble-spark/src/main/resources/docker/Dockerfile
@@ -57,6 +57,8 @@ COPY --chmod=755 ./src/main/resources/scripts/setup.sh $SPARK_HOME/setup.sh
 RUN --mount=target=/tmp/patch-jars,type=bind,source=${PATCH_DIR} \
     $SPARK_HOME/setup.sh /tmp/patch-jars $SPARK_HOME $SPARK_VERSION $HADOOP_VERSION
 
+RUN find / -type f -name '*derby*.jar' -delete
+
 ## Add spark configurations
 COPY ./src/main/resources/conf/ $SPARK_HOME/conf/
 RUN chown -R spark:spark $SPARK_HOME

--- a/extensions/extensions-metadata-service/pom.xml
+++ b/extensions/extensions-metadata-service/pom.xml
@@ -123,6 +123,12 @@
             <artifactId>spark-hive_2.12</artifactId>
             <version>${version.spark}</version>
             <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.derby</groupId>
+                    <artifactId>derby</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>
@@ -220,6 +226,12 @@
         <dependency>
             <groupId>io.smallrye.reactive</groupId>
             <artifactId>smallrye-reactive-messaging-in-memory</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.derby</groupId>
+            <artifactId>derby</artifactId>
+            <version>10.14.2.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/extensions/extensions-transform/extensions-transform-spark-java/pom.xml
+++ b/extensions/extensions-transform/extensions-transform-spark-java/pom.xml
@@ -56,6 +56,12 @@
             <artifactId>spark-hive_2.12</artifactId>
             <version>${version.spark}</version>
             <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.derby</groupId>
+                    <artifactId>derby</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>

--- a/foundation/foundation-drift-detection/aissemble-foundation-drift-detection-client-python/pom.xml
+++ b/foundation/foundation-drift-detection/aissemble-foundation-drift-detection-client-python/pom.xml
@@ -22,6 +22,17 @@
 <!--        </dependency>-->
 <!--    </dependencies>-->
 
+    <dependencies>
+        <dependency>
+            <groupId>com.boozallen.aissemble</groupId>
+            <artifactId>foundation-drift-detection-service</artifactId>
+            <version>${project.version}</version>
+            <classifier>app</classifier>
+            <type>zip</type>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
     <build>
         <directory>dist</directory>
         <plugins>
@@ -55,9 +66,70 @@
                     <plugin>
                         <groupId>org.technologybrewery.habushu</groupId>
                         <artifactId>habushu-maven-plugin</artifactId>
-                        <configuration>
-                            <behaveOptions>--tags ~manual</behaveOptions>
-                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>integration-tests</id>
+                                <phase>integration-test</phase>
+                                <goals>
+                                    <goal>behave-bdd-test</goal>
+                                </goals>
+                                <configuration>
+                                    <behaveOptions>--tags integration</behaveOptions>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-dependency-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>unpack-service-app</id>
+                                <phase>pre-integration-test</phase>
+                                <goals>
+                                    <goal>unpack-dependencies</goal>
+                                </goals>
+                                <configuration>
+                                    <outputDirectory>${project.build.directory}</outputDirectory>
+                                    <failOnMissingClassifierArtifact>true</failOnMissingClassifierArtifact>
+                                    <includeClassifiers>app</includeClassifiers>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>com.bazaarvoice.maven.plugins</groupId>
+                        <artifactId>process-exec-maven-plugin</artifactId>
+                        <version>0.7</version>
+                        <executions>
+                            <execution>
+                                <id>foundation-drift-detection-service</id>
+                                <phase>pre-integration-test</phase>
+                                <goals>
+                                    <goal>start</goal>
+                                </goals>
+                                <configuration>
+                                    <name>DriftDetectionService</name>
+                                    <waitForInterrupt>false</waitForInterrupt>
+                                    <healthcheckUrl>http://localhost:8084/invoke-drift/healthcheck</healthcheckUrl>
+                                    <arguments>
+                                        <argument>java</argument>
+                                        <argument>-DKRAUSENING_BASE=${basedir}/tests/resources/config/</argument>
+                                        <argument>-DDRIFT_DETECTION_POLICIES=${basedir}/tests/resources/drift-policies</argument>
+                                        <argument>-Dquarkus.http.port=8084</argument>
+                                        <argument>-jar</argument>
+                                        <argument>${project.build.directory}/quarkus-app/quarkus-run.jar</argument>
+                                    </arguments>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>stop-all</id>
+                                <phase>post-integration-test</phase>
+                                <goals>
+                                    <goal>stop-all</goal>
+                                </goals>
+                            </execution>
+                        </executions>
                     </plugin>
                 </plugins>
             </build>

--- a/foundation/foundation-drift-detection/aissemble-foundation-drift-detection-client-python/tests/features/environment.py
+++ b/foundation/foundation-drift-detection/aissemble-foundation-drift-detection-client-python/tests/features/environment.py
@@ -17,54 +17,11 @@ logger = LogManager.get_instance().get_logger("Environment")
 
 
 def before_all(context):
-    krauseningBasePath = os.path.abspath("tests/resources/config")
-    krauseningBaseArg = "-DKRAUSENING_BASE=" + krauseningBasePath
-    driftDetectionPolicyPath = os.path.abspath("tests/resources/drift-policies")
-    driftDetectionPolicyArg = "-DDRIFT_DETECTION_POLICIES=" + driftDetectionPolicyPath
-    servicePortArg = "-Dquarkus.http.port=8084"
-    driftDetectionServicePath = os.path.abspath(
-        "../foundation-drift-detection-service/target/quarkus-app/quarkus-run.jar"
-    )
-    logger.info(f"Starting Drift Detection Service")
-    context.driftDetectionService = subprocess.Popen(
-        [
-            "java",
-            krauseningBaseArg,
-            servicePortArg,
-            driftDetectionPolicyArg,
-            "-jar",
-            driftDetectionServicePath,
-        ]
-    )
-
-    # call to health check to verify Drift Detection Services are started
-    health_check_url = "http://localhost:8084/invoke-drift/health-check"
-    success = False
-    retries = 1
-    wait = 0.1
-    while not success and retries < 10:
-        try:
-            resp = requests.get(url=health_check_url).json()
-            if resp["status"] == "UP":
-                success = True
-        except:
-            logger.info(
-                f"Waiting {wait} seconds for Drift Detection Services to start - waiting for a response from {health_check_url}"
-            )
-            time.sleep(wait)
-            retries += 1
-            wait *= 2
-
-    (
-        logger.info(f"Drift Detection Service started")
-        if success
-        else logger.info(f"Drift Detection Service failed to start")
-    )
+    pass
 
 
 def after_all(context):
-    logger.info(f"Stopping Drift Detection Service")
-    context.driftDetectionService.kill()
+    pass
 
 
 def before_tag(context, tag):

--- a/test/test-mda-models/test-data-delivery-spark-model-basic/pom.xml
+++ b/test/test-mda-models/test-data-delivery-spark-model-basic/pom.xml
@@ -195,6 +195,12 @@
             <artifactId>spark-hive_2.12</artifactId>
             <version>${version.spark}</version>
             <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.derby</groupId>
+                    <artifactId>derby</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>

--- a/test/test-mda-models/test-data-delivery-spark-model/pom.xml
+++ b/test/test-mda-models/test-data-delivery-spark-model/pom.xml
@@ -282,6 +282,12 @@
             <artifactId>spark-hive_2.12</artifactId>
             <version>${version.spark}</version>
             <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.derby</groupId>
+                    <artifactId>derby</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>


### PR DESCRIPTION
#662 
- Remove Apache Derby from compile dependencies.
- Enabled drift-detection client (Python) ITs build-cache compatible. 