### PR TITLE
[#733] incorporate dependapot suggestions

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -20,7 +20,7 @@
         <!-- **************** -->
         <!-- Plugins versions -->
         <!-- **************** -->
-        <version.archetype.plugin>3.2.1</version.archetype.plugin>
+        <version.archetype.plugin>3.3.0</version.archetype.plugin>
         <version.assembly.plugin>3.7.1</version.assembly.plugin>
         <version.buildhelper.plugin>3.6.0</version.buildhelper.plugin>
         <version.buildnumber.plugin>3.2.1</version.buildnumber.plugin>
@@ -64,7 +64,7 @@
         <version.kafka.client>3.8.0</version.kafka.client>
         <version.netty.handler>4.1.118.Final</version.netty.handler>
         <version.xstream>1.4.21</version.xstream>
-        <version.keycloak>26.0.6</version.keycloak>
+        <version.keycloak>26.1.2</version.keycloak>
 
         <!-- Java EE Dependencies -->
         <version.jakarta.cdi>4.0.1</version.jakarta.cdi>
@@ -185,18 +185,36 @@
             <artifactId>fermenter-mda</artifactId>
             <version>${version.fermenter}</version>
             <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.technologybrewery.habushu</groupId>
             <artifactId>habushu-maven-plugin</artifactId>
             <version>${version.habushu.plugin}</version>
             <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.technologybrewery.baton</groupId>
             <artifactId>baton-maven-plugin</artifactId>
             <version>${version.baton}</version>
             <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <!-- END: workaround to get maven build cache invalidation on new SNAPSHOTS of commonly updated plugins -->
     </dependencies>

--- a/extensions/extensions-data-delivery/extensions-data-delivery-spark-neo4j/pom.xml
+++ b/extensions/extensions-data-delivery/extensions-data-delivery-spark-neo4j/pom.xml
@@ -39,6 +39,10 @@
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-sql_2.12</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.technologybrewery.krausening</groupId>
+            <artifactId>krausening</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/extensions/extensions-data-delivery/extensions-data-delivery-spark-postgres/pom.xml
+++ b/extensions/extensions-data-delivery/extensions-data-delivery-spark-postgres/pom.xml
@@ -19,6 +19,10 @@
             <artifactId>postgresql</artifactId>
             <version>${version.postgresql}</version>
         </dependency>
+        <dependency>
+            <groupId>org.technologybrewery.krausening</groupId>
+            <artifactId>krausening</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/foundation/foundation-archetype/pom.xml
+++ b/foundation/foundation-archetype/pom.xml
@@ -52,6 +52,12 @@
             <version>3.3.0</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>net.masterthought</groupId>
+            <artifactId>cucumber-reporting</artifactId>
+            <version>${version.cucumber.reporting.plugin}</version>
+            <scope>test</scope>
+        </dependency>
         <!-- Supports archetype execution via Groovy Shell -->
         <dependency>
             <groupId>org.apache.maven.wagon</groupId>
@@ -60,9 +66,9 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>net.masterthought</groupId>
-            <artifactId>cucumber-reporting</artifactId>
-            <version>${version.cucumber.reporting.plugin}</version>
+            <groupId>org.eclipse.aether</groupId>
+            <artifactId>aether-api</artifactId>
+            <version>1.1.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/foundation/foundation-maven-plugins/artifacts-maven-plugin/pom.xml
+++ b/foundation/foundation-maven-plugins/artifacts-maven-plugin/pom.xml
@@ -143,7 +143,7 @@
         <dependency>
             <groupId>commons-beanutils</groupId>
             <artifactId>commons-beanutils</artifactId>
-            <version>1.9.4</version>
+            <version>1.11.0</version>
             <scope>provided</scope>
         </dependency>
 

--- a/foundation/foundation-maven-plugins/mda-maven-plugin/pom.xml
+++ b/foundation/foundation-maven-plugins/mda-maven-plugin/pom.xml
@@ -92,7 +92,7 @@
         <dependency>
             <groupId>commons-beanutils</groupId>
             <artifactId>commons-beanutils</artifactId>
-            <version>1.9.4</version>
+            <version>1.11.0</version>
             <scope>provided</scope>
         </dependency>
 


### PR DESCRIPTION
Primarly just touches Maven plugins like the archetype. Because we've add Habushu as a dependency in order to help with build cache calculations, a transitive dependency there was making dependabot think we were using a vulnerable version of a library in our application code. I added exclusions to the dependencies we added for this purpose just to reduce the noise.

This exposed a few places where we were actually relying on the transitive dependencies brought in by those for, namely, Krausening and aether-api.