### PR TITLE
[#782] add image IT and fix image crash

### DIFF
--- a/extensions/extensions-data-lineage/extensions-data-lineage-http-consumer-service/pom.xml
+++ b/extensions/extensions-data-lineage/extensions-data-lineage-http-consumer-service/pom.xml
@@ -36,6 +36,10 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-smallrye-health</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-smallrye-reactive-messaging</artifactId>
         </dependency>
         <dependency>
@@ -63,6 +67,10 @@
                     <artifactId>kafka-clients</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-clients</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
@@ -114,11 +122,6 @@
             <groupId>io.openlineage</groupId>
             <artifactId>openlineage-java</artifactId>
             <version>${version.open.lineage.java}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.kafka</groupId>
-            <artifactId>kafka-clients</artifactId>
-            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/extensions/extensions-docker/aissemble-data-lineage-http-consumer/pom.xml
+++ b/extensions/extensions-docker/aissemble-data-lineage-http-consumer/pom.xml
@@ -80,4 +80,55 @@
         </plugins>
     </build>
 
+    <profiles>
+        <profile>
+            <id>integration-test</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>${group.fabric8.plugin}</groupId>
+                        <artifactId>docker-maven-plugin</artifactId>
+                        <configuration>
+                            <buildArchiveOnly>false</buildArchiveOnly>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>test-image</id>
+                                <phase>integration-test</phase>
+                                <configuration>
+                                    <images>
+                                        <image>
+                                            <run>
+                                                <wait>
+                                                    <http>
+                                                        <url>http://localhost:8080/q/health</url>
+                                                        <method>GET</method>
+                                                        <status>200</status>
+                                                    </http>
+                                                </wait>
+                                                <ports>
+                                                    <port>8080:8080</port>
+                                                </ports>
+                                            </run>
+                                        </image>
+                                    </images>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>exec-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>test-image-cleanup</id>
+                                <phase>post-integration-test</phase>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
 </project>


### PR DESCRIPTION
Also added the health check Quarkus extension so that the image test can detect that Quarkus has started successfully. (And clients for that matter.)