### PR TITLE
711 pypark worker containerization

### DIFF
--- a/DRAFT_RELEASE_NOTES.md
+++ b/DRAFT_RELEASE_NOTES.md
@@ -20,8 +20,7 @@ Spark upgraded from 3.5.4 to 3.5.5. For upgrade information, see the Spark [rele
 New projects generated on version 1.13.0 of aiSSEMBLE will use Poetry 2.x.  With this update, the minimum version of Python supported by aiSSEMBLE is updated from 3.8 to 3.9.
 
 ## Habushu 3.0 upgrade
-Starting with aiSSEMBLE version 1.13.0, newly generated projects will use Habushu [3.0.0](https://github.com/TechnologyBrewery/habushu/releases/tag/habushu-3.0.0). This release includes several significant improvements, most notably support for UV, a modern Python packaging and build tool comparable to Poetry. Because Habushu 3 has dropped support for other containerization approaches, aiSSEMBLE will now use the [containerize-dependencies feature](https://github.com/TechnologyBrewery/habushu/blob/dev/docs/CONFIGURATION_README.md#containerization-configurations) to package PySpark and Machine Learning pipelines. Users should update their `<project-name>-docker/<project-name>-<training-step-name>-docker/src/main/resources/Dockerfile` with the appropriate `#HABUSHU_BUILDER_STAGE` and `#HABUSHU_FINAL_STAGE` tags to utilize the new behavior. For more information, reference the [examples](https://github.com/TechnologyBrewery/habushu/blob/dev/examples/poetry/habushu-poetry-containerize/README.md) provided by Habushu.
-
+Habushu has been upgraded to [version 3.0](https://github.com/TechnologyBrewery/habushu/releases/tag/habushu-3.0.0). Because Habushu 3 has dropped support for other containerization approaches, aiSSEMBLE will now use the [containerize-dependencies feature](https://github.com/TechnologyBrewery/habushu/blob/dev/docs/CONFIGURATION_README.md#containerization-configurations) to package PySpark and Machine Learning pipelines.  The Habushu project has [examples](https://github.com/TechnologyBrewery/habushu/blob/dev/examples/poetry/habushu-poetry-containerize/README.md) to help illustrate how containerization works.
 
 ## Dependency Upgrades
 | Dependency                          | from          | to                                                   | Reason/Note                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
@@ -42,6 +41,7 @@ Starting with aiSSEMBLE version 1.13.0, newly generated projects will use Habush
 | org.technologybrewery.habushu       | 2.18.1        | 3.0.0                                                | For upgrade information, see the Habushu [release notes](https://github.com/TechnologyBrewery/habushu/releases)                                                                                                                                                                                                                                                                                                                                                                                                                                       |
 | mlflow                              | 2.3.1         | 2.22.0                                               | Resolve Critical/High CVE issue                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
 | pandas                              | ^1.5.0        | >=1.5.0                                              | Fixes version incompatibility with MLFlow 2.22.0                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+
 
 # Breaking Changes
 _Note: instructions for adapting to these changes are outlined in the upgrade instructions below._
@@ -74,7 +74,6 @@ When using a Docker daemon that does not reside in `/var/run` (e.g. running Ranc
 
 | Date<br/>identified | Vulnerability | Severity | Package | Affected <br/>versions | CVE | Fixed <br/>in |
 |---------------------|---------------|----------|---------|------------------------|-----|---------------|
-
 
 # How to Upgrade
 

--- a/extensions/extensions-docker/aissemble-spark/src/main/resources/docker/Dockerfile
+++ b/extensions/extensions-docker/aissemble-spark/src/main/resources/docker/Dockerfile
@@ -40,7 +40,6 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
   python${PYTHON_VERSION}-distutils \
 #provides ensurepip
   python${PYTHON_VERSION}-venv \
-  pipx \
 #Patch for CVE-2023-4863: upgrade libwebp7 to 1.3.2+
   && apt-get upgrade -y libwebp7 \
   && ln -s /usr/bin/python${PYTHON_VERSION} /usr/bin/python \

--- a/foundation/foundation-mda/src/main/resources/templates/general-docker/spark-worker.docker.file.vm
+++ b/foundation/foundation-mda/src/main/resources/templates/general-docker/spark-worker.docker.file.vm
@@ -7,9 +7,22 @@
 ARG DOCKER_BASELINE_REPO_ID
 ARG VERSION_AISSEMBLE
 
-FROM ${DOCKER_BASELINE_REPO_ID}boozallen/aissemble-spark:${VERSION_AISSEMBLE}
-
+#if ($pysparkPipelines.size() > 0)
+# The following two lines help work around a Habushu bug that assumes the user is root in the builder
+FROM ${DOCKER_BASELINE_REPO_ID}boozallen/aissemble-spark:${VERSION_AISSEMBLE} AS root_habushu_builder
 USER root
+
+#HABUSHU_BUILDER_STAGE
+
+#HABUSHU_FINAL_STAGE
+
+RUN chown -R spark:spark /opt/venv
+
+#else
+# If no Pyspark pipelines exist then Java based pipelines will still need this FROM statement
+
+FROM ${DOCKER_BASELINE_REPO_ID}boozallen/aissemble-spark:${VERSION_AISSEMBLE}
+#end
 
 #if (${enableSedonaSupport})
 # Add GEOS library
@@ -19,21 +32,8 @@ RUN apt-get update -y && apt-get install -y \
     && apt-get clean
 #end
 
-WORKDIR /
-
-#Install 3rd party Pyspark pipeline dependencies (does nothing if you only have Spark pipelines)
-COPY ./target/dockerbuild/requirements/. /tmp/requirements/
-RUN set -e && files=$(find /tmp/requirements -path '/tmp/requirements/*/*' -name requirements.txt -type f); for file in $files; do python3 -m pip install --no-cache-dir -r $file || exit 1; done;
-
-#Install monorepo Pyspark pipeline dependencies (does nothing if you only have Spark pipelines)
-COPY ./target/dockerbuild/wheels/. /tmp/wheels/
-RUN set -e && files=$(find /tmp/wheels -path '/tmp/wheels/*' -name '*.whl' -type f); for file in $files; do python3 -m pip install --no-cache-dir $file || exit 1; done;
-
 #Pipelines
 COPY --chown=spark:spark --chmod=777 ./target/dockerbuild/. /opt/spark/jobs/pipelines/
-
-#Install Pyspark pipelines (does nothing if you only have Spark pipelines)
-RUN set -e && files=$(find /opt/spark/jobs -path '/opt/spark/jobs/pipelines/*/*' -name '*.tar.gz' -type f); for file in $files; do python3 -m pip install --no-deps --no-cache-dir $file || exit 1; done;
 
 COPY --chown=spark ./src/main/resources/krausening/ ${SPARK_HOME}/krausening/
 

--- a/foundation/foundation-mda/src/main/resources/templates/general-docker/spark-worker.docker.pom.xml.vm
+++ b/foundation/foundation-mda/src/main/resources/templates/general-docker/spark-worker.docker.pom.xml.vm
@@ -82,6 +82,31 @@
                 <groupId>${group.fabric8.plugin}</groupId>
                 <artifactId>docker-maven-plugin</artifactId>
             </plugin>
+
+            <plugin>
+                <groupId>org.technologybrewery.habushu</groupId>
+                <artifactId>habushu-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>dockerize</id>
+                        <goals>
+                            <goal>containerize-dependencies</goal>
+                        </goals>
+                        <phase>prepare-package</phase>
+                        <configuration>
+                            <dockerfile>src/main/resources/docker/Dockerfile</dockerfile>
+                            <!--The purpose of following config is so that we can switch the user from spark to root to allow -->
+                            <!--Habushu containerization to build correctly (correct permissions). -->
+                            <!-- Should be switched to aissemble-spark like the final image and the Dockerfile template should be -->
+                            <!-- updated to remove root_habushu_builder after TechnologyBrewery/habushu#389 -->
+                            <dockerBuilderBase>root_habushu_builder</dockerBuilderBase>
+                            <dockerFinalBase>${DOCKER_BASELINE_REPO_ID}boozallen/aissemble-spark:${VERSION_AISSEMBLE}</dockerFinalBase>
+                            <dockerUser>spark</dockerUser>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
         </plugins>
     </build>
 


### PR DESCRIPTION
Spark Worker containerization requires two custom templates in order to successfully install all monorepo dependencies, so you will notice that we are using custom templates and not the default.