### PR TITLE
[#723] aissemble spark bom migration

### DIFF
--- a/DRAFT_RELEASE_NOTES.md
+++ b/DRAFT_RELEASE_NOTES.md
@@ -101,6 +101,7 @@ To reduce burden of upgrading aiSSEMBLE, the Baton project is used to automate t
 | trino-delta-lake-connector-yaml-migration          | Add the Delta Lake connector configuration in the Trino chart values.yaml file                                                                                               |                                     |
 | habushu-monorepo-dependency-migration              | Ensures that all dependencies from Habushu modules on other Habushu modules in the same project are type `habushu`                                                           |                                     |
 | ruff-toml-file-generation-migration                | Generates an initial ruff.toml file with a few lines of configuration to make the ruff linting and formatting consistent with prior linting and formatting.  This file can be configured using https://docs.astral.sh/ruff/configuration/ as a guide |                                     |
+| spark-bom-dependency-migration                     | Adds the `aissemble-spark-bom` to data delivery pipelines for centralized Spark, Hadoop, and Hive dependency management and ensures version alignment with the `aissemble-spark` image|                                     |
 
 Migrations with arguments will not be executed unless that argument is provided (e.g. `./mvnw org.technologybrewery.baton:baton-maven-plugin:baton-migrate -D<argumentName>`). To deactivate any of these migrations, add the following configuration to the `baton-maven-plugin` within your root `pom.xml`:
 

--- a/foundation/foundation-mda/src/main/resources/templates/data-delivery-data-records/data-delivery-combined-data-records-java.pom.xml.vm
+++ b/foundation/foundation-mda/src/main/resources/templates/data-delivery-data-records/data-delivery-combined-data-records-java.pom.xml.vm
@@ -38,6 +38,7 @@
             </plugin>
         </plugins>
     </build>
+
     <dependencies>
         <dependency>
             <groupId>com.boozallen.aissemble</groupId>

--- a/foundation/foundation-mda/src/main/resources/templates/data-delivery-data-records/data-delivery-data-pyspark.pom.xml.vm
+++ b/foundation/foundation-mda/src/main/resources/templates/data-delivery-data-records/data-delivery-data-pyspark.pom.xml.vm
@@ -59,6 +59,7 @@
             </plugin>
         </plugins>
     </build>
+
     <dependencies>
         <dependency>
             <groupId>#[[${project.groupId}]]#</groupId>

--- a/foundation/foundation-mda/src/main/resources/templates/data-delivery-data-records/data-delivery-data-spark.pom.xml.vm
+++ b/foundation/foundation-mda/src/main/resources/templates/data-delivery-data-records/data-delivery-data-spark.pom.xml.vm
@@ -38,6 +38,7 @@
             </plugin>
         </plugins>
     </build>
+
     <dependencies>
         <dependency>
             <groupId>com.boozallen.aissemble</groupId>

--- a/foundation/foundation-mda/src/main/resources/templates/data-delivery-data-records/data-delivery-separate-data-records-java.pom.xml.vm
+++ b/foundation/foundation-mda/src/main/resources/templates/data-delivery-data-records/data-delivery-separate-data-records-java.pom.xml.vm
@@ -26,6 +26,7 @@
             </plugin>
         </plugins>
     </build>
+
     <dependencies>
         <dependency>
             <groupId>org.codehaus.jackson</groupId>

--- a/foundation/foundation-mda/src/main/resources/templates/general-docker/inference.docker.pom.xml.vm
+++ b/foundation/foundation-mda/src/main/resources/templates/general-docker/inference.docker.pom.xml.vm
@@ -93,6 +93,7 @@
             </plugin>
         </plugins>
     </build>
+
     <dependencies>
         <dependency>
             <groupId>#[[${project.groupId}]]#</groupId>

--- a/foundation/foundation-mda/src/main/resources/templates/general-docker/spark-worker.docker.pom.xml.vm
+++ b/foundation/foundation-mda/src/main/resources/templates/general-docker/spark-worker.docker.pom.xml.vm
@@ -84,6 +84,7 @@
             </plugin>
         </plugins>
     </build>
+
     <dependencies>
     #foreach($pipeline in $sparkPipelines)
         <dependency>

--- a/foundation/foundation-mda/src/main/resources/templates/general-docker/training.docker.pom.xml.vm
+++ b/foundation/foundation-mda/src/main/resources/templates/general-docker/training.docker.pom.xml.vm
@@ -90,6 +90,7 @@
             </plugin>
         </plugins>
     </build>
+
     <dependencies>
         <dependency>
             <groupId>#[[${project.groupId}]]#</groupId>

--- a/foundation/foundation-mda/src/main/resources/templates/general-mlflow/pipeline.step.pom.xml.vm
+++ b/foundation/foundation-mda/src/main/resources/templates/general-mlflow/pipeline.step.pom.xml.vm
@@ -107,6 +107,7 @@
             </plugin>
         </plugins>
     </build>
+
     <dependencies>
         <dependency>
             <groupId>net.masterthought</groupId>

--- a/foundation/foundation-upgrade/src/main/java/com/boozallen/aissemble/upgrade/migration/version_specific/SparkBomDependencyMigration.java
+++ b/foundation/foundation-upgrade/src/main/java/com/boozallen/aissemble/upgrade/migration/version_specific/SparkBomDependencyMigration.java
@@ -1,0 +1,83 @@
+package com.boozallen.aissemble.upgrade.migration.version_specific;
+
+/*-
+ * #%L
+ * aiSSEMBLE::Foundation::Upgrade
+ * %%
+ * Copyright (C) 2021 Booz Allen
+ * %%
+ * This software package is licensed under the Booz Allen Public License. All Rights Reserved.
+ * #L%
+ */
+
+import com.boozallen.aissemble.upgrade.migration.AbstractPomMigration;
+import org.apache.maven.model.Model;
+import org.apache.maven.project.MavenProject;
+import org.technologybrewery.baton.util.pom.PomHelper;
+import org.technologybrewery.baton.util.pom.PomModifications;
+
+import java.io.File;
+
+import static org.apache.commons.lang3.StringUtils.repeat;
+import static org.technologybrewery.baton.util.pom.LocationAwareMavenReader.END;
+
+public class SparkBomDependencyMigration extends AbstractPomMigration {
+
+    @Override
+    protected boolean shouldExecuteOnFile(File pomFile) {
+        Model model = PomHelper.getLocationAnnotatedModel(pomFile);
+        return hasSparkDependency(model) && hasAissembleBuildParent(getRootProject()) && !hasSparkBomDependencyManagement(model);
+    }
+
+    @Override
+    protected boolean performMigration(File pomFile) {
+        Model model = PomHelper.getLocationAnnotatedModel(pomFile);
+        detectAndSetIndent(pomFile);
+        PomModifications modifications = new PomModifications();
+        String sparkBomDependency = buildSparkBomDependency();
+        // If <dependencyManagement> exists, insert into <dependencies>
+        if (model.getDependencyManagement() != null) {
+            modifications.add(new PomModifications.Insertion(model.getDependencyManagement().getLocation("dependencies" + END), 1, ignore -> sparkBomDependency));
+        } else {
+            // If <dependencyManagement> doesn't exist, create it here add it before <dependencies>
+            String depsManagementBlock =
+                    repeat(indent, 1) + "<dependencyManagement>\n" +
+                    repeat(indent, 2) + "<dependencies>\n" +
+                    sparkBomDependency +
+                    repeat(indent, 2) + "</dependencies>\n" +
+                    repeat(indent, 1) + "</dependencyManagement>\n\n";
+            modifications.add(new PomModifications.Insertion(model.getLocation("dependencies"), 1, ingnore -> depsManagementBlock));
+        }
+        return PomHelper.writeModifications(pomFile, modifications.finalizeMods());
+    }
+
+    private boolean hasSparkDependency(Model model) {
+        return model.getDependencies().stream()
+                .anyMatch(dep -> dep.getGroupId().equals("org.apache.spark"));
+    }
+
+    private boolean hasAissembleBuildParent(MavenProject rootProject) {
+        return rootProject.getParent().getArtifactId().equals(AISSEMBLE_PARENT);
+    }
+
+    private boolean hasSparkBomDependencyManagement(Model model) {
+        if (model.getDependencyManagement() == null || model.getDependencyManagement().getDependencies() == null) {
+            return false;
+        }
+        return model.getDependencyManagement().getDependencies().stream()
+                .anyMatch(dep -> dep.getGroupId().equals("com.boozallen.aissemble")
+                        && dep.getArtifactId().equals("aissemble-spark-bom"));
+    }
+
+    private String buildSparkBomDependency(){
+        StringBuilder builder = new StringBuilder();
+        builder.append(repeat(indent, 3)).append("<dependency>\n")
+               .append(repeat(indent, 4)).append("<groupId>com.boozallen.aissemble</groupId>\n")
+               .append(repeat(indent, 4)).append("<artifactId>aissemble-spark-bom</artifactId>\n")
+               .append(repeat(indent, 4)).append("<version>${version.aissemble}</version>\n")
+               .append(repeat(indent, 4)).append("<type>pom</type>\n")
+               .append(repeat(indent, 4)).append("<scope>import</scope>\n")
+               .append(repeat(indent, 3)).append("</dependency>\n");
+        return builder.toString();
+    }
+}

--- a/foundation/foundation-upgrade/src/main/java/com/boozallen/aissemble/upgrade/migration/version_specific/SparkProvidedDependenciesMigration.java
+++ b/foundation/foundation-upgrade/src/main/java/com/boozallen/aissemble/upgrade/migration/version_specific/SparkProvidedDependenciesMigration.java
@@ -85,8 +85,6 @@ public class SparkProvidedDependenciesMigration extends AbstractPomMigration {
             builder.append(repeat(indent, 2)).append("<dependency>\n")
                     .append(repeat(indent, 3)).append("<groupId>org.apache.spark</groupId>\n")
                     .append(repeat(indent, 3)).append("<artifactId>").append(depArtifactId).append("</artifactId>\n")
-                    .append(repeat(indent, 3)).append("<version>${version.spark}</version>\n")
-                    .append(repeat(indent, 3)).append("<scope>provided</scope>\n")
                     .append(repeat(indent, 2)).append("</dependency>\n");
         }
         return builder.toString();

--- a/foundation/foundation-upgrade/src/main/resources/migrations.json
+++ b/foundation/foundation-upgrade/src/main/resources/migrations.json
@@ -122,6 +122,15 @@
             "includes": ["pom.xml"]
           }
         ]
