### PR TITLE
create the builders in fabric8s config directory

### DIFF
--- a/.github/actions/install_dependencies/action.yaml
+++ b/.github/actions/install_dependencies/action.yaml
@@ -12,10 +12,12 @@ runs:
     - name: Install required packages
       shell: bash
       run: |
+        echo "::group::APT installs"
         sudo apt-get update
         sudo apt install -y build-essential libssl-dev zlib1g-dev libbz2-dev libreadline-dev libsqlite3-dev curl \
           git libncursesw5-dev xz-utils tk-dev libxml2-dev libxmlsec1-dev libffi-dev liblzma-dev zip unzip \
           libpython3.11
+        echo "::endgroup::"
     - name: Install Python
       uses: gabrielfalcao/pyenv-action@v18
       with:
@@ -29,14 +31,18 @@ runs:
     - name: Install Helm
       shell: bash
       run: |
+        echo "::group::Install Helm"
         curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3
         chmod 700 get_helm.sh
         ./get_helm.sh
+        echo "::endgroup::"
     - name: Install Helm Unittest Plugin
       shell: bash
       run: |
+        echo "::group::Install Helm Unittest"
         echo "Updating helm unittest plugin to latest version..."
         helm plugin install https://github.com/helm-unittest/helm-unittest.git
+        echo "::endgroup::"
     - name: Set up JDK 17
       uses: actions/setup-java@v4
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -100,6 +100,7 @@ jobs:
                                 --driver=kubernetes \
                                 --platform=linux/arm64 \
                                 --driver-opt="nodeselector=kubernetes.io/arch=arm64","image=docker.io/moby/buildkit:v0.19.0"
+          cp -R ~/.docker ~/.docker/fabric8
       # Generate the settings.xml for ghcr.io, pypi, & dev-pypi server profiles
       - name: Create settings.xml
         id: create-settings-xml


### PR DESCRIPTION
We can't directly use `--config ~/.docker/fabric8` because it will not
be present with the buildx plugin on a fresh action runner. Instead, we
just wholesale copy the setup from `.docker` into the fabric8 directory.
This allows for the credentials to be preserved in the root `.docker`
directory between image builds, and still allows us to do default
builder management in the build setup.

Also groups the install dependencies steps for more readable output.