### PR TITLE
[#720] use python action instead of pyenv

### DIFF
--- a/.github/actions/install_dependencies/action.yaml
+++ b/.github/actions/install_dependencies/action.yaml
@@ -19,9 +19,9 @@ runs:
           libpython3.11
         echo "::endgroup::"
     - name: Install Python
-      uses: gabrielfalcao/pyenv-action@v18
+      uses: actions/setup-python@v5
       with:
-        default: 3.11.4
+        python-version: 3.11.4
     - name: Install Poetry
       uses: snok/install-poetry@v1
       # TODO: REMOVE THIS WHEN ARCHETYPE TESTS USES HABUSHU'S CONTAINERIZE DEPENDENCIES GOAL

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -132,7 +132,7 @@ jobs:
       # Execute archetype tests
       - name: Run Archetype Tests
         run: |
-          ./mvnw -B clean install -Parchetype-test -pl :foundation-archetype
+          ./mvnw -B clean install -Pci,archetype-test -pl :foundation-archetype
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Submit Dependency Graph

--- a/DRAFT_RELEASE_NOTES.md
+++ b/DRAFT_RELEASE_NOTES.md
@@ -51,6 +51,7 @@ _Note: instructions for adapting to these changes are outlined in the upgrade in
   - `aissemble-fastapi` docker image
 - The default behavior on the `aissemble-infrastructure-chart` has been changed. The ArgoCD chart will no longer be deployed by default. To enable the ArgoCD deployment, follow the **How to Upgrade** section for details.
 - Removed local deployment tool Tilt, and the remote deployment tool ArgoCD as we migrated to use Helmfile as the aiSSEMBLE deployment tool.
+- Habushu is now configured with [`usePyenv`](https://github.com/TechnologyBrewery/habushu/tree/3b885791b347de91b02124633b32b2b723cdd6e2/docs#usepyenv) set to `false` by default in the `ci` profile
 
 # Known Issues
 
@@ -195,6 +196,32 @@ aissemble-infrastructure-chart:
 
 ### For projects that deploy to a custom namespace
 The `aissemble-spark-application` chart has been updated to default the namespace to the release namespace (e.g. provided by `helm install --namespace X`). Unless your project needs the namespace hard-coded, it is recommended to remove `metadata.namespace` from your pipeline's _*-base-values.yaml_ file.  For projects using a GitOps approach that _relies_ on a hard-coded namespace the `metadata.namespace` property will still take precedences over the release namespace.
+
+### For projects that require using PyEnv in CI
+It is recommended that you use Python directly in CI, especially when installing Python from scratch.  If you cannot use Python directly and require version switching (e.g. a
+shared build environment with different version requirements between projects) you can switch the configuration of Habushu back to the previous setting by adding the following to
+your root _pom.xml_:
+
+```xml
+    <profiles>
+        <profile>
+            <id>ci</id>
+            <build>
+                <pluginManagement>
+                    <plugins>
+                        <plugin>
+                            <groupId>org.technologybrewery.habushu</groupId>
+                            <artifactId>habushu-maven-plugin</artifactId>
+                            <configuration>
+                                <usePyenv>true</usePyenv>
+                            </configuration>
+                        </plugin>
+                    </plugins>
+                </pluginManagement>
+            </build>
+        </profile>
+    </profiles>
+```
 
 ## Final Steps - Required for All Projects
 ### Finalizing the Upgrade

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -971,6 +971,7 @@ To suppress enforce-helm-version rule, you must add following plugin to the root
                             <artifactId>habushu-maven-plugin</artifactId>
                             <version>${version.habushu.plugin}</version>
                             <configuration>
+                                <usePyenv>false</usePyenv>
                                 <deleteVirtualEnv>true</deleteVirtualEnv>
                                 <forceSync>true</forceSync>
                                 <decryptPassword>false</decryptPassword>

--- a/foundation/foundation-archetype/pom.xml
+++ b/foundation/foundation-archetype/pom.xml
@@ -14,6 +14,10 @@
     <description>Defines a root level project archetype that can then have pipeline archetypes added to it</description>
     <packaging>maven-archetype</packaging>
 
+    <properties>
+        <archetype.profiles></archetype.profiles>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
@@ -136,8 +140,13 @@
     
     <profiles>
         <profile>
+            <id>ci</id>
+            <properties>
+                <archetype.profiles>ci</archetype.profiles>
+            </properties>
+        </profile>
+        <profile>
             <id>archetype-test</id>
-            <modules />
             <build>
                 <plugins>
                     <plugin>
@@ -154,6 +163,7 @@
                                     <executable>${project.basedir}/test-project-archetype.sh</executable>
                                     <arguments>
                                         <argument>${project.version}</argument>
+                                        <argument>${archetype.profiles}</argument>
                                     </arguments>
                                 </configuration>
                             </execution>

--- a/foundation/foundation-archetype/test-project-archetype.sh
+++ b/foundation/foundation-archetype/test-project-archetype.sh
@@ -13,10 +13,12 @@
 set -o pipefail
 echo -e "\n\n **** TESTING ARCHETYPE GENERATION **** \n\n"
 
-if [ $# -ne 1 ]; then
+if [ $# -eq 0 ] || [ $# -gt 2 ]; then
     echo "Incorrect number of arguments. Usage:"
     echo "   test-project-archetype.sh <archetype_version>"
     exit 1
+elif [ -n "$2" ]; then
+  PROFILES="-P$2"
 fi
 
 mkdir -p target/temp
@@ -102,7 +104,7 @@ function runBuildAndApplyManualActions {
 
   # $deployOutputStart match at end ensures the match line isn't captured. NF ensures blank lines aren't captured.
   #TODO: remove docker.skip when Habushu containerization works
-  ./mvnw -Ddocker.skip clean install | \
+  ./mvnw -Ddocker.skip clean install $PROFILES | \
       tee >(awk "BEGIN {output=0} /$outputEnd/ {output=0} NF && output {print} /$deployOutputStart/ {output=1}">deploy.out ) | \
       tee >(awk "BEGIN {output=0} /$outputEnd/ {output=0} NF && output {print} /$helmfileOutputStart/ {output=1}">helmfile.out ) | \
       tee >(awk "BEGIN {output=0} /$outputEnd/ {output=0} NF && output {print} /$helmfileAppsOutputStart/ {output=1}">helmfile-apps.out ) \
@@ -141,6 +143,7 @@ function runBuildAndApplyManualActions {
 
 package='com.bah.aiops'
 echo "Using Project Version: $1"
+echo "Using build profiles: [$PROFILES]"
 echo -e "\nINFO: Generating a new project from the archetype\n"
 rm -rf test-generator
 mvn archetype:generate -B \
@@ -335,12 +338,12 @@ runBuildAndApplyManualActions
 
 #TODO: remove docker.skip when Habushu containerization works
 echo -e "\nINFO: Running final build to ensure success"
-./mvnw -Ddocker.skip clean install || { echo -e '\n\n\t**** MAVEN BUILD FAILED ****\n\n' ; exit 1; }
+./mvnw -Ddocker.skip clean install $PROFILES || { echo -e '\n\n\t**** MAVEN BUILD FAILED ****\n\n' ; exit 1; }
 
 echo -e "\nINFO: Running fermenter generation to check for left over manual actions\n"
 # NOTE: because fermenter results are cached, the build-cache will hide remaining manual actions that were missed in previous steps
 #TODO: remove docker.skip when Habushu containerization works
-./mvnw -Ddocker.skip clean generate-sources -Dmaven.build.cache.skipCache -Dfermenter.display.message.keys=true | tee >(awk '/WARNING/ {print}' > maven-build.log) \
+./mvnw -Ddocker.skip clean generate-sources $PROFILES -Dmaven.build.cache.skipCache -Dfermenter.display.message.keys=true | tee >(awk '/WARNING/ {print}' > maven-build.log) \
     || { echo -e '\n\n\t**** MAVEN BUILD FAILED ****\n\n' ; exit 1; }
 if grep -iq 'Manual action' maven-build.log; then
   echo -e "\n\n **** ERROR: Manual action still found in build **** \n    Look at **archetype/target/temp/test-generator/maven-build.log** to see what the problem was. \n\n"

--- a/foundation/foundation-upgrade/src/test/java/com/boozallen/aissemble/upgrade/migration/version_specific/RuffTomlFileGenerationMigrationStep.java
+++ b/foundation/foundation-upgrade/src/test/java/com/boozallen/aissemble/upgrade/migration/version_specific/RuffTomlFileGenerationMigrationStep.java
@@ -27,7 +27,7 @@ public class RuffTomlFileGenerationMigrationStep extends AbstractMigrationTest {
 
     @Given("a projects does not have a root ruff.toml file")
     public void a_projects_does_not_have_a_root_ruff_toml_file() {
-        setTestFileToVersionMigration("RuffTomlfileGenerationMigration", "pom.xml");
+        setTestFileToVersionMigration("RuffTomlFileGenerationMigration", "pom.xml");
     }
 
     @When("the ruff.toml generation migration is performed")


### PR DESCRIPTION
Mostly this just involves updating the `install_dependencies` action and updating Habushu's `usePyenv` to `false` if the `ci` profile is active. However, because the archetype test _also_ builds Habushu modules, it was trying to use `pyenv`.  So the foundation-archetype pom/test was updated to allow passing build profiles to the test script, and if the `ci` profile is active the module will pass `-Pci` to the script.

Also fixes the `RuffTomlFileGenerationMigration` test. Apparently MacOs treats file paths case-insensitive (at least when accessed via Java) whereas the Ubuntu image we're using in CI does not.