### PR TITLE
[#686] updating aissemble-versioning chart tests to match expected value

### DIFF
--- a/extensions/extensions-helm/aissemble-versioning-chart/tests/deployment_test.yaml
+++ b/extensions/extensions-helm/aissemble-versioning-chart/tests/deployment_test.yaml
@@ -8,7 +8,7 @@ tests:
           of: Deployment
       - equal:
           path: metadata.name
-          value: aissemble-versioning-chart
+          value: aissemble-versioning
       - equal:
           path: spec.template.spec.automountServiceAccountToken
           value: false

--- a/extensions/extensions-helm/aissemble-versioning-chart/tests/service_test.yaml
+++ b/extensions/extensions-helm/aissemble-versioning-chart/tests/service_test.yaml
@@ -8,10 +8,10 @@ tests:
           of: Service
       - equal:
           path: metadata.name
-          value: aissemble-versioning-chart
+          value: aissemble-versioning
       - equal:
           path: spec.selector["app.kubernetes.io/name"]
-          value: aissemble-versioning-chart
+          value: aissemble-versioning
       - contains:
           path: spec.ports
           content:


### PR DESCRIPTION
Build broke because I didn't properly match the tests names to the expected `app.name` in the aissemble-versioning chart