### PR TITLE
[#712] improve build stability

### DIFF
--- a/.github/actions/install_dependencies/action.yaml
+++ b/.github/actions/install_dependencies/action.yaml
@@ -34,7 +34,7 @@ runs:
         echo "::group::Install Helm"
         curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3
         chmod 700 get_helm.sh
-        ./get_helm.sh
+        ./get_helm.sh -v 3.17.3
         echo "::endgroup::"
     - name: Install Helm Unittest Plugin
       shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,11 +1,3 @@
-# This workflow will build a Java project with Maven, and cache/restore any dependencies to improve the workflow execution time
-# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-java-with-maven
-
-# This workflow uses actions that are not certified by GitHub.
-# They are provided by a third-party and are governed by
-# separate terms of service, privacy policy, and support
-# documentation.
-
 name: Build aissemble
 
 on:
@@ -25,7 +17,6 @@ jobs:
   build:
     runs-on: arc-runner-set-aissemble
     env:
-      DOCKER_CONFIG: /home/runner/.docker
       RUNS_ON_S3_BUCKET_CACHE: aissemble-github-cache
       DOCKER_BUILDER_NAME: k8s-multiarch
     steps:
@@ -100,17 +91,39 @@ jobs:
                                 --driver=kubernetes \
                                 --platform=linux/arm64 \
                                 --driver-opt="nodeselector=kubernetes.io/arch=arm64","image=docker.io/moby/buildkit:v0.19.0"
-          mkdir -p ~/.docker/fabric8/buildx && cp -R ~/.docker/buildx ~/.docker/fabric8/buildx
+          mkdir ~/.docker/fabric8 && cp -R ~/.docker/buildx ~/.docker/fabric8/buildx
       # Generate the settings.xml for ghcr.io, pypi, & dev-pypi server profiles
       - name: Create settings.xml
         id: create-settings-xml
         run: |
-          echo "<settings><servers><server><id>ghcr.io</id><username>${{ secrets.GHCR_IO_USERNAME }}</username><password>${{ secrets.GHCR_IO_TOKEN }}</password></server><server><id>pypi</id><username>${{ secrets.PYPI_USERNAME }}</username><password>${{ secrets.PYPI_TOKEN }}</password></server><server><id>dev-pypi</id><username>${{ secrets.TEST_PYPI_USERNAME }}</username><password>${{ secrets.TEST_PYPI_TOKEN }}</password></server> </servers></settings>" > $HOME/.m2/settings.xml
+          cat > $HOME/.m2/settings.xml << EOF
+          <settings>
+            <servers>
+              <server>
+                <id>ghcr.io</id>
+                <username>\${env.GITHUB_ACTOR}</username>
+                <password>\${env.GITHUB_TOKEN}</password>
+              </server>
+              <server>
+                <id>pypi</id>
+                <username>${{ secrets.PYPI_USERNAME }}</username>
+                <password>${{ secrets.PYPI_TOKEN }}</password>
+              </server>
+              <server>
+                <id>dev-pypi</id>
+                <username>${{ secrets.TEST_PYPI_USERNAME }}</username>
+                <password>${{ secrets.TEST_PYPI_TOKEN }}</password>
+              </server>
+            </servers>
+          </settings>
+          EOF
           echo "HOME_DIR=$HOME" >> "$GITHUB_OUTPUT"
       # Run build with the gh-build profile
       - name: Build aiSSEMBLE
         run: |
-          ./mvnw -B clean deploy -U -file pom.xml -Pci,integration-test,gh-build --settings $HOME/.m2/settings.xml
+          ./mvnw clean deploy -B -U -Pci,integration-test,gh-build
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       # Install Maven which is needed for archetype tests
       - name: Set up Maven
         uses: stCarolas/setup-maven@v5
@@ -120,6 +133,8 @@ jobs:
       - name: Run Archetype Tests
         run: |
           ./mvnw -B clean install -Parchetype-test -pl :foundation-archetype
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Submit Dependency Graph
         uses: advanced-security/maven-dependency-submission-action@v4
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Install Antora
         run: npm i antora
       - name: Generate Site
-        run: GIT_CREDENTIALS="https://${{ secrets.PAT }}:@github.com" npx antora docs/antora-playbook.yml
+        run: npx antora docs/antora-playbook.yml
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,11 +1,3 @@
-# This workflow will build a Java project with Maven, and cache/restore any dependencies to improve the workflow execution time
-# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-java-with-maven
-
-# This workflow uses actions that are not certified by GitHub.
-# They are provided by a third-party and are governed by
-# separate terms of service, privacy policy, and support
-# documentation.
-
 name: Release aissemble
 
 on:
@@ -29,7 +21,6 @@ jobs:
 
     runs-on: arc-runner-set-aissemble
     env:
-      DOCKER_CONFIG: /home/runner/.docker
       RELEASE_VERSION: ${{ inputs.releaseVersion }}
       NEXT_DEVELOPMENT_VERSION: ${{ inputs.developmentVersion }}
       RELEASE_BRANCH: ${{ inputs.releaseBranch }}
@@ -75,11 +66,35 @@ jobs:
           docker-username: ${{ secrets.DOCKERHUB_USERNAME }}
           docker-token: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Create settings.xml
+        id: create-settings-xml
         run: |
-          echo "<settings><servers><server><id>ossrh</id><username>${{ secrets.SONATYPE_CENTRAL_REPO_TOKEN_USER }}</username><password>${{ secrets.SONATYPE_CENTRAL_REPO_TOKEN_KEY }}</password></server><server><id>ghcr.io</id><username>${{ secrets.GHCR_IO_USERNAME }}</username><password>${{ secrets.GHCR_IO_TOKEN }}</password></server><server><id>pypi</id><username>${{ secrets.PYPI_USERNAME }}</username><password>${{ secrets.PYPI_TOKEN }}</password></server></servers></settings>" > $HOME/.m2/settings.xml
+          cat > $HOME/.m2/settings.xml << EOF
+          <settings>
+            <servers>
+              <server>
+                <id>ossrh</id>
+                <username>${{ secrets.SONATYPE_CENTRAL_REPO_TOKEN_USER }}</username>
+                <password>${{ secrets.SONATYPE_CENTRAL_REPO_TOKEN_KEY }}</password>
+              </server>
+              <server>
+                <id>ghcr.io</id>
+                <username>\${env.GITHUB_ACTOR}</username>
+                <password>\${env.GITHUB_TOKEN}</password>
+              </server>
+              <server>
+                <id>pypi</id>
+                <username>${{ secrets.PYPI_USERNAME }}</username>
+                <password>${{ secrets.PYPI_TOKEN }}</password>
+              </server>
+            </servers>
+          </settings>
+          EOF
+          echo "HOME_DIR=$HOME" >> "$GITHUB_OUTPUT"
       - name: Release aiSSEMBLE
         run: | 
-          ./mvnw release:clean release:prepare release:perform -s $HOME/.m2/settings.xml -U -B -Pci,gh-build -DpushChanges=true -DreleaseVersion=${{ env.RELEASE_VERSION }} -DdevelopmentVersion=${{ env.NEXT_DEVELOPMENT_VERSION }} -Dgpg.keyname=aissemble@bah.com -DsignTag=true -Dmaven.build.cache.enabled=false
+          ./mvnw release:clean release:prepare release:perform -U -B -Pci,gh-build -DpushChanges=true -DreleaseVersion=${{ env.RELEASE_VERSION }} -DdevelopmentVersion=${{ env.NEXT_DEVELOPMENT_VERSION }} -Dgpg.keyname=aissemble@bah.com -DsignTag=true -Dmaven.build.cache.enabled=false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Split version
         id: split_version_development
         uses: ./.github/actions/split_version

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -14,13 +14,6 @@
 
     <description>Build parent to bring in required build-time dependencies (e.g., Maven configuration)</description>
 
-    <distributionManagement>
-        <snapshotRepository>
-            <id>ghcr.io</id>
-            <url>https://maven.pkg.github.com/boozallen/aissemble</url>
-        </snapshotRepository>
-    </distributionManagement>
-
     <properties>
         <version.aissemble>1.13.0-SNAPSHOT</version.aissemble>
 

--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,13 @@
         </developer>
     </developers>
 
+    <distributionManagement>
+        <snapshotRepository>
+            <id>ghcr.io</id>
+            <url>https://maven.pkg.github.com/boozallen/aissemble</url>
+        </snapshotRepository>
+    </distributionManagement>
+
     <modules>
         <module>build-support</module>
         <module>build-parent</module>


### PR DESCRIPTION
 - fix logic for copying buildx dir to fabric8 state dir,
 - set snapshot repo to boozallen/aissemble in root pom so that aissemble-root and it's children can be published with the built-in action token
 - authenticate with GH action token instead of manual PAT
 - force Helm 3.17.3 to work-around helm/helm#30873