### PR TITLE
[#779] update toml files to include generated source in wheels

### DIFF
--- a/foundation/foundation-lineage/foundation-data-lineage/aissemble-foundation-data-lineage-python/pyproject.toml
+++ b/foundation/foundation-lineage/foundation-data-lineage/aissemble-foundation-data-lineage-python/pyproject.toml
@@ -1,11 +1,3 @@
-[tool.poetry]
-packages = [
-    {include = "aissemble_data_lineage", from = "src"}
-]
-include = [
-    { path = "src/aissemble_data_lineage/default_properties/*" }
-]
-
 [project]
 name = "aissemble-foundation-data-lineage-python"
 version = "1.13.0.dev"
@@ -14,6 +6,14 @@ authors = [{name = "aiSSEMBLE Baseline Community", email = "aissemble@bah.com"}]
 requires-python = ">=3.9"
 dynamic = ["version", "dependencies"]
 readme = "README.md"
+
+[tool.poetry]
+packages = [
+    {include = "aissemble_data_lineage", from = "src"}
+]
+include = [
+    { path = "src/aissemble_data_lineage/default_properties/*", format=["sdist", "wheel"] }
+]
 
 [tool.poetry.dependencies]
 krausening = ">=20"

--- a/foundation/foundation-mda/src/main/resources/templates/data-delivery-data-records/combined.pyproject.toml.vm
+++ b/foundation/foundation-mda/src/main/resources/templates/data-delivery-data-records/combined.pyproject.toml.vm
@@ -9,7 +9,7 @@ authors = [{name = "Your Name", email = "<you@example.com>"}]
 requires-python = ">=3.9"
 
 [tool.poetry]
-packages = [{include = "${artifactIdPythonCase}", from = "src"}]
+include = [{path = "${artifactIdPythonCase}/generated/**/*.py", format = ["sdist", "wheel"]}]
 
 [tool.poetry.dependencies]
 pyspark = "${versionSpark}"

--- a/foundation/foundation-mda/src/main/resources/templates/data-delivery-data-records/separate.core.pyproject.toml.vm
+++ b/foundation/foundation-mda/src/main/resources/templates/data-delivery-data-records/separate.core.pyproject.toml.vm
@@ -9,7 +9,7 @@ authors = [{name = "Your Name", email = "<you@example.com>"}]
 requires-python = ">=3.9"
 
 [tool.poetry]
-packages = [{include = "${artifactIdPythonCase}", from = "src"}]
+include = [{path = "${artifactIdPythonCase}/generated/**/*.py", format = ["sdist", "wheel"]}]
 
 [tool.poetry.dependencies]
 jsonpickle = "^2.1.0"

--- a/foundation/foundation-mda/src/main/resources/templates/data-delivery-data-records/separate.spark.pyproject.toml.vm
+++ b/foundation/foundation-mda/src/main/resources/templates/data-delivery-data-records/separate.spark.pyproject.toml.vm
@@ -9,7 +9,7 @@ authors = [{name = "Your Name", email = "<you@example.com>"}]
 requires-python = ">=3.9"
 
 [tool.poetry]
-packages = [{include = "${artifactIdPythonCase}", from = "src"}]
+include = [{path = "${artifactIdPythonCase}/generated/**/*.py", format = ["sdist", "wheel"]}]
 
 [tool.poetry.dependencies]
 pyspark = "${versionSpark}"

--- a/foundation/foundation-mda/src/main/resources/templates/data-delivery-pyspark/pyproject.toml.vm
+++ b/foundation/foundation-mda/src/main/resources/templates/data-delivery-pyspark/pyproject.toml.vm
@@ -9,7 +9,7 @@ authors = [{name = "Your Name", email = "<you@example.com>"}]
 requires-python = ">=3.9"
 
 [tool.poetry]
-packages = [{include = "${artifactIdPythonCase}", from = "src"}]
+include = [{path = "${artifactIdPythonCase}/generated/**/*.py", format = ["sdist", "wheel"]}]
 
 [tool.poetry.dependencies]
 krausening = ">=20"

--- a/foundation/foundation-mda/src/main/resources/templates/general-mlflow/pyproject.toml.vm
+++ b/foundation/foundation-mda/src/main/resources/templates/general-mlflow/pyproject.toml.vm
@@ -9,7 +9,7 @@ authors = [{name = "Your Name", email = "<you@example.com>"}]
 requires-python = ">=3.9"
 
 [tool.poetry]
-packages = [{include = "${artifactIdPythonCase}", from = "src"}]
+include = [{path = "${artifactIdPythonCase}/generated/**/*.py", format = ["sdist", "wheel"]}]
 
 [tool.poetry.dependencies]
 krausening = ">=20"

--- a/foundation/foundation-mda/src/main/resources/templates/inference/pyproject.toml.vm
+++ b/foundation/foundation-mda/src/main/resources/templates/inference/pyproject.toml.vm
@@ -9,7 +9,7 @@ authors = [{name = "Your Name", email = "<you@example.com>"}]
 requires-python = ">=3.9"
 
 [tool.poetry]
-packages = [{include = "${artifactIdPythonCase}", from = "src"}]
+include = [{path = "${artifactIdPythonCase}/generated/**/*.py", format = ["sdist", "wheel"]}]
 
 [tool.poetry.dependencies]
 mlflow = ">=2.22.0"

--- a/foundation/foundation-messaging/foundation-messaging-python/aissemble-foundation-messaging-python-client/pyproject.toml
+++ b/foundation/foundation-messaging/foundation-messaging-python/aissemble-foundation-messaging-python-client/pyproject.toml
@@ -1,11 +1,3 @@
-[tool.poetry]
-packages = [
-    {include = "aissemble_messaging", from = "src"},
-]
-include = [
-    { path = "src/aissemble_messaging/service_resources/classpath/*" }
-]
-
 [project]
 name = "aissemble-foundation-messaging-python"
 version = "1.13.0.dev"
@@ -14,6 +6,14 @@ authors = [{name = "aiSSEMBLE Baseline Community", email = "aissemble@bah.com"}]
 requires-python = ">=3.9"
 dynamic = ["version", "dependencies"]
 readme = "README.md"
+
+[tool.poetry]
+packages = [
+    {include = "aissemble_messaging", from = "src"},
+]
+include = [
+    { path = "src/aissemble_messaging/service_resources/classpath/*", format=["wheel"] }
+]
 
 [tool.poetry.dependencies]
 py4j = "0.10.9.7"

--- a/test/test-mda-models/aissemble-test-data-delivery-pyspark-model-basic/pyproject.toml
+++ b/test/test-mda-models/aissemble-test-data-delivery-pyspark-model-basic/pyproject.toml
@@ -11,6 +11,8 @@ dynamic = ["version", "dependencies"]
 
 [tool.poetry]
 packages = [{include ="aissemble_test_data_delivery_pyspark_model_basic", from = "src"}]
+# We have to explicitly include all source not just generated as it's all git-ignored in the test modules
+include = [{path = "src/aissemble_test_data_delivery_pyspark_model_basic/generated/**/*.py", format = ["wheel", "sdist"]}]
 
 [tool.poetry.dependencies]
 confluent-kafka = { version = "2.1.1", optional = true }

--- a/test/test-mda-models/aissemble-test-data-delivery-pyspark-model/pyproject.toml
+++ b/test/test-mda-models/aissemble-test-data-delivery-pyspark-model/pyproject.toml
@@ -10,6 +10,8 @@ dynamic = ["version", "dependencies"]
 
 [tool.poetry]
 packages = [{include = "aissemble_test_data_delivery_pyspark_model", from = "src" }]
+# We have to explicitly include all source not just generated as it's all git-ignored in the test modules
+include = [{path = "src/aissemble_test_data_delivery_pyspark_model/generated/**/*.py", format = ["wheel", "sdist"]}]
 
 [tool.poetry.dependencies]
 confluent-kafka = { version = "2.1.1", optional = true }

--- a/test/test-mda-models/test-machine-learning-base-model/aissemble-machine-learning-training-base/pyproject.toml
+++ b/test/test-mda-models/test-machine-learning-base-model/aissemble-machine-learning-training-base/pyproject.toml
@@ -8,6 +8,8 @@ dynamic = ["version", "dependencies"]
 
 [tool.poetry]
 packages = [{include = "aissemble_machine_learning_training_base", from = "src"}]
+# We have to explicitly include all source not just generated as it's all git-ignored in the test modules
+include = [{path = "src/aissemble_machine_learning_training_base/generated/**/*.py", format = ["wheel", "sdist"]}]
 
 [tool.poetry.dependencies]
 aissemble-foundation-pdp-client-python = {path = "../../../../foundation/foundation-security/aissemble-foundation-pdp-client-python", develop = true}

--- a/test/test-mda-models/test-machine-learning-model/aissemble-machine-learning-inference/pyproject.toml
+++ b/test/test-mda-models/test-machine-learning-model/aissemble-machine-learning-inference/pyproject.toml
@@ -8,6 +8,8 @@ dynamic = ["version", "dependencies"]
 
 [tool.poetry]
 packages = [{include = "aissemble_machine_learning_inference", from = "src"}]
+# We have to explicitly include all source not just generated as it's all git-ignored in the test modules
+include = [{path = "src/aissemble_machine_learning_inference/generated/**/*.py", format = ["wheel", "sdist"]}]
 
 [tool.poetry.dependencies]
 aissemble-foundation-pdp-client-python = {path = "../../../../foundation/foundation-security/aissemble-foundation-pdp-client-python", develop = true}

--- a/test/test-mda-models/test-machine-learning-model/aissemble-machine-learning-training/pyproject.toml
+++ b/test/test-mda-models/test-machine-learning-model/aissemble-machine-learning-training/pyproject.toml
@@ -11,6 +11,8 @@ dynamic = ["version", "dependencies"]
 
 [tool.poetry]
 packages = [{include = "aissemble_machine_learning_training", from = "src"}]
+# We have to explicitly include all source not just generated as it's all git-ignored in the test modules
+include = [{path = "src/aissemble_machine_learning_training/generated/**/*.py", format = ["wheel", "sdist"]}]
 
 [tool.poetry.dependencies]
 aissemble-foundation-pdp-client-python = {path = "../../../../foundation/foundation-security/aissemble-foundation-pdp-client-python", develop = true}


### PR DESCRIPTION
Add back the `tool.poetry.include` specification for files in `.gitignore` so they are packaged in the wheel file.