### PR TITLE
703 feature add ruff toml file creation

### DIFF
--- a/DRAFT_RELEASE_NOTES.md
+++ b/DRAFT_RELEASE_NOTES.md
@@ -99,6 +99,7 @@ To reduce burden of upgrading aiSSEMBLE, the Baton project is used to automate t
 | my-sql-connector-yaml-migration                    | Update the my-sql-connector package to use the version with no CVE issue                                                                                                     |                                     |
 | trino-delta-lake-connector-yaml-migration          | Add the Delta Lake connector configuration in the Trino chart values.yaml file                                                                                               |                                     |
 | habushu-monorepo-dependency-migration              | Ensures that all dependencies from Habushu modules on other Habushu modules in the same project are type `habushu`                                                           |                                     |
+| ruff-toml-file-generation-migration                | Generates an initial ruff.toml file with a few lines of configuration to make the ruff linting and formatting consistent with prior linting and formatting.  This file can be configured using https://docs.astral.sh/ruff/configuration/ as a guide |                                     |
 
 Migrations with arguments will not be executed unless that argument is provided (e.g. `./mvnw org.technologybrewery.baton:baton-maven-plugin:baton-migrate -D<argumentName>`). To deactivate any of these migrations, add the following configuration to the `baton-maven-plugin` within your root `pom.xml`:
 

--- a/foundation/aissemble-foundation-model-training-api/pyproject.toml
+++ b/foundation/aissemble-foundation-model-training-api/pyproject.toml
@@ -33,8 +33,3 @@ ruff = "^0.11.7"
 [build-system]
 requires = ["poetry-core>=1.7.0"]
 build-backend = "poetry.core.masonry.api"