+      },
+      {
+        "name": "spark-bom-dependency-migration",
+        "implementation": "com.boozallen.aissemble.upgrade.migration.version_specific.SparkBomDependencyMigration",
+        "fileSets": [
+          {
+            "includes": ["pom.xml"]
+          }
+        ]
       }
     ]
   },

--- a/foundation/foundation-upgrade/src/test/java/com/boozallen/aissemble/upgrade/migration/extensions/SparkBomDependencyMigrationTest.java
+++ b/foundation/foundation-upgrade/src/test/java/com/boozallen/aissemble/upgrade/migration/extensions/SparkBomDependencyMigrationTest.java
@@ -1,0 +1,32 @@
+package com.boozallen.aissemble.upgrade.migration.extensions;
+
+/*-
+ * #%L
+ * aiSSEMBLE::Foundation::Upgrade
+ * %%
+ * Copyright (C) 2021 Booz Allen
+ * %%
+ * This software package is licensed under the Booz Allen Public License. All Rights Reserved.
+ * #L%
+ */
+
+import com.boozallen.aissemble.upgrade.migration.version_specific.SparkBomDependencyMigration;
+
+import org.apache.maven.project.MavenProject;
+
+import java.io.File;
+
+public class SparkBomDependencyMigrationTest extends SparkBomDependencyMigration {
+
+    public SparkBomDependencyMigrationTest(File testPom) {
+        MavenProject parentAissembleProject = new MavenProject();
+        parentAissembleProject.setArtifactId(AISSEMBLE_PARENT);
+        parentAissembleProject.setGroupId("com.boozallen.aissemble");
+
+        MavenProject project = new MavenProject();
+        project.setArtifactId("simple-project");
+        project.setParent(parentAissembleProject);
+        project.setFile(testPom);
+        setMavenProject(project);
+    }
+}

