### PR TITLE
[#721] ML inference uses Habushu containerization for docker build

### DIFF
--- a/DRAFT_RELEASE_NOTES.md
+++ b/DRAFT_RELEASE_NOTES.md
@@ -103,12 +103,11 @@ To reduce burden of upgrading aiSSEMBLE, the Baton project is used to automate t
 | maven-build-cache-migration                        | Updates build cache configuration to avoid stale Docker images                                                                                                                                                                                       |                                     |
 | my-sql-connector-yaml-migration                    | Update the my-sql-connector package to use the version with no CVE issue                                                                                                                                                                             |                                     |
 | trino-delta-lake-connector-yaml-migration          | Add the Delta Lake connector configuration in the Trino chart values.yaml file                                                                                                                                                                       |                                     |
-| habushu-monorepo-dependency-migration              | Ensures that all dependencies from Habushu modules on other Habushu modules in the same project are type `habushu`                                                                                                                                   |                                     |
 | ruff-toml-file-generation-migration                | Generates an initial ruff.toml file with a few lines of configuration to make the ruff linting and formatting consistent with prior linting and formatting.  This file can be configured using https://docs.astral.sh/ruff/configuration/ as a guide |                                     |
+| habushu-monorepo-dependency-migration              | Ensures that all dependencies from Habushu modules on other Habushu modules in the same project are type `habushu`                                                                                                                                   |                                     |
+| inference-docker-pom-migration                     | Update ML inference docker image generation to use Habushu's containerize-dependencies goal by adding the goal to the maven POM file                                                                                                                 |                                     |
 | spark-bom-dependency-migration                     | Adds the `aissemble-spark-bom` to data delivery pipelines for centralized Spark, Hadoop, and Hive dependency management and ensures version alignment with the `aissemble-spark` image                                                               |                                     |
 | ml-train-pipeline-docker-migration                 | Adds Habushu `containerize-dependencies` goal to relevant ML training pipeline docker pom files                                                                                                                                                      |                                     |
-| ml-train-image-tag-migration                       | Adds `imagePullPolicy: IfNotPresent` to Model training API dev values files                                                                                                                                                                          |                                     | 
-
 
 Migrations with arguments will not be executed unless that argument is provided (e.g. `./mvnw org.technologybrewery.baton:baton-maven-plugin:baton-migrate -D<argumentName>`). To deactivate any of these migrations, add the following configuration to the `baton-maven-plugin` within your root `pom.xml`:
 
@@ -230,6 +229,28 @@ your root _pom.xml_:
             </build>
         </profile>
     </profiles>
+```
+
+### For projects using Python
+With the Habushu version upgrade to 3.0.0, aiSSEMBLE will leverage Habushu's containerize-dependencies goal for these pipelines. Migrations are in place to automatically update the POM files for these docker modules but not the Dockerfile's themselves. Habushu will insert code in place of the tags `#HABUSHU_BUILDER_STAGE` and `#HABUSHU_FINAL_STAGE`. If they are not present, Habushu will place them at the top and bottom of the Dockerfile so you will need to add these tags into your dockerfile where it makes sense. Visit [Habushu's documentation](https://github.com/TechnologyBrewery/habushu/blob/dev/docs/HABUSHU_LIFECYCLE_README.md#containerize-dependencies) for more information. This is an example of a ML Inference and Ml Training dockerfile with the Habushu tags
+```dockerfile
+ARG DOCKER_BASELINE_REPO_ID
+ARG VERSION_AISSEMBLE
+
+#HABUSHU_BUILDER_STAGE
+
+#HABUSHU_FINAL_STAGE
+
+ENV GIT_PYTHON_REFRESH=quiet
+ENV ENABLE_LINEAGE=true
+
+# Ensure that any needed Krausening properties are copied and KRAUSENING_BASE environment variable is set!
+ENV KRAUSENING_BASE /app/config
+COPY target/krausening/base/ /app/config/
+COPY src/main/resources/krausening/base/ /app/config/
+
+# Start the drivers
+CMD ...
 ```
 
 ## Final Steps - Required for All Projects

--- a/foundation/foundation-mda/src/main/resources/templates/general-docker/inference.docker.file.vm
+++ b/foundation/foundation-mda/src/main/resources/templates/general-docker/inference.docker.file.vm
@@ -7,47 +7,17 @@
 ARG DOCKER_BASELINE_REPO_ID
 ARG VERSION_AISSEMBLE
 
-# Start build stage based on aiSSEMBLE extension of Nvidia base image
-FROM ${DOCKER_BASELINE_REPO_ID}boozallen/aissemble-nvidia:${VERSION_AISSEMBLE}
+#HABUSHU_BUILDER_STAGE
 
-# Set environment variables
+#HABUSHU_FINAL_STAGE
+
 ENV GIT_PYTHON_REFRESH=quiet
-ENV DEBIAN_FRONTEND=noninteractive
-
-# Update repositories and add necessary ones
-RUN apt-get -y update \
-    && apt-get install -y software-properties-common \
-    && add-apt-repository universe \
-    && add-apt-repository ppa:deadsnakes/ppa
-
-# Install Python 3.11 and related packages, install python-is-python3, create symbolic link, and perform cleanup
-RUN apt-get -y update \
-    && apt install python3.11 python3.11-distutils gcc python3.11-dev curl -y \
-    && apt-get install -y python-is-python3 \
-    && rm -f /usr/bin/python \
-    && ln -s /usr/bin/python3.11 /usr/bin/python \
-    && rm -rf /var/lib/apt/lists/* \
-    && apt-get clean
-    
-# Download and install pip for Python 3.11
-RUN curl -sS https://bootstrap.pypa.io/get-pip.py | python3.11
-
-# Copy Perceptor app.py file to required location
-COPY src/generated/resources/perceptor/app.py /home/app/
+ENV ENABLE_LINEAGE=true
 
 # Ensure that any needed Krausening properties are copied and KRAUSENING_BASE environment variable is set!
 ENV KRAUSENING_BASE /app/config
 COPY target/krausening/base/ /app/config/
 COPY src/main/resources/krausening/base/ /app/config/
-
-#Install ${inferenceModule} dependencies
-COPY target/${inferenceModule}/dist/requirements.txt /installation/${inferenceModule}/
-RUN python -m pip install --ignore-installed -r /installation/${inferenceModule}/requirements.txt
-
-# Install ${inferenceModule}
-COPY target/${inferenceModule}/dist /modules/${inferenceModule}
-RUN set -e && \
-    cd /modules/${inferenceModule}; for x in *.whl; do python -m pip install $x --no-cache-dir --no-deps; done
 
 # Start the inference API drivers for FastAPI and gRPC
 CMD python -m ${inferenceModuleSnakeCase}.inference_api_driver "fastAPI" & python -m ${inferenceModuleSnakeCase}.inference_api_driver "grpc"

--- a/foundation/foundation-upgrade/src/main/java/com/boozallen/aissemble/upgrade/migration/version_specific/AbstractContainerizeMigration.java
+++ b/foundation/foundation-upgrade/src/main/java/com/boozallen/aissemble/upgrade/migration/version_specific/AbstractContainerizeMigration.java
@@ -1,0 +1,82 @@
+package com.boozallen.aissemble.upgrade.migration.version_specific;
+
+/*-
+ * #%L
+ * aiSSEMBLE::Foundation::Upgrade
+ * %%
+ * Copyright (C) 2021 Booz Allen
+ * %%
+ * This software package is licensed under the Booz Allen Public License. All Rights Reserved.
+ * #L%
+ */
+
+import static org.apache.commons.lang3.StringUtils.repeat;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.maven.model.Plugin;
+import org.apache.maven.model.PluginExecution;
+import org.apache.maven.project.MavenProject;
+import org.codehaus.plexus.util.xml.Xpp3Dom;
+
+import com.boozallen.aissemble.upgrade.migration.AbstractPomMigration;
+
+public abstract class AbstractContainerizeMigration extends AbstractPomMigration {
+
+    public static final String HABUSHU_MAVEN_PLUGIN_ID = "org.technologybrewery.habushu:habushu-maven-plugin";
+    private static final String FERMENTER_MDA_PLUGIN_ID = "org.technologybrewery.fermenter:fermenter-mda";
+    private static final String DOCKER_BUILD_TYPE = "docker-build";
+    private static final String PROFILE = "profile";
+
+    protected boolean containsHabushuContainerizeGoal(MavenProject mavenProject) {
+        Plugin habushuPlugin = mavenProject.getPlugin(HABUSHU_MAVEN_PLUGIN_ID);
+        if (habushuPlugin != null) {
+            for (PluginExecution execution : habushuPlugin.getExecutions()) {
+                if (execution.getGoals().contains("containerize-dependencies")) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    protected boolean isDockerBuildPackage(MavenProject mavenProject) {
+        return StringUtils.equals(DOCKER_BUILD_TYPE, mavenProject.getModel().getPackaging());
+    }
+
+    protected boolean containsFermenterProfile(MavenProject mavenProject, String profileId) {
+        Plugin fermenterMdaPlugin = mavenProject.getPlugin(FERMENTER_MDA_PLUGIN_ID);
+        if (fermenterMdaPlugin != null) {
+            Xpp3Dom configuration = (Xpp3Dom) fermenterMdaPlugin.getConfiguration();
+
+            for (Xpp3Dom child: configuration.getChildren()) {
+                if(PROFILE.equals(child.getName()) && profileId.equals(child.getValue())) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    protected String habushuPluginWithContainerizationGoal(int indentCount){
+        StringBuilder builder = new StringBuilder();
+        builder.append(repeat(indent, indentCount)).append("<plugin>\n")
+                .append(repeat(indent, indentCount+1)).append("<groupId>org.technologybrewery.habushu</groupId>\n")
+                .append(repeat(indent, indentCount+1)).append("<artifactId>habushu-maven-plugin</artifactId>\n")
+                .append(repeat(indent, indentCount+1)).append("<executions>\n")
+                .append(repeat(indent, indentCount+2)).append("<execution>\n")
+                .append(repeat(indent, indentCount+3)).append("<id>dockerize</id>\n")
+                .append(repeat(indent, indentCount+3)).append("<goals>\n")
+                .append(repeat(indent, indentCount+4)).append("<goal>containerize-dependencies</goal>\n")
+                .append(repeat(indent, indentCount+3)).append("</goals>\n")
+                .append(repeat(indent, indentCount+3)).append("<phase>prepare-package</phase>\n")
+                .append(repeat(indent, indentCount+3)).append("<configuration>\n")
+                .append(repeat(indent, indentCount+4)).append("<dockerfile>src/main/resources/docker/Dockerfile</dockerfile>\n")
+                .append(repeat(indent, indentCount+4)).append("<dockerBuilderBase>${DOCKER_BASELINE_REPO_ID}boozallen/aissemble-nvidia:${VERSION_AISSEMBLE}</dockerBuilderBase>\n")
+                .append(repeat(indent, indentCount+4)).append("<dockerFinalBase>${DOCKER_BASELINE_REPO_ID}boozallen/aissemble-nvidia:${VERSION_AISSEMBLE}</dockerFinalBase>\n")
+                .append(repeat(indent, indentCount+3)).append("</configuration>\n")
+                .append(repeat(indent, indentCount+2)).append("</execution>\n")
+                .append(repeat(indent, indentCount+1)).append("</executions>\n")
+                .append(repeat(indent, indentCount)).append("</plugin>\n");
+        return builder.toString();
+    }
+}

--- a/foundation/foundation-upgrade/src/main/java/com/boozallen/aissemble/upgrade/migration/version_specific/InferenceDockerPomMigration.java
+++ b/foundation/foundation-upgrade/src/main/java/com/boozallen/aissemble/upgrade/migration/version_specific/InferenceDockerPomMigration.java
@@ -1,0 +1,59 @@
+package com.boozallen.aissemble.upgrade.migration.version_specific;
+
+/*-
+ * #%L
+ * aiSSEMBLE::Foundation::Upgrade
+ * %%
+ * Copyright (C) 2021 Booz Allen
+ * %%
+ * This software package is licensed under the Booz Allen Public License. All Rights Reserved.
+ * #L%
+ */
+
+import static org.apache.commons.lang3.StringUtils.repeat;
+import static org.technologybrewery.baton.util.pom.LocationAwareMavenReader.END;
+
+import java.io.File;
+
+import org.apache.maven.model.Model;
+import org.apache.maven.project.MavenProject;
+import org.technologybrewery.baton.util.pom.PomHelper;
+import org.technologybrewery.baton.util.pom.PomModifications;
+
+public class InferenceDockerPomMigration extends AbstractContainerizeMigration {
+
+    public static final String AISSEMBLE_INFERENCE_DOCKER = "aissemble-inference-docker";
+
+    /**
+     * Determines if the migration should be executed. Will return true if the inference docker pom does not use the
+     * Habushu containerization goal
+     *
+     * @param file file to check
+     * @return true if the migration should run
+     */
+    @Override
+    protected boolean shouldExecuteOnFile(File file) {
+        MavenProject mavenProject = getMavenProject();
+        return isDockerBuildPackage(mavenProject) && containsFermenterProfile(mavenProject, AISSEMBLE_INFERENCE_DOCKER)
+                && !containsHabushuContainerizeGoal(mavenProject);
+    }
+
+    /**
+     * Performs the migration. Inserts the habushu-maven-plugin into the projects plugin list
+     *
+     * @param file POM file to insert the plugin into
+     * @return true if the migration was successful
+     */
+    @Override
+    protected boolean performMigration(File file) {
+        detectAndSetIndent(file);
+        Model model = PomHelper.getLocationAnnotatedModel(file);
+        PomModifications pomModifications = new PomModifications();
+
+        // Safe to assume the pom has build and plugins because "shouldExecuteOnFile" checks the fermenter plugin
+        final String insertContent = habushuPluginWithContainerizationGoal(3);
+        pomModifications.add(new PomModifications.Insertion(model.getBuild().getLocation("plugins" + END),
+                3, content -> insertContent));
+        return PomHelper.writeModifications(file, pomModifications.finalizeMods());
+    }
+}

--- a/foundation/foundation-upgrade/src/main/java/com/boozallen/aissemble/upgrade/migration/version_specific/MlTrainPipelineDockerMigration.java
+++ b/foundation/foundation-upgrade/src/main/java/com/boozallen/aissemble/upgrade/migration/version_specific/MlTrainPipelineDockerMigration.java
@@ -10,48 +10,32 @@ package com.boozallen.aissemble.upgrade.migration.version_specific;
  * #L%
  */
 
-import com.boozallen.aissemble.upgrade.migration.AbstractPomMigration;
-import static org.technologybrewery.baton.util.pom.LocationAwareMavenReader.END;
 import static org.apache.commons.lang3.StringUtils.repeat;
-
-import org.apache.maven.model.Model;
-import org.apache.maven.model.Plugin;
-import org.apache.commons.lang3.StringUtils;
-import org.apache.maven.model.PluginExecution;
-import org.apache.maven.project.MavenProject;
-import org.codehaus.plexus.util.xml.Xpp3Dom;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import org.technologybrewery.baton.util.pom.PomHelper;
-import org.technologybrewery.baton.util.pom.PomModifications;
+import static org.technologybrewery.baton.util.pom.LocationAwareMavenReader.END;
 
 import java.io.File;
+
+import org.apache.maven.model.Model;
+import org.apache.maven.project.MavenProject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.technologybrewery.baton.util.pom.PomHelper;
+import org.technologybrewery.baton.util.pom.PomModifications;
 
 
 /**
  * Migration that updates the POM files for machine learning pipelines with a train step to use Habushu's containerize-dependencies goal.
  */
-public class MlTrainPipelineDockerMigration extends AbstractPomMigration {
+public class MlTrainPipelineDockerMigration extends AbstractContainerizeMigration {
     protected static final Logger logger = LoggerFactory.getLogger(MlTrainPipelineDockerMigration.class);
-    private static final String DOCKER_BUILD_TYPE = "docker-build";
-    private static final String DOCKERIZE = "dockerize";
-    private static final String HABUSHU_GROUP_ID = "org.technologybrewery.habushu";
-    private static final String HABUSHU_ARTIFACT_ID = "habushu-maven-plugin";
-    private static final String FERMENTER_MDA_PLUGIN_ID = "org.technologybrewery.fermenter:fermenter-mda";
     private static final String AISSEMBLE_TRAINING_DOCKER = "aissemble-training-docker";
-    private static final String CONTAINERIZE_DEPS_GOAL = "containerize-dependencies";
 
     @Override
     protected boolean shouldExecuteOnFile(File file) {
-        // package/type needs to be docker-build
+        // Should migrate if the pom package is docker-build, the fermenter plugin is for aissemble training, and it
+        // does not already have the containerize plugin
         MavenProject mavenProject = getMavenProject();
-        if (!StringUtils.equals(DOCKER_BUILD_TYPE, mavenProject.getModel().getPackaging())) {
-            return false;
-        }
-
-        return isMlTrainingDockerPom(mavenProject) && !containsHabushuContainerizeGoal(mavenProject);
+        return isDockerBuildPackage(mavenProject) && containsFermenterProfile(mavenProject, AISSEMBLE_TRAINING_DOCKER) && !containsHabushuContainerizeGoal(mavenProject);
     }
 
     @Override
@@ -60,63 +44,9 @@ public class MlTrainPipelineDockerMigration extends AbstractPomMigration {
         detectAndSetIndent(file);
         PomModifications modifications = new PomModifications();
 
-        String content = getHabushuPluginConfiguration();
+        String content = habushuPluginWithContainerizationGoal(3);
         modifications.add(new PomModifications.Insertion(model.getBuild().getLocation("plugins" + END), 3, ignore -> content));
 
         return PomHelper.writeModifications(file, modifications.finalizeMods());
-    }
-
-    private boolean containsHabushuContainerizeGoal(MavenProject mavenProject) {
-        Plugin habushuPlugin = mavenProject.getPlugin(HABUSHU_GROUP_ID + ":" + HABUSHU_ARTIFACT_ID);
-        if (habushuPlugin != null) {
-            for (PluginExecution execution : habushuPlugin.getExecutions()) {
-                if (DOCKERIZE.equals(execution.getId())) {
-                    return true;
-                }
-            }
-        }
-        return false;
-    }
-
-    protected boolean isMlTrainingDockerPom(MavenProject mavenProject){
-        getMavenProject().getBuildPlugins();
-        Plugin fermenterMdaPlugin = mavenProject.getPlugin(FERMENTER_MDA_PLUGIN_ID);
-
-        if (fermenterMdaPlugin == null) {
-            return false;
-        }
-
-        Object rawConfig = fermenterMdaPlugin.getConfiguration();
-        if (!(rawConfig instanceof Xpp3Dom)){
-            return false;
-        }
-        Xpp3Dom configuration = (Xpp3Dom) rawConfig;
-        for (Xpp3Dom child : configuration.getChildren()) {
-            if (AISSEMBLE_TRAINING_DOCKER.equals(child.getValue())) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    private String getHabushuPluginConfiguration() {
-        return repeat(indent, 3) + "<plugin>\n" +
-                repeat(indent, 4) + "<groupId>" + HABUSHU_GROUP_ID + "</groupId>\n" +
-                repeat(indent, 4) + "<artifactId>" + HABUSHU_ARTIFACT_ID + "</artifactId>\n" +
-                repeat(indent, 4) + "<executions>\n" +
-                repeat(indent, 5) + "<execution>\n" +
-                repeat(indent, 6) + "<id>" + DOCKERIZE + "</id>\n" +
-                repeat(indent, 6) + "<goals>\n" +
-                repeat(indent, 7) + "<goal>" + CONTAINERIZE_DEPS_GOAL + "</goal>\n" +
-                repeat(indent, 6) + "</goals>\n" +
-                repeat(indent, 6) + "<phase>prepare-package</phase>\n" +
-                repeat(indent, 6) + "<configuration>\n" +
-                repeat(indent, 7) + "<dockerfile>src/main/resources/docker/Dockerfile</dockerfile>\n" +
-                repeat(indent, 7) + "<dockerBuilderBase>${DOCKER_BASELINE_REPO_ID}boozallen/aissemble-nvidia:${VERSION_AISSEMBLE}</dockerBuilderBase>\n" +
-                repeat(indent, 7) + "<dockerFinalBase>${DOCKER_BASELINE_REPO_ID}boozallen/aissemble-nvidia:${VERSION_AISSEMBLE}</dockerFinalBase>\n" +
-                repeat(indent, 6) + "</configuration>\n" +
-                repeat(indent, 5) + "</execution>\n" +
-                repeat(indent, 4) + "</executions>\n" +
-                repeat(indent, 3) + "</plugin>\n";
     }
 }

--- a/foundation/foundation-upgrade/src/main/resources/migrations.json
+++ b/foundation/foundation-upgrade/src/main/resources/migrations.json
@@ -131,6 +131,24 @@
             "includes": ["pom.xml"]
           }
         ]
+      },
+      {
+        "name": "inference-docker-pom-migration",
+        "implementation": "com.boozallen.aissemble.upgrade.migration.version_specific.InferenceDockerPomMigration",
+        "fileSets": [
+          {
+            "includes": ["pom.xml"]
+          }
+        ]
+      },
+      {
+        "name": "ml-train-pipeline-docker-migration",
+        "implementation": "com.boozallen.aissemble.upgrade.migration.version_specific.MlTrainPipelineDockerMigration",
+        "fileSets": [
+          {
+            "includes": ["pom.xml"]
+          }
+        ]
       }
     ]
   },
@@ -183,15 +201,6 @@
       {
         "name": "ruff-toml-file-generation-migration",
         "implementation": "com.boozallen.aissemble.upgrade.migration.version_specific.RuffTomlFileGenerationMigration",
-        "fileSets": [
-          {
-            "includes": ["pom.xml"]
-          }
-        ]
-      },
-      {
-        "name": "ml-train-pipeline-docker-migration",
-        "implementation": "com.boozallen.aissemble.upgrade.migration.version_specific.MlTrainPipelineDockerMigration",
         "fileSets": [
           {
             "includes": ["pom.xml"]

--- a/foundation/foundation-upgrade/src/test/java/com/boozallen/aissemble/upgrade/migration/extensions/HabushuMonorepoDependencyMigrationTest.java
+++ b/foundation/foundation-upgrade/src/test/java/com/boozallen/aissemble/upgrade/migration/extensions/HabushuMonorepoDependencyMigrationTest.java
@@ -1,4 +1,4 @@
-package com.boozallen.aissemble.upgrade.migration.version_specific;
+package com.boozallen.aissemble.upgrade.migration.extensions;
 
 /*-
  * #%L
@@ -14,6 +14,8 @@ import org.apache.maven.project.MavenProject;
 
 import java.util.ArrayList;
 import java.util.List;
+
+import com.boozallen.aissemble.upgrade.migration.version_specific.HabushuMonorepoDependencyMigration;
 
 /**
  * HabushuMonorepoDependencyMigrationTest

--- a/foundation/foundation-upgrade/src/test/java/com/boozallen/aissemble/upgrade/migration/version_specific/HabushuContainerizationSteps.java
+++ b/foundation/foundation-upgrade/src/test/java/com/boozallen/aissemble/upgrade/migration/version_specific/HabushuContainerizationSteps.java
@@ -10,34 +10,33 @@ package com.boozallen.aissemble.upgrade.migration.version_specific;
  * #L%
  */
 
-import com.boozallen.aissemble.upgrade.migration.AbstractMigrationTest;
+import java.io.FileReader;
+import java.io.IOException;
 
-import io.cucumber.java.en.And;
-import io.cucumber.java.en.Given;
-import io.cucumber.java.en.Then;
-import io.cucumber.java.en.When;
 import org.apache.maven.model.Model;
 import org.apache.maven.model.io.xpp3.MavenXpp3Reader;
 import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
 
-import java.io.FileReader;
-import java.io.IOException;
+import com.boozallen.aissemble.upgrade.migration.AbstractMigrationTest;
+import com.boozallen.aissemble.upgrade.migration.extensions.HabushuMonorepoDependencyMigrationTest;
 
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
 
 public class HabushuContainerizationSteps extends AbstractMigrationTest {
     HabushuMonorepoDependencyMigrationTest habushuMonorepoDependencyMigration = new HabushuMonorepoDependencyMigrationTest();
     MlTrainPipelineDockerMigration trainingDockerPomMigration = new MlTrainPipelineDockerMigration();
+    InferenceDockerPomMigration inferenceDockerPomMigration = new InferenceDockerPomMigration();
 
     @Given("a POM with packaging habushu")
     public void aPomWithPackagingHabushu() throws IOException, XmlPullParserException {
         setTestFileToVersionMigration("HabushuMonorepoDependencyMigration", "pom.xml");
-        Model model = new MavenXpp3Reader().read(new FileReader(testFile));
-        MavenProject testProject = new MavenProject(model);
-        habushuMonorepoDependencyMigration.setMavenProject(testProject);
+        habushuMonorepoDependencyMigration.setMavenProject(createMavenProjectFromPom());
     }
 
-    @And("a pom-type dependency on another habushu-packaged module that is in the list of Maven projects")
+    @Given("a pom-type dependency on another habushu-packaged module that is in the list of Maven projects")
     public void aPomTypeDependencyOnAnotherHabushuPackagedModuleThatIsInTheListOfMavenProjects() {
         //dependencies are set in the test POM file, so just add project
         habushuMonorepoDependencyMigration.addProject("habushu-library", "habushu");
@@ -55,7 +54,7 @@ public class HabushuContainerizationSteps extends AbstractMigrationTest {
         trainingDockerPomMigration.setMavenProject(createMavenProjectFromPom());
     }
 
-    @And("the fermenter-mda plugin has the profile aissemble-training-docker")
+    @Given("the fermenter-mda plugin has the profile aissemble-training-docker")
     public void theFermenterMdaPluginHasTheProfileAissembleTrainingDocker(){
         // Already covered by test POM file content
     }
@@ -63,6 +62,35 @@ public class HabushuContainerizationSteps extends AbstractMigrationTest {
     @When("the training docker pom migration executes")
     public void theTrainingDockerPomMigrationExecutes() {
         performMigration(trainingDockerPomMigration);
+        habushuMonorepoDependencyMigration.addProject("habushu-library", "habushu");
+    }
+
+    @Given("an inference POM without a Habushu containerize goal")
+    public void anInferencePOMWithoutAHabushuContainerizeGoal() throws IOException, XmlPullParserException {
+        setTestFileToVersionMigration("InferenceDockerPomMigration", "pom.xml");
+        inferenceDockerPomMigration.setMavenProject(createMavenProjectFromPom());
+    }
+
+    @Given("an inference POM with a Habushu containerize goal")
+    public void anInferencePOMWithAHabushuContainerizeGoal() throws XmlPullParserException, IOException {
+        setTestFileToVersionMigration("InferenceDockerPomMigration", "pom-with-containerize.xml");
+        inferenceDockerPomMigration.setMavenProject(createMavenProjectFromPom());
+    }
+
+    @Given("the fermenter-mda plugin has the profile aissemble-inference-docker")
+    public void theFermenterMdaPluginHasTheProfileAissembleInferenceDocker() {
+        // Handled in test file
+    }
+
+    @Given("a non ML Inference docker POM files")
+    public void aNonMLInferenceDockerPOMFiles() throws XmlPullParserException, IOException {
+        setTestFileToVersionMigration("InferenceDockerPomMigration", "non-ml-inference-pom.xml");
+        inferenceDockerPomMigration.setMavenProject(createMavenProjectFromPom());
+    }
+
+    @When("the inference docker pom migration executes")
+    public void theInferenceDockerPomMigrationExecutes() {
+        performMigration(inferenceDockerPomMigration);
     }
 
     @When("the Habushu dependency type migration executes")
@@ -78,11 +106,17 @@ public class HabushuContainerizationSteps extends AbstractMigrationTest {
 
     @Then("the POM is updated to use the habushu containerize goal")
     public void thePOMIsUpdatedToUseTheHabushuContainerizeGoal() {
+        assertMigrationSuccess();
         assertTestFileMatchesExpectedFile("Habushu containerize-dependencies goal was not added to POM file");
     }
 
     @Then("the training docker pom migration was skipped")
     public void theTrainingDockerPomMigrationWasSkipped() {
+        assertMigrationSkipped();
+    }
+
+    @Then("the inference docker pom migration was skipped")
+    public void theInferenceDockerPomMigrationWasSkipped() {
         assertMigrationSkipped();
     }
 

--- a/foundation/foundation-upgrade/src/test/resources/specifications/version-specific/habushu-containerization-migration.feature
+++ b/foundation/foundation-upgrade/src/test/resources/specifications/version-specific/habushu-containerization-migration.feature
@@ -21,3 +21,20 @@ Feature: Habushu Containerization Migration
     And the fermenter-mda plugin has the profile aissemble-training-docker
     When the training docker pom migration executes
     Then the training docker pom migration was skipped
+
+  Scenario: ML Inference docker pom files are updated to leverage the Habushu containerize goal
+    Given an inference POM without a Habushu containerize goal
+    And the fermenter-mda plugin has the profile aissemble-inference-docker
+    When the inference docker pom migration executes
+    Then the POM is updated to use the habushu containerize goal
+
+  Scenario: ML Inference docker POM file has Habushu containerize goal, the migration should be skipped
+    Given an inference POM with a Habushu containerize goal
+    And the fermenter-mda plugin has the profile aissemble-inference-docker
+    When the inference docker pom migration executes
+    Then the inference docker pom migration was skipped
+
+  Scenario: Non ML Inference docker POM files are not migrated
+    Given a non ML Inference docker POM files
+    When the inference docker pom migration executes
+    Then the inference docker pom migration was skipped

--- a/foundation/foundation-upgrade/src/test/resources/test-files/version-specific/InferenceDockerPomMigration/migration/non-ml-inference-pom.xml
+++ b/foundation/foundation-upgrade/src/test/resources/test-files/version-specific/InferenceDockerPomMigration/migration/non-ml-inference-pom.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  aiSSEMBLE::Foundation::Upgrade
+  %%
+  Copyright (C) 2021 Booz Allen
+  %%
+  This software package is licensed under the Booz Allen Public License. All Rights Reserved.
+  #L%
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.boozallen</groupId>
+    <artifactId>test-aissemble-empty-docker-pom</artifactId>
+    <packaging>docker-build</packaging>
+
+    <name>aiSSEMBLE::Test::Docker::Emtpy</name>
+    <description>An empty POM used for testing InferenceDockerPomMigration to Skip</description>
+
+</project>

--- a/foundation/foundation-upgrade/src/test/resources/test-files/version-specific/InferenceDockerPomMigration/migration/pom-with-containerize.xml
+++ b/foundation/foundation-upgrade/src/test/resources/test-files/version-specific/InferenceDockerPomMigration/migration/pom-with-containerize.xml
@@ -1,21 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  aiSSEMBLE::Foundation::Upgrade
+  %%
+  Copyright (C) 2021 Booz Allen
+  %%
+  This software package is licensed under the Booz Allen Public License. All Rights Reserved.
+  #L%
+  -->
+
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <parent>
-        <groupId>${groupId}</groupId>
-        <artifactId>${parentArtifactId}</artifactId>
-        <version>${version}</version>
-    </parent>
-
-    <artifactId>${artifactId}</artifactId>
-
+    <groupId>com.boozallen</groupId>
+    <artifactId>test-aissemble-machine-learning-inference-docker</artifactId>
     <packaging>docker-build</packaging>
 
-    <name>${parentDescriptiveName}::Inference</name>
-    <description>Build for an Inference Docker container to run a compliant inference service</description>
+    <name>aiSSEMBLE::Test::Docker::Inference</name>
+    <description>A POM used for testing InferenceDockerPomMigration</description>
 
     <build>
         <plugins>
@@ -23,7 +27,7 @@
                 <groupId>org.technologybrewery.fermenter</groupId>
                 <artifactId>fermenter-mda</artifactId>
                 <configuration>
-                    <basePackage>${basePackage}</basePackage>
+                    <basePackage>com.boozallen.aissemble</basePackage>
                     <profile>aissemble-inference-docker</profile>
                     <propertyVariables>
                         <dockerProjectRepositoryUrl>${docker.project.repository.url}</dockerProjectRepositoryUrl>
@@ -59,7 +63,7 @@
                             <outputDirectory>${project.build.directory}/krausening/base</outputDirectory>
                             <resources>
                                 <resource>
-                                    <directory>${project.parent.parent.basedir}/${rootArtifactId}-pipelines/${inferencePipeline.pipelineArtifactId}/${inferencePipeline.stepArtifactId}/src/${inferenceModuleSnakeCase}/resources/krausening/base</directory>
+                                    <directory>${project.parent.parent.basedir}/test-pipelines/test-machine-learning-pipeline/test-aissemble-machine-learning-inference/src/test_aissemble_machine_learning_inference/resources/krausening/base</directory>
                                     <filtering>false</filtering>
                                 </resource>
                             </resources>
@@ -91,12 +95,11 @@
             </plugin>
         </plugins>
     </build>
-
     <dependencies>
         <dependency>
-            <groupId>#[[${project.groupId}]]#</groupId>
-            <artifactId>${inferencePipeline.stepArtifactId}</artifactId>
-            <version>#[[${project.version}]]#</version>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>test-aissemble-machine-learning-inference</artifactId>
+            <version>${project.version}</version>
             <type>habushu</type>
         </dependency>
     </dependencies>

--- a/foundation/foundation-upgrade/src/test/resources/test-files/version-specific/InferenceDockerPomMigration/migration/pom.xml
+++ b/foundation/foundation-upgrade/src/test/resources/test-files/version-specific/InferenceDockerPomMigration/migration/pom.xml
@@ -1,21 +1,26 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  aiSSEMBLE::Foundation::Upgrade
+  %%
+  Copyright (C) 2021 Booz Allen
+  %%
+  This software package is licensed under the Booz Allen Public License. All Rights Reserved.
+  #L%
+  -->
+
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <parent>
-        <groupId>${groupId}</groupId>
-        <artifactId>${parentArtifactId}</artifactId>
-        <version>${version}</version>
-    </parent>
-
-    <artifactId>${artifactId}</artifactId>
-
+    <groupId>com.boozallen</groupId>
+    <artifactId>test-aissemble-machine-learning-inference-docker</artifactId>
+    <version>1.0.0</version>
     <packaging>docker-build</packaging>
 
-    <name>${parentDescriptiveName}::Inference</name>
-    <description>Build for an Inference Docker container to run a compliant inference service</description>
+    <name>aiSSEMBLE::Test::Docker::Inference</name>
+    <description>A POM used for testing InferenceDockerPomMigration</description>
 
     <build>
         <plugins>
@@ -23,7 +28,7 @@
                 <groupId>org.technologybrewery.fermenter</groupId>
                 <artifactId>fermenter-mda</artifactId>
                 <configuration>
-                    <basePackage>${basePackage}</basePackage>
+                    <basePackage>com.boozallen.aissemble</basePackage>
                     <profile>aissemble-inference-docker</profile>
                     <propertyVariables>
                         <dockerProjectRepositoryUrl>${docker.project.repository.url}</dockerProjectRepositoryUrl>
@@ -59,7 +64,7 @@
                             <outputDirectory>${project.build.directory}/krausening/base</outputDirectory>
                             <resources>
                                 <resource>
-                                    <directory>${project.parent.parent.basedir}/${rootArtifactId}-pipelines/${inferencePipeline.pipelineArtifactId}/${inferencePipeline.stepArtifactId}/src/${inferenceModuleSnakeCase}/resources/krausening/base</directory>
+                                    <directory>${project.parent.parent.basedir}/test-pipelines/test-machine-learning-pipeline/test-aissemble-machine-learning-inference/src/test_aissemble_machine_learning_inference/resources/krausening/base</directory>
                                     <filtering>false</filtering>
                                 </resource>
                             </resources>
@@ -71,32 +76,13 @@
                 <groupId>${group.fabric8.plugin}</groupId>
                 <artifactId>docker-maven-plugin</artifactId>
             </plugin>
-            <plugin>
-                <groupId>org.technologybrewery.habushu</groupId>
-                <artifactId>habushu-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>dockerize</id>
-                        <goals>
-                            <goal>containerize-dependencies</goal>
-                        </goals>
-                        <phase>prepare-package</phase>
-                        <configuration>
-                            <dockerfile>src/main/resources/docker/Dockerfile</dockerfile>
-                            <dockerBuilderBase>${DOCKER_BASELINE_REPO_ID}boozallen/aissemble-nvidia:${VERSION_AISSEMBLE}</dockerBuilderBase>
-                            <dockerFinalBase>${DOCKER_BASELINE_REPO_ID}boozallen/aissemble-nvidia:${VERSION_AISSEMBLE}</dockerFinalBase>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
         </plugins>
     </build>
-
     <dependencies>
         <dependency>
-            <groupId>#[[${project.groupId}]]#</groupId>
-            <artifactId>${inferencePipeline.stepArtifactId}</artifactId>
-            <version>#[[${project.version}]]#</version>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>test-aissemble-machine-learning-inference</artifactId>
+            <version>${project.version}</version>
             <type>habushu</type>
         </dependency>
     </dependencies>

--- a/foundation/foundation-upgrade/src/test/resources/test-files/version-specific/InferenceDockerPomMigration/validation/pom.xml
+++ b/foundation/foundation-upgrade/src/test/resources/test-files/version-specific/InferenceDockerPomMigration/validation/pom.xml
@@ -1,21 +1,26 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  aiSSEMBLE::Foundation::Upgrade
+  %%
+  Copyright (C) 2021 Booz Allen
+  %%
+  This software package is licensed under the Booz Allen Public License. All Rights Reserved.
+  #L%
+  -->
+
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <parent>
-        <groupId>${groupId}</groupId>
-        <artifactId>${parentArtifactId}</artifactId>
-        <version>${version}</version>
-    </parent>
-
-    <artifactId>${artifactId}</artifactId>
-
+    <groupId>com.boozallen</groupId>
+    <artifactId>test-aissemble-machine-learning-inference-docker</artifactId>
+    <version>1.0.0</version>
     <packaging>docker-build</packaging>
 
-    <name>${parentDescriptiveName}::Inference</name>
-    <description>Build for an Inference Docker container to run a compliant inference service</description>
+    <name>aiSSEMBLE::Test::Docker::Inference</name>
+    <description>A POM used for testing InferenceDockerPomMigration</description>
 
     <build>
         <plugins>
@@ -23,7 +28,7 @@
                 <groupId>org.technologybrewery.fermenter</groupId>
                 <artifactId>fermenter-mda</artifactId>
                 <configuration>
-                    <basePackage>${basePackage}</basePackage>
+                    <basePackage>com.boozallen.aissemble</basePackage>
                     <profile>aissemble-inference-docker</profile>
                     <propertyVariables>
                         <dockerProjectRepositoryUrl>${docker.project.repository.url}</dockerProjectRepositoryUrl>
@@ -59,7 +64,7 @@
                             <outputDirectory>${project.build.directory}/krausening/base</outputDirectory>
                             <resources>
                                 <resource>
-                                    <directory>${project.parent.parent.basedir}/${rootArtifactId}-pipelines/${inferencePipeline.pipelineArtifactId}/${inferencePipeline.stepArtifactId}/src/${inferenceModuleSnakeCase}/resources/krausening/base</directory>
+                                    <directory>${project.parent.parent.basedir}/test-pipelines/test-machine-learning-pipeline/test-aissemble-machine-learning-inference/src/test_aissemble_machine_learning_inference/resources/krausening/base</directory>
                                     <filtering>false</filtering>
                                 </resource>
                             </resources>
@@ -91,12 +96,11 @@
             </plugin>
         </plugins>
     </build>
-
     <dependencies>
         <dependency>
-            <groupId>#[[${project.groupId}]]#</groupId>
-            <artifactId>${inferencePipeline.stepArtifactId}</artifactId>
-            <version>#[[${project.version}]]#</version>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>test-aissemble-machine-learning-inference</artifactId>
+            <version>${project.version}</version>
             <type>habushu</type>
         </dependency>
     </dependencies>


### PR DESCRIPTION
Downstream projects now generate the ml inference docker and pom that leverage habushus containerize goal instead of installing requirements and whl files.

Baton migration adds the Habushu containerize goal to existing projects