-<<<<<<< HEAD
-=======
-
-
->>>>>>> 44ee8940 ([#678] habushu upgrade + automatic updates + ruff lint ignore codes)

--- a/foundation/aissemble-foundation-versioning-service/pyproject.toml
+++ b/foundation/aissemble-foundation-versioning-service/pyproject.toml
@@ -17,12 +17,7 @@ readme = "README.md"
 # the versioning_api.py module within aissemble-versioning-docker are defined here and installed when the corresponding
 # wheel for aissemble-versioning-service is installed.
 [tool.poetry.dependencies]
-<<<<<<< HEAD
 mlflow = "2.10.2"
-=======
-
-mlflow = "2.3.1"
->>>>>>> 44ee8940 ([#678] habushu upgrade + automatic updates + ruff lint ignore codes)
 fastapi = ">=0.95.0"
 uvicorn = {version = "^0.18.0", extras = ["standard"]}
 

--- a/foundation/foundation-upgrade/src/main/java/com/boozallen/aissemble/upgrade/migration/version_specific/RuffTomlFileGenerationMigration.java
+++ b/foundation/foundation-upgrade/src/main/java/com/boozallen/aissemble/upgrade/migration/version_specific/RuffTomlFileGenerationMigration.java
@@ -1,0 +1,104 @@
+package com.boozallen.aissemble.upgrade.migration.version_specific;
+
+/*-
+ * #%L
+ * aiSSEMBLE::Foundation::Upgrade
+ * %%
+ * Copyright (C) 2021 Booz Allen
+ * %%
+ * This software package is licensed under the Booz Allen Public License. All Rights Reserved.
+ * #L%
+ */
+
+import com.boozallen.aissemble.upgrade.migration.AbstractAissembleMigration;
+import org.apache.commons.io.FileUtils;
+import org.apache.maven.project.MavenProject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.technologybrewery.baton.BatonException;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * Migration to create the initial ruff.toml file the archetype creates. If projects are upgrading to this version then
+ * they will not be running the archetype generation and will not have the default  ruff.toml file to add manual actions too
+ * . Because projects may choose not to use  ruff.toml file, the migration will only run if the  ruff.toml file migration enable
+ * key is set to true.
+ */
+public class RuffTomlFileGenerationMigration extends AbstractAissembleMigration {
+    private static final Logger logger = LoggerFactory.getLogger(RuffTomlFileGenerationMigration.class);
+    public static final String RUFF_TOML_FILE = "ruff.toml";
+    private String ruffFileLocation;
+
+    /**
+     * Determines whether the migration should execute.
+     * Migration will run if the there is a hubushu module in the project.
+     *
+     * @param file pom file to check
+     * @return true if the migration should run
+     */
+    @Override
+    protected boolean shouldExecuteOnFile(File file) {
+        return hasHabushuModuleAndRuffTolmFileDoesNotAlreadyExist(getRootProject());
+    }
+
+    /**
+     * First checks if the  ruff.toml files exist. If not, initialize it.
+     *
+     * @param file pom file to migrate
+     * @return true if migration was successful
+     */
+    @Override
+    protected boolean performMigration(File file) {
+        createRuffTomlFileIfNotExist();
+        return true;
+    }
+
+    private void createRuffTomlFileIfNotExist() throws BatonException {
+        try {
+            InputStream initialRuffTomlFile = getClass().getClassLoader().getResourceAsStream("version_specific/" + RUFF_TOML_FILE);
+
+            if (initialRuffTomlFile == null) {
+                throw new BatonException("Could not find the ruff.toml template");
+            }
+            File ruffTomlFile = new File(getRuffTomlFileLocation());
+            FileUtils.copyInputStreamToFile(initialRuffTomlFile, ruffTomlFile);
+        } catch (IOException e) {
+            throw new BatonException("Failed to instantiate the riff.toml file", e);
+        }
+        logger.info("Initialized root ruff.toml");
+    }
+
+    /**
+     * Checks if the ruff.toml file already exists and if the project has a habushu sub-module
+     * @param mavenProject The maven project object
+     * @return if there is no ruff.toml file and the project has a habushu sub-module
+     */
+    protected boolean hasHabushuModuleAndRuffTolmFileDoesNotAlreadyExist(MavenProject mavenProject) {
+        boolean hasHabushuModule = false;
+
+        try {
+            hasHabushuModule = mavenProject.getCollectedProjects().stream().anyMatch(proj -> proj.getPackaging().equals("habushu"));
+        } catch (Exception e) {
+            logger.warn("Unable to check for habushu modules");
+        }
+
+        return hasHabushuModule && !ruffTomlFileExists();
+    }
+
+    private boolean ruffTomlFileExists() {
+        File ruffTolmFile = new File(getRuffTomlFileLocation());
+
+        return ruffTolmFile.exists();
+    }
+
+    private String getRuffTomlFileLocation() {
+        if(ruffFileLocation == null){
+            ruffFileLocation = getRootProject().getBasedir().getPath() + "/" + RUFF_TOML_FILE;
+        }
+        
+        return ruffFileLocation;
+    }
+}

--- a/foundation/foundation-upgrade/src/main/resources/migrations.json
+++ b/foundation/foundation-upgrade/src/main/resources/migrations.json
@@ -170,6 +170,24 @@
             "includes": ["src/main/resources/apps/trino/values.yaml"]
           }
         ]
+      },
+      {
+        "name": "trino-delta-lake-connector-yaml-migration",
+        "implementation": "com.boozallen.aissemble.upgrade.migration.version_specific.TrinoDeltaLakeConnectorYamlMigration",
+        "fileSets": [
+          {
+            "includes": ["src/main/resources/apps/trino/values.yaml"]
+          }
+        ]
+      },
+      {
+        "name": "ruff-toml-file-generation-migration",
+        "implementation": "com.boozallen.aissemble.upgrade.migration.version_specific.RuffTomlFileGenerationMigration",
+        "fileSets": [
+          {
+            "includes": ["pom.xml"]
+          }
+        ]
       }
     ]
   }

--- a/foundation/foundation-upgrade/src/main/resources/version_specific/ruff.toml
+++ b/foundation/foundation-upgrade/src/main/resources/version_specific/ruff.toml
@@ -1,0 +1,2 @@
+[lint]
+ignore = ["E4","E7","F"]

--- a/foundation/foundation-upgrade/src/test/java/com/boozallen/aissemble/upgrade/migration/extensions/RuffTomlFileGenerationMigrationTest.java
+++ b/foundation/foundation-upgrade/src/test/java/com/boozallen/aissemble/upgrade/migration/extensions/RuffTomlFileGenerationMigrationTest.java
@@ -1,0 +1,35 @@
+package com.boozallen.aissemble.upgrade.migration.extensions;
+
+/*-
+ * #%L
+ * aiSSEMBLE::Foundation::Upgrade
+ * %%
+ * Copyright (C) 2021 Booz Allen
+ * %%
+ * This software package is licensed under the Booz Allen Public License. All Rights Reserved.
+ * #L%
+ */
+
+import com.boozallen.aissemble.upgrade.migration.version_specific.RuffTomlFileGenerationMigration;
+import org.apache.maven.model.Model;
+import org.apache.maven.model.io.xpp3.MavenXpp3Reader;
+import org.apache.maven.project.MavenProject;
+import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
+
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.util.List;
+
+public class RuffTomlFileGenerationMigrationTest extends RuffTomlFileGenerationMigration {
+
+    public RuffTomlFileGenerationMigrationTest(File testPom) throws IOException, XmlPullParserException {
+        Model model = new MavenXpp3Reader().read(new FileReader(testPom));
+        MavenProject project = new MavenProject(model);
+        project.setFile(testPom);
+        MavenProject habushuMavenProject = new MavenProject();
+        habushuMavenProject.setPackaging("habushu");
+        project.setCollectedProjects(List.of(habushuMavenProject));
+        setMavenProject(project);
+    }
+}

