### PR TITLE
[#753] update to parent 7 and isolate release logic

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,7 +76,7 @@ jobs:
           <settings>
             <servers>
               <server>
-                <id>ossrh</id>
+                <id>central</id>
                 <username>${{ secrets.SONATYPE_CENTRAL_REPO_TOKEN_USER }}</username>
                 <password>${{ secrets.SONATYPE_CENTRAL_REPO_TOKEN_KEY }}</password>
               </server>

--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,9 @@ Chart.lock
 extensions/extensions-helm/aissemble-spark-operator-chart/values.yaml
 extensions/extensions-helm/aissemble-infrastructure-chart/values.yaml
 
+# Generated resources
+foundation/foundation-messaging/foundation-messaging-python/aissemble-foundation-messaging-python-client/src/aissemble_messaging/service_resources
+
 # The test project should test that we generate files that compile and have the expected structure for model options
 # there should not be any no custom logic added and we should clean up the project properly before each build
 # so ignore the one time generated files

--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -14,5 +14,5 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.6/apache-maven-3.9.6-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.11/apache-maven-3.9.11-bin.zip
 wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.3.2/maven-wrapper-3.3.2.jar

--- a/DRAFT_RELEASE_NOTES.md
+++ b/DRAFT_RELEASE_NOTES.md
@@ -48,6 +48,7 @@ Habushu has been upgraded to [version 3.0](https://github.com/TechnologyBrewery/
 # Breaking Changes
 _Note: instructions for adapting to these changes are outlined in the upgrade instructions below._
 
+- Release settings are no longer inherited from the baseline
 - The data encryption modules marked for deletion in 1.13.0 have been removed. Follow **How to Upgrade** section for migration instructions. In addition, the following artifacts were removed:
   - extensions-encryption-vault-java java data encryption
   - foundation-encryption-policy-java java encryption policy
@@ -134,7 +135,15 @@ Migrations with arguments will not be executed unless that argument is provided 
     </plugin>
 ```
 
-## Precondition Steps - Required for All Projects
+## Precondition Steps
+
+### For projects using the maven-release-plugin
+Prior to upgrading, generate an effective POM with the `help` plugin and ensure all necessary configurations for the 
+`maven-release-plugin` and `nexus-staging-maven-plugin` are present directly in your project. After upgrading, the
+configuration values inherited from the baseline will no longer be present.
+```shell
+mvn help:effective-pom -Doutput=effective-pom.xml
+```
 
 ### Beginning the Upgrade
 To start your aiSSEMBLE upgrade, update your project's pom.xml to use the 1.13.0 version of the build-parent:

--- a/foundation/foundation-maven-plugins/artifacts-maven-plugin/pom.xml
+++ b/foundation/foundation-maven-plugins/artifacts-maven-plugin/pom.xml
@@ -16,7 +16,8 @@
         <!-- versions for plugin specific dependencies-->
         <version.testing.harness>3.3.0</version.testing.harness>
         <version.cucumber>7.17.0</version.cucumber>
-        <version.aether>1.1.0</version.aether>
+        <!-- must match version pulled in my maven-resolver-provider -->
+        <version.resolver>1.6.3</version.resolver>
     </properties>
 
     <build>
@@ -51,46 +52,16 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.eclipse.aether</groupId>
-            <artifactId>aether-connector-basic</artifactId>
-            <version>${version.aether}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.aether</groupId>
-            <artifactId>aether-transport-file</artifactId>
-            <version>${version.aether}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.aether</groupId>
-            <artifactId>aether-transport-http</artifactId>
-            <version>${version.aether}</version>
-            <scope>test</scope>
+            <groupId>org.apache.maven.</groupId>
+            <artifactId>maven-resolver-provider</artifactId>
+            <version>${version.maven.core}</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.maven.plugin-tools</groupId>
             <artifactId>maven-plugin-annotations</artifactId>
             <version>${version.plugin.plugin}</version>
             <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.maven.plugin-testing</groupId>
-            <artifactId>maven-plugin-testing-harness</artifactId>
-            <version>${version.testing.harness}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.codehaus.plexus</groupId>
-            <artifactId>plexus-archiver</artifactId>
-            <version>${version.plexus.archiver}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.maven</groupId>
-            <artifactId>maven-compat</artifactId>
-            <version>${version.maven.core}</version>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.maven.plugins</groupId>
@@ -128,23 +99,12 @@
             <version>3.1</version>
         </dependency>
         <dependency>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-resources-plugin</artifactId>
-            <version>${version.maven.resources.plugin}</version>
-        </dependency>
-        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-slf4j2-impl</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>commons-beanutils</groupId>
-            <artifactId>commons-beanutils</artifactId>
-            <version>1.11.0</version>
-            <scope>provided</scope>
         </dependency>
 
         <!-- Test dependencies: -->
@@ -163,6 +123,38 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.resolver</groupId>
+            <artifactId>maven-resolver-connector-basic</artifactId>
+            <version>${version.resolver}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.resolver</groupId>
+            <artifactId>maven-resolver-transport-file</artifactId>
+            <version>${version.resolver}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.resolver</groupId>
+            <artifactId>maven-resolver-transport-http</artifactId>
+            <version>${version.resolver}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.plugin-testing</groupId>
+            <artifactId>maven-plugin-testing-harness</artifactId>
+            <version>${version.testing.harness}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <!--  Because plugin-testing-harness maintains Maven 2 compatibility,
+                 compat layer is required - should change with Maven 4 -->
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-compat</artifactId>
+            <version>${version.maven.core}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/foundation/foundation-maven-plugins/artifacts-maven-plugin/src/main/java/com/boozallen/aissemble/MojoBase.java
+++ b/foundation/foundation-maven-plugins/artifacts-maven-plugin/src/main/java/com/boozallen/aissemble/MojoBase.java
@@ -11,9 +11,7 @@ package com.boozallen.aissemble;
  */
 
 import org.apache.maven.plugin.AbstractMojo;
-import org.apache.maven.project.MavenProject;
 import org.apache.maven.execution.MavenSession;
-import org.apache.maven.plugin.BuildPluginManager;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.Component;
 import org.eclipse.aether.RepositorySystem;
@@ -23,16 +21,10 @@ import org.eclipse.aether.RepositorySystem;
  */
 public abstract class MojoBase extends AbstractMojo {
 
-    @Parameter(defaultValue = "${project}", required = true, readonly = true)
-    MavenProject project;
-
     @Parameter(required = true, readonly = true, defaultValue = "${session}")
     MavenSession mavenSession;
 
     @Component
     RepositorySystem repoSystem;
-
-    @Component
-    BuildPluginManager pluginManager;
 
 }

--- a/foundation/foundation-maven-plugins/mda-maven-plugin/pom.xml
+++ b/foundation/foundation-maven-plugins/mda-maven-plugin/pom.xml
@@ -18,9 +18,8 @@
 
     <properties>
         <!-- versions for plugin specific dependencies-->
-        <version.mojo.executor>2.4.0</version.mojo.executor>
+        <version.mojo.executor>2.4.1</version.mojo.executor>
         <version.testing.harness>3.3.0</version.testing.harness>
-        <version.aether>1.1.0</version.aether>
     </properties>
 
     <dependencies>
@@ -90,9 +89,9 @@
             <artifactId>log4j-slf4j2-impl</artifactId>
         </dependency>
         <dependency>
-            <groupId>commons-beanutils</groupId>
-            <artifactId>commons-beanutils</artifactId>
-            <version>1.11.0</version>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-resolver-provider</artifactId>
+            <version>${version.maven.core}</version>
             <scope>provided</scope>
         </dependency>
 
@@ -156,18 +155,6 @@
             <groupId>org.apache.velocity.tools</groupId>
             <artifactId>velocity-tools-generic</artifactId>
             <version>3.1</version>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.aether</groupId>
-            <artifactId>aether-connector-basic</artifactId>
-            <version>${version.aether}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.aether</groupId>
-            <artifactId>aether-transport-http</artifactId>
-            <version>${version.aether}</version>
-            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/foundation/foundation-maven-plugins/mda-maven-plugin/src/test/resources/test-pom/pom.xml
+++ b/foundation/foundation-maven-plugins/mda-maven-plugin/src/test/resources/test-pom/pom.xml
@@ -26,6 +26,8 @@
                     <groupId>com.boozallen.aissemble</groupId>
                     <modelsArtifactId>test</modelsArtifactId>
                     <habushuArtifactVersion>1.0.0.dev0</habushuArtifactVersion>
+                    <!-- Something about the way we are setting up the test Maven session causes scoping issues for dependency-plugin 3.8.1 -->
+                    <mavenDependencyPluginVersion>3.6.1</mavenDependencyPluginVersion>
                 </configuration>
                 <executions>
                     <execution>

--- a/foundation/foundation-mda/pom.xml
+++ b/foundation/foundation-mda/pom.xml
@@ -13,11 +13,6 @@
     <name>aiSSEMBLE::Foundation::MDA</name>
     <description>Model driven architecture artifacts for aiSSEMBLE</description>
 
-    <properties>
-        <version.plexus.component>2.1.0</version.plexus.component>
-        <version.plugin.annotations>3.6.0</version.plugin.annotations>
-    </properties>
-
     <build>
         <resources>
             <resource>

--- a/pom.xml
+++ b/pom.xml
@@ -111,7 +111,7 @@
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-lang3</artifactId>
-                <version>3.17.0</version>
+                <version>3.18.0</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.boozallen.aissemble</groupId>
         <artifactId>aissemble-parent</artifactId>
-        <version>6</version>
+        <version>7</version>
         <relativePath />
     </parent>
 
@@ -31,13 +31,6 @@
             <organizationUrl>https://boozallen.com</organizationUrl>
         </developer>
     </developers>
-
-    <distributionManagement>
-        <snapshotRepository>
-            <id>ghcr.io</id>
-            <url>https://maven.pkg.github.com/boozallen/aissemble</url>
-        </snapshotRepository>
-    </distributionManagement>
 
     <modules>
         <module>build-support</module>
@@ -290,11 +283,34 @@
             </build>
         </profile>
         <profile>
-            <!-- inheriting general ossrh-release setup from aissemble-parent -->
-            <id>ossrh-release</id>
+            <id>aissemble-release</id>
             <properties>
                 <maven.build.cache.enabled>false</maven.build.cache.enabled>
             </properties>
+            <build>
+                <pluginManagement>
+                    <plugins>
+                        <plugin>
+                            <groupId>org.sonatype.central</groupId>
+                            <artifactId>central-publishing-maven-plugin</artifactId>
+                            <configuration>
+                                <waitPollingInterval>15</waitPollingInterval>
+                            </configuration>
+                        </plugin>
+                        <plugin>
+                            <!-- Add the modified pyproject.toml files that Habushu has set to fixed versions. -->
+                            <groupId>org.apache.maven.plugins</groupId>
+                            <artifactId>maven-scm-plugin</artifactId>
+                            <inherited>false</inherited>
+                            <configuration>
+                                <includes>**/pyproject.toml</includes>
+                                <excludes>**/target/**,**/.venv/**</excludes>
+                                <pushChanges>false</pushChanges>
+                            </configuration>
+                        </plugin>
+                    </plugins>
+                </pluginManagement>
+            </build>
         </profile>
     </profiles>
     <build>
@@ -306,26 +322,13 @@
                     <version>${version.exec.maven.plugin}</version>
                 </plugin>
                 <plugin>
-                    <groupId>org.sonatype.plugins</groupId>
-                    <artifactId>nexus-staging-maven-plugin</artifactId>
-                    <configuration>
-                        <!-- how long to wait for the staging repository to be closed and released -->
-                        <stagingProgressTimeoutMinutes>30</stagingProgressTimeoutMinutes>
-                        <!-- how long to wait between checks for the staging repository to be closed and released -->
-                        <stagingProgressPauseDurationSeconds>15</stagingProgressPauseDurationSeconds>
-                    </configuration>
-                </plugin>
-                <plugin>
-                    <!-- This plugin should never run as part of a normal build, and is only ever triggered by
-                      devops/JenkinsRelease.groovy. We configure it here because it's a bit easier to read/edit/verify
-                      in the native POM compared to configuring the execution through groovy code. -->
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-release-plugin</artifactId>
+                    <!-- Keep downstream projects from inheriting our release setup -->
+                    <inherited>false</inherited>
                     <configuration>
                         <scmCommentPrefix>:bookmark: [maven-release-plugin] </scmCommentPrefix>
-                        <!-- the CI build already compile and verify all the packages so to shorten the release process
-                             we can skip the prepare verify phase. The help plugin allows to skip project execution
-                             completely.-->
+                        <!-- The CI build already runs compile and verify on all the packages so skip prepare verify -->
                         <preparationGoals>help:help</preparationGoals>
 
                         <!-- Because the release plugin doesn't build after updating to the next development snapshot,
@@ -335,20 +338,7 @@
                             added to the dev snapshot update commit. This wasn't noticed until now, because prior to this release
                             we were manually bumping the dev version before we even cut the actual release. -->
                         <completionGoals>org.technologybrewery.habushu:habushu-maven-plugin:initialize-habushu scm:add</completionGoals>
-                        <releaseProfiles>ossrh-release</releaseProfiles>
-                    </configuration>
-                </plugin>
-                <plugin>
-                    <!-- This plugin should not run in a normal build. It's called directly during the preparation phase
-                    of the release plugin. This adds the modified pyproject.toml file that Habushu has updated with the
-                    fixed version from the POM files for all python modules. -->
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-scm-plugin</artifactId>
-                    <inherited>false</inherited>
-                    <configuration>
-                        <includes>**/pyproject.toml</includes>
-                        <excludes>**/target/**,**/.venv/**</excludes>
-                        <pushChanges>false</pushChanges>
+                        <releaseProfiles>central-release,aissemble-release</releaseProfiles>
                     </configuration>
                 </plugin>
                 <plugin>


### PR DESCRIPTION
Two commits for easier review:
 - (6ed3bb6d) pre-upgrade cleanup
    Clean-up items to help make the upgrade to aissemble-parent 7 smoother. Includes the following:
     - Update wrapper to Maven 3.9.11
     - Add generated resources to .gitignore
     - Use maven-resolver aether classes in mda/artifacts plugins
     - Remove unused dependencies and properties in plugins
     - Upgrade mojo-executor and commons-lang3
 - (43b24451) update to parent 7 and isolate release logic
    Primary changes for this ticket:
     - Create an aissemble-release profile for isolating plugin configs used
       during release outside of the release plugin itself.
     - Set the release plugin to not inherit to downstream POMs.
     - Migrate nexus-staging to central-publishing.
     - Patch mda-maven test as the current test setup doesn't work with
       dependency-plugin > 3.6. The actual functionality is fine, our Maven
       session just isn't configured properly during testing.