--- a/foundation/foundation-upgrade/src/test/java/com/boozallen/aissemble/upgrade/migration/version_specific/SparkBomDependencyMigrationStep.java
+++ b/foundation/foundation-upgrade/src/test/java/com/boozallen/aissemble/upgrade/migration/version_specific/SparkBomDependencyMigrationStep.java
@@ -1,0 +1,66 @@
+package com.boozallen.aissemble.upgrade.migration.version_specific;
+
+/*-
+ * #%L
+ * aiSSEMBLE::Foundation::Upgrade
+ * %%
+ * Copyright (C) 2021 Booz Allen
+ * %%
+ * This software package is licensed under the Booz Allen Public License. All Rights Reserved.
+ * #L%
+ */
+
+import com.boozallen.aissemble.upgrade.migration.AbstractMigrationTest;
+import com.boozallen.aissemble.upgrade.migration.extensions.SparkBomDependencyMigrationTest;
+
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.When;
+import io.cucumber.java.en.Then;
+
+public class SparkBomDependencyMigrationStep extends AbstractMigrationTest {
+
+    @Given("a POM file that doesn't have the aissemble-spark-bom dependency")
+    public void aPomFileWithoutAissembleSparkBom() {
+       setTestFileToVersionMigration("SparkBomDependencyMigration", "pom.xml");
+    }
+
+    @Given("a POM file that doesn't have the aissemble-spark-bom dependency with no spark dependency")
+    public void aPomFileWithoutAissembleSparkBomAndNoSparkDependency() {
+       setTestFileToVersionMigration("SparkBomDependencyMigration", "pom-no-spark.xml");
+    }
+
+    @Given("a POM file that doesn't have the aissemble-spark-bom dependency with an existing dependencyManagement section")
+    public void aPomFileWithoutAissembleSparkBomAndExistingDependencyManagementSection() {
+       setTestFileToVersionMigration("SparkBomDependencyMigration", "pom-dependency-management-exists.xml");
+    }
+
+    @Given("contains a spark dependency")
+    public void containsSparkDependency() {
+        // Already covered by the test POM file content
+    }
+
+    @Given("includes aissemble build-parent in its hierarchy")
+    public void includesAissembleBuildParent() {
+        // Already covered by the test POM file content
+    }
+
+    @When("the aissemble-spark-bom pom migration executes")
+    public void runMigration() {
+        performMigration(new SparkBomDependencyMigrationTest(testFile));
+    }
+
+    @Then("the aissemble-spark-bom dependency is added to the POM file")
+    public void aissembleSparkBomAdded() {
+        assertTestFileMatchesExpectedFile("aissemble-spark-bom dependencyManagement block was not added as expected");
+    }
+
+    @Given("doesn't contain a spark dependency")
+    public void doesNotContainSparkDependency() {
+        // Already covered by the test POM file content
+    }
+
+    @Then("the migration is skipped")
+    public void migrationIsSkipped() {
+        assertMigrationSkipped();
+    }
+}