--- a/foundation/foundation-upgrade/src/test/java/com/boozallen/aissemble/upgrade/migration/version_specific/RuffTomlFileGenerationMigrationStep.java
+++ b/foundation/foundation-upgrade/src/test/java/com/boozallen/aissemble/upgrade/migration/version_specific/RuffTomlFileGenerationMigrationStep.java
@@ -1,0 +1,43 @@
+package com.boozallen.aissemble.upgrade.migration.version_specific;
+
+/*-
+ * #%L
+ * aiSSEMBLE::Foundation::Upgrade
+ * %%
+ * Copyright (C) 2021 Booz Allen
+ * %%
+ * This software package is licensed under the Booz Allen Public License. All Rights Reserved.
+ * #L%
+ */
+
+import com.boozallen.aissemble.upgrade.migration.AbstractMigrationTest;
+import com.boozallen.aissemble.upgrade.migration.extensions.RuffTomlFileGenerationMigrationTest;
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
+import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+
+import static org.junit.Assert.assertTrue;
+
+public class RuffTomlFileGenerationMigrationStep extends AbstractMigrationTest {
+
+    @Given("a projects does not have a root ruff.toml file")
+    public void a_projects_does_not_have_a_root_ruff_toml_file() {
+        setTestFileToVersionMigration("RuffTomlfileGenerationMigration", "pom.xml");
+    }
+
+    @When("the ruff.toml generation migration is performed")
+    public void the_ruff_toml_generation_migration_is_performed() throws XmlPullParserException, IOException {
+        performMigration(new RuffTomlFileGenerationMigrationTest(testFile));
+    }
+
+    @Then("the ruff.toml is generated")
+    public void the_ruff_toml_is_generated() throws IOException {
+        File ruffTomlFile = new File(testFile.getParentFile(), RuffTomlFileGenerationMigration.RUFF_TOML_FILE);
+        assertTrue("ruff.toml was not generated.", ruffTomlFile.exists());
+    }
+}

--- a/foundation/foundation-upgrade/src/test/resources/specifications/version-specific/ruff-toml-file-generation-migration.feature
+++ b/foundation/foundation-upgrade/src/test/resources/specifications/version-specific/ruff-toml-file-generation-migration.feature
@@ -1,0 +1,7 @@
+@helmfile-generate
+Feature: Helmfile generation migration is performed correctly and only when needed
+
+  Scenario: The project does not have a root ruff.toml file
+    Given a projects does not have a root ruff.toml file
+    When the ruff.toml generation migration is performed
+    Then the ruff.toml is generated

--- a/foundation/foundation-upgrade/src/test/resources/test-files/version-specific/RuffTomlFileGenerationMigration/migration/pom.xml
+++ b/foundation/foundation-upgrade/src/test/resources/test-files/version-specific/RuffTomlFileGenerationMigration/migration/pom.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  aiSSEMBLE::Foundation::Upgrade
+  %%
+  Copyright (C) 2021 Booz Allen
+  %%
+  This software package is licensed under the Booz Allen Public License. All Rights Reserved.
+  #L%
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.boozallen.aissemble</groupId>
+        <artifactId>build-parent</artifactId>
+        <version>1.13.0</version>
+    </parent>
+
+    <groupId>com.test</groupId>
+    <artifactId>simple-project</artifactId>
+    <packaging>pom</packaging>
+    <version>1.0.0</version>
+    <name>Test Helmfile Generation::Project::Simple Project</name>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.technologybrewery.baton</groupId>
+                <artifactId>baton-maven-plugin</artifactId>
+                <dependencies>
+                    <dependency>
+                        <groupId>com.boozallen.aissemble</groupId>
+                        <artifactId>foundation-upgrade</artifactId>
+                        <version>${version.aissemble}</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>


### PR DESCRIPTION
Adding a migration to handle adding the ruff.toml to a project when they have at least one habushu module.