### PR TITLE
715 Remove scipy version constraint

### DIFF
--- a/foundation/foundation-mda/src/main/resources/templates/general-mlflow/pyproject.toml.vm
+++ b/foundation/foundation-mda/src/main/resources/templates/general-mlflow/pyproject.toml.vm
@@ -21,11 +21,6 @@ pandas = ">=1.5.0"
 # https://stackoverflow.com/questions/74981558/error-updating-python3-pip-attributeerror-module-lib-has-no-attribute-openss
 pyopenssl = ">22.1.0"
 
-# The latest versions of scipy cap numpy to < 1.26.0, but older versions don't. The recent release of numpy caused
-# scipy to downgrade to a version that is incompatible with the latest version of numpy. Presumably, scipy will release
-# a new version that is compatible with the latest version of numpy, but until then, we need to explicitly avoid the downgrade.
-scipy = "^1.9.3"
-
 # If protobuf is not explicitly downgraded and 4.x is transitively used via mlflow, developers
 # may need to set the PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python to achieve backward compatibility
 # with any modules that were generated using protobuf 3.x

--- a/foundation/foundation-mda/src/main/resources/templates/inference/pyproject.toml.vm
+++ b/foundation/foundation-mda/src/main/resources/templates/inference/pyproject.toml.vm
@@ -19,11 +19,6 @@ grpcio = "^1.50.0"
 krausening = ">=20"
 pandas = ">=1.5.0"
 
-# The latest versions of scipy cap numpy to < 1.26.0, but older versions don't. The recent release of numpy caused
-# scipy to downgrade to a version that is incompatible with the latest version of numpy. Presumably, scipy will release
-# a new version that is compatible with the latest version of numpy, but until then, we need to explicitly avoid the downgrade.
-scipy = "^1.9.3"
-
 aissemble-foundation-core-python = "${aissemblePythonVersion}"
 aissemble-foundation-pdp-client-python = "${aissemblePythonVersion}"
 

--- a/test/test-mda-models/test-machine-learning-base-model/aissemble-machine-learning-training-base/pyproject.toml
+++ b/test/test-mda-models/test-machine-learning-base-model/aissemble-machine-learning-training-base/pyproject.toml
@@ -21,11 +21,6 @@ pandas = ">=1.5.0"
 # https://stackoverflow.com/questions/74981558/error-updating-python3-pip-attributeerror-module-lib-has-no-attribute-openss
 pyopenssl = ">22.1.0"
 
-# The latest versions of scipy cap numpy to < 1.26.0, but older versions don't. The recent release of numpy caused
-# scipy to downgrade to a version that is incompatible with the latest version of numpy. Presumably, scipy will release
-# a new version that is compatible with the latest version of numpy, but until then, we need to explicitly avoid the downgrade.
-scipy = "^1.9.3"
-
 # If protobuf is not explicitly downgraded and 4.x is transitively used via mlflow, developers
 # may need to set the PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python to achieve backward compatibility
 # with any modules that were generated using protobuf 3.x

--- a/test/test-mda-models/test-machine-learning-model/aissemble-machine-learning-inference/pyproject.toml
+++ b/test/test-mda-models/test-machine-learning-model/aissemble-machine-learning-inference/pyproject.toml
@@ -19,11 +19,6 @@ grpcio = "^1.50.0"
 krausening = ">=20"
 pandas = ">=1.5.0"
 
-# The latest versions of scipy cap numpy to < 1.26.0, but older versions don't. The recent release of numpy caused
-# scipy to downgrade to a version that is incompatible with the latest version of numpy. Presumably, scipy will release
-# a new version that is compatible with the latest version of numpy, but until then, we need to explicitly avoid the downgrade.
-scipy = "^1.9.3"
-
 [tool.poetry.group.dev.dependencies]
 behave = ">=1.2.6"
 nose = ">=1.3.7"

--- a/test/test-mda-models/test-machine-learning-model/aissemble-machine-learning-training/pyproject.toml
+++ b/test/test-mda-models/test-machine-learning-model/aissemble-machine-learning-training/pyproject.toml
@@ -26,11 +26,6 @@ pandas = ">=1.5.0"
 # https://stackoverflow.com/questions/74981558/error-updating-python3-pip-attributeerror-module-lib-has-no-attribute-openss
 pyopenssl = ">22.1.0"
 
-# The latest versions of scipy cap numpy to < 1.26.0, but older versions don't. The recent release of numpy caused
-# scipy to downgrade to a version that is incompatible with the latest version of numpy. Presumably, scipy will release
-# a new version that is compatible with the latest version of numpy, but until then, we need to explicitly avoid the downgrade.
-scipy = "^1.9.3"
-
 # If protobuf is not explicitly downgraded and 4.x is transitively used via mlflow, developers
 # may need to set the PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python to achieve backward compatibility
 # with any modules that were generated using protobuf 3.x


### PR DESCRIPTION
Additional cleanup of `scipy` version constraint in pyproject.toml and template files.

**Note**: No baton migration is included, in order to avoid inadvertently modifying and breaking existing projects that may rely on the previously pinned version.