--- a/foundation/foundation-upgrade/src/test/resources/specifications/version-specific/spark-bom-dependency-migration.feature
+++ b/foundation/foundation-upgrade/src/test/resources/specifications/version-specific/spark-bom-dependency-migration.feature
@@ -1,0 +1,23 @@
+Feature: Add aissemble-spark-bom dependency to POM file
+
+  Scenario: Adding aissemble-spark-bom dependency to POM file
+    Given a POM file that doesn't have the aissemble-spark-bom dependency
+    And contains a spark dependency
+    And includes aissemble build-parent in its hierarchy
+    When the aissemble-spark-bom pom migration executes
+    Then the aissemble-spark-bom dependency is added to the POM file
+
+  Scenario: Skip migration if spark dependency is not present
+    Given a POM file that doesn't have the aissemble-spark-bom dependency with no spark dependency
+    And includes aissemble build-parent in its hierarchy
+    But doesn't contain a spark dependency
+    When the aissemble-spark-bom pom migration executes
+    Then the migration is skipped
+
+  Scenario: Adding aissemble-spark-bom dependency to already existing dependencyManagement
+    Given a POM file that doesn't have the aissemble-spark-bom dependency with an existing dependencyManagement section
+    And includes aissemble build-parent in its hierarchy
+    And contains a spark dependency
+    When the aissemble-spark-bom pom migration executes
+    Then the aissemble-spark-bom dependency is added to the POM file
+

