### PR TITLE
use separate state dir for fabric8's docker plugin

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -583,6 +583,7 @@
                                     </args>
                                     <buildx>
                                         <builderName>default</builderName>
+                                        <!-- use a separate state dir to ensure pre-configured credentials are not deleted -->
                                         <dockerStateDir>~/.docker/fabric8</dockerStateDir>
                                         <platforms>
                                             <platform>${docker.platforms}</platform>

--- a/extensions/extensions-docker/pom.xml
+++ b/extensions/extensions-docker/pom.xml
@@ -150,7 +150,6 @@
             <id>gh-build</id>
             <properties>
                 <docker.builder.name>${env.DOCKER_BUILDER_NAME}</docker.builder.name>
-                <docker.builder.stateDir>~/.docker</docker.builder.stateDir>
             </properties>
             <build>
                 <pluginManagement>
@@ -164,7 +163,6 @@
                                         <build>
                                             <buildx>
                                                 <builderName>${docker.builder.name}</builderName>
-                                                <dockerStateDir>${docker.builder.stateDir}</dockerStateDir>
                                             </buildx>
                                         </build>
                                     </image>


### PR DESCRIPTION
Fabric8's docker-maven-plugin cleans up the state directory after each build. It initially copies the `~/.docker` directory into the state directory, but after each build it deletes the state directory. If the Fabric8 state directory is also `~/.docker`, it will delete any pre-configurations after the first image build, including login credentials.