--- a/foundation/foundation-upgrade/src/test/resources/test-files/version-specific/SparkBomDependencyMigration/migration/pom-dependency-management-exists.xml
+++ b/foundation/foundation-upgrade/src/test/resources/test-files/version-specific/SparkBomDependencyMigration/migration/pom-dependency-management-exists.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  aiSSEMBLE::Foundation::Upgrade
+  %%
+  Copyright (C) 2021 Booz Allen
+  %%
+  This software package is licensed under the Booz Allen Public License. All Rights Reserved.
+  #L%
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.boozallen.aissemble</groupId>
+        <artifactId>build-parent</artifactId>
+        <version>1.13.0</version>
+    </parent>
+
+    <groupId>com.test</groupId>
+    <artifactId>simple-project</artifactId>
+    <packaging>pom</packaging>
+    <version>1.0.0</version>
+    <name>Test Spark Bom Migration::Project::Simple Project</name>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.technologybrewery.baton</groupId>
+                <artifactId>baton-maven-plugin</artifactId>
+                <dependencies>
+                    <dependency>
+                        <groupId>com.boozallen.aissemble</groupId>
+                        <artifactId>foundation-upgrade</artifactId>
+                        <version>${version.aissemble}</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>com.test.blah</groupId>
+                <artifactId>nothing-here</artifactId>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.spark</groupId>
+            <artifactId>spark-core_2.12</artifactId>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/foundation/foundation-upgrade/src/test/resources/test-files/version-specific/SparkBomDependencyMigration/migration/pom-no-spark.xml
+++ b/foundation/foundation-upgrade/src/test/resources/test-files/version-specific/SparkBomDependencyMigration/migration/pom-no-spark.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  aiSSEMBLE::Foundation::Upgrade
+  %%
+  Copyright (C) 2021 Booz Allen
+  %%
+  This software package is licensed under the Booz Allen Public License. All Rights Reserved.
+  #L%
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.boozallen.aissemble</groupId>
+        <artifactId>build-parent</artifactId>
+        <version>1.13.0</version>
+    </parent>
+
+    <groupId>com.test</groupId>
+    <artifactId>simple-project</artifactId>
+    <packaging>pom</packaging>
+    <version>1.0.0</version>
+    <name>Test Spark Bom Migration::Project::Simple Project</name>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.technologybrewery.baton</groupId>
+                <artifactId>baton-maven-plugin</artifactId>
+                <dependencies>
+                    <dependency>
+                        <groupId>com.boozallen.aissemble</groupId>
+                        <artifactId>foundation-upgrade</artifactId>
+                        <version>${version.aissemble}</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/foundation/foundation-upgrade/src/test/resources/test-files/version-specific/SparkBomDependencyMigration/migration/pom.xml
+++ b/foundation/foundation-upgrade/src/test/resources/test-files/version-specific/SparkBomDependencyMigration/migration/pom.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  aiSSEMBLE::Foundation::Upgrade
+  %%
+  Copyright (C) 2021 Booz Allen
+  %%
+  This software package is licensed under the Booz Allen Public License. All Rights Reserved.
+  #L%
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.boozallen.aissemble</groupId>
+        <artifactId>build-parent</artifactId>
+        <version>1.13.0</version>
+    </parent>
+
+    <groupId>com.test</groupId>
+    <artifactId>simple-project</artifactId>
+    <packaging>pom</packaging>
+    <version>1.0.0</version>
+    <name>Test Spark Bom Migration::Project::Simple Project</name>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.technologybrewery.baton</groupId>
+                <artifactId>baton-maven-plugin</artifactId>
+                <dependencies>
+                    <dependency>
+                        <groupId>com.boozallen.aissemble</groupId>
+                        <artifactId>foundation-upgrade</artifactId>
+                        <version>${version.aissemble}</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.spark</groupId>
+            <artifactId>spark-core_2.12</artifactId>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/foundation/foundation-upgrade/src/test/resources/test-files/version-specific/SparkBomDependencyMigration/validation/pom-dependency-management-exists.xml
+++ b/foundation/foundation-upgrade/src/test/resources/test-files/version-specific/SparkBomDependencyMigration/validation/pom-dependency-management-exists.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  aiSSEMBLE::Foundation::Upgrade
+  %%
+  Copyright (C) 2021 Booz Allen
+  %%
+  This software package is licensed under the Booz Allen Public License. All Rights Reserved.
+  #L%
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.boozallen.aissemble</groupId>
+        <artifactId>build-parent</artifactId>
+        <version>1.13.0</version>
+    </parent>
+
+    <groupId>com.test</groupId>
+    <artifactId>simple-project</artifactId>
+    <packaging>pom</packaging>
+    <version>1.0.0</version>
+    <name>Test Spark Bom Migration::Project::Simple Project</name>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.technologybrewery.baton</groupId>
+                <artifactId>baton-maven-plugin</artifactId>
+                <dependencies>
+                    <dependency>
+                        <groupId>com.boozallen.aissemble</groupId>
+                        <artifactId>foundation-upgrade</artifactId>
+                        <version>${version.aissemble}</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>com.test.blah</groupId>
+                <artifactId>nothing-here</artifactId>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>com.boozallen.aissemble</groupId>
+                <artifactId>aissemble-spark-bom</artifactId>
+                <version>${version.aissemble}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.spark</groupId>
+            <artifactId>spark-core_2.12</artifactId>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/foundation/foundation-upgrade/src/test/resources/test-files/version-specific/SparkBomDependencyMigration/validation/pom.xml
+++ b/foundation/foundation-upgrade/src/test/resources/test-files/version-specific/SparkBomDependencyMigration/validation/pom.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  aiSSEMBLE::Foundation::Upgrade
+  %%
+  Copyright (C) 2021 Booz Allen
+  %%
+  This software package is licensed under the Booz Allen Public License. All Rights Reserved.
+  #L%
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.boozallen.aissemble</groupId>
+        <artifactId>build-parent</artifactId>
+        <version>1.13.0</version>
+    </parent>
+
+    <groupId>com.test</groupId>
+    <artifactId>simple-project</artifactId>
+    <packaging>pom</packaging>
+    <version>1.0.0</version>
+    <name>Test Spark Bom Migration::Project::Simple Project</name>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.technologybrewery.baton</groupId>
+                <artifactId>baton-maven-plugin</artifactId>
+                <dependencies>
+                    <dependency>
+                        <groupId>com.boozallen.aissemble</groupId>
+                        <artifactId>foundation-upgrade</artifactId>
+                        <version>${version.aissemble}</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>com.boozallen.aissemble</groupId>
+                <artifactId>aissemble-spark-bom</artifactId>
+                <version>${version.aissemble}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.spark</groupId>
+            <artifactId>spark-core_2.12</artifactId>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/foundation/foundation-upgrade/src/test/resources/test-files/version-specific/SparkProvidedDependenciesMigration/validation/pom.xml
+++ b/foundation/foundation-upgrade/src/test/resources/test-files/version-specific/SparkProvidedDependenciesMigration/validation/pom.xml
@@ -254,32 +254,22 @@
         <dependency>
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-core_2.12</artifactId>
-            <version>${version.spark}</version>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-hive_2.12</artifactId>
-            <version>${version.spark}</version>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-streaming_2.12</artifactId>
-            <version>${version.spark}</version>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-sql_2.12</artifactId>
-            <version>${version.spark}</version>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-catalyst_2.12</artifactId>
-            <version>${version.spark}</version>
-            <scope>provided</scope>
         </dependency>
     </dependencies>
 

--- a/foundation/foundation-upgrade/src/test/resources/test-files/version-specific/SparkProvidedDependenciesMigration/validation/some-pom.xml
+++ b/foundation/foundation-upgrade/src/test/resources/test-files/version-specific/SparkProvidedDependenciesMigration/validation/some-pom.xml
@@ -266,20 +266,14 @@
         <dependency>
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-core_2.12</artifactId>
-            <version>${version.spark}</version>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-hive_2.12</artifactId>
-            <version>${version.spark}</version>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-streaming_2.12</artifactId>
-            <version>${version.spark}</version>
-            <scope>provided</scope>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
[686bb84](https://github.com/boozallen/aissemble/pull/730/commits/686bb845a1e3c8d5314dca69e3d47293a9e9b64e) - migration logic
[ea587ef](https://github.com/boozallen/aissemble/pull/730/commits/ea587ef6eaac336c2dd51dc421ee47b91e06c1b6) - updating SparkProvidedDependenciesMigration to remove `scope` and `version` from the spark dependencies
[b1d044b](https://github.com/boozallen/aissemble/pull/730/commits/b1d044b40d9db2614fa6c312948da6177e1c5133) - updating spacing in `pom.xml` file templates to include a space between `build` and `dependency` sections