### PR TITLE
[#791] fix issues with parallel build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,16 +41,6 @@ jobs:
         with:
           docker-username: ${{ secrets.DOCKERHUB_USERNAME }}
           docker-token: ${{ secrets.DOCKERHUB_TOKEN }}
-      #NB: We restore/save cache manually so that we save the cache even if the build fails
-      - name: Load docker build cache
-        id: cached-docker-build
-        uses: runs-on/cache/restore@v4
-        if: ${{ ! github.event.schedule }}
-        with:
-          path: ~/.docker/cache
-          key: docker-cache-${{ hashFiles('**/Dockerfile') }}
-          restore-keys: |
-            docker-cache-
       - name: Load m2 repository cache # Manually caching .m2 repo as the setup-java caching isn't falling back to older caches
         id: cached-m2-repo
         uses: runs-on/cache/restore@v4
@@ -75,12 +65,6 @@ jobs:
           key: poetry-cache-${{ hashFiles('**/pyproject.toml') }}
           restore-keys: |
             poetry-cache-
-      - name: Hash starting Docker cache
-        id: docker-cache-start
-        uses: actions/github-script@v7
-        with:
-          result-encoding: string
-          script: await glob.hashFiles(`~/.docker/cache/**`, require('os').homedir())
       - name: Provision Docker builder
         id: provision-docker-builder
         run: |
@@ -88,13 +72,13 @@ jobs:
                                 --bootstrap \
                                 --driver=kubernetes \
                                 --platform=linux/amd64 \
-                                --driver-opt="nodeselector=kubernetes.io/arch=amd64","image=docker.io/moby/buildkit:v0.19.0"
+                                --driver-opt="nodeselector=kubernetes.io/arch=amd64","image=docker.io/moby/buildkit:v0.19.0",replicas=3
           docker builder create --name=$DOCKER_BUILDER_NAME \
                                 --append \
                                 --bootstrap \
                                 --driver=kubernetes \
                                 --platform=linux/arm64 \
-                                --driver-opt="nodeselector=kubernetes.io/arch=arm64","image=docker.io/moby/buildkit:v0.19.0"
+                                --driver-opt="nodeselector=kubernetes.io/arch=arm64","image=docker.io/moby/buildkit:v0.19.0",replicas=3
           mkdir ~/.docker/fabric8 && cp -R ~/.docker/buildx ~/.docker/fabric8/buildx
       # Generate the settings.xml for ghcr.io, pypi, & dev-pypi server profiles
       - name: Create settings.xml
@@ -125,7 +109,7 @@ jobs:
       # Run build with the gh-build profile
       - name: Build aiSSEMBLE
         run: |
-          ./mvnw clean deploy -B -U -Pci,integration-test,gh-build
+          ./mvnw clean deploy -T8 -B -U -Pci,integration-test,gh-build
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       # Install Maven which is needed for archetype tests
@@ -148,19 +132,6 @@ jobs:
         if: always()
         run: |
           docker builder rm -f $DOCKER_BUILDER_NAME
-      - name: Hash final Docker cache
-        id: docker-cache-final
-        uses: actions/github-script@v7
-        with:
-          result-encoding: string
-          script: await glob.hashFiles(`~/.docker/cache/**`, require('os').homedir())
-      - name: Save docker build cache
-        id: save-docker-build
-        uses: runs-on/cache/save@v4
-        if: ${{ !cancelled() && steps.docker-cache-start.outputs.result != steps.docker-cache-final.outputs.result }}
-        with:
-          path: ~/.docker/cache
-          key: ${{ steps.cached-docker-build.outputs.cache-primary-key }}
       - name: Save m2 repository cache
         id: save-m2-repo
         uses: runs-on/cache/save@v4

--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -2,6 +2,6 @@
     <extension>
         <groupId>org.apache.maven.extensions</groupId>
         <artifactId>maven-build-cache-extension</artifactId>
-        <version>1.1.0</version>
+        <version>1.2.0</version>
     </extension>
 </extensions>

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -31,7 +31,7 @@
         <version.hive>4.0.0</version.hive>
         <version.python>3.11.4</version.python>
         <version.help.plugin>3.5.0</version.help.plugin>
-        <version.krausening>20</version.krausening>
+        <version.krausening>21</version.krausening>
         <version.plugin.plugin>3.9.0</version.plugin.plugin>
         <version.quarkus>3.15.6</version.quarkus>
         <version.quarkus.plugin>${version.quarkus}</version.quarkus.plugin>
@@ -86,7 +86,7 @@
         <version.hadoop>3.4.1</version.hadoop>
         <version.neo4j>4.1.5_for_spark_3</version.neo4j>
         <version.aws.sdk.bundle>2.31.8</version.aws.sdk.bundle>
-        <version.baton>1.1.1</version.baton>
+        <version.baton>1.1.2</version.baton>
         <version.quarkus.cucumber>1.0.0</version.quarkus.cucumber>
         <version.quarkus.cucumber.java>${version.cucumber}</version.quarkus.cucumber.java>
 

--- a/extensions/extensions-data-delivery/aissemble-extensions-data-delivery-spark-py/pyproject.toml
+++ b/extensions/extensions-data-delivery/aissemble-extensions-data-delivery-spark-py/pyproject.toml
@@ -13,7 +13,7 @@ dynamic = ["version", "dependencies"]
 readme = "README.md"
 
 [tool.poetry.dependencies]
-krausening = ">=20"
+krausening = ">=21"
 pyspark = "3.5.5"
 pyyaml = "^6.0"
 

--- a/extensions/extensions-data-lineage/extensions-data-lineage-http-consumer-service/src/test/resources/application.properties
+++ b/extensions/extensions-data-lineage/extensions-data-lineage-http-consumer-service/src/test/resources/application.properties
@@ -8,9 +8,8 @@
 # #L%
 ###
 quarkus.rest-client."com.boozallen.aissemble.datalineage.consumer.HttpProducerService".uri=http://127.0.0.1:15100/endpoint
-quarkus.amqp.devservices.image-name=quay.io/artemiscloud/activemq-artemis-broker:1.0.25
-#Artemis image requires --user arg to startup and this fixes the issue, see https://github.com/quarkusio/quarkus/issues/36190
-quarkus.amqp.devservices.extra-args=--no-autotune --mapped --no-fsync --relax-jolokia
-quarkus.kafka.devservices.image-name=redpandadata/redpanda:v24.1.7
+quarkus.rabbitmq.devservices.enabled=false
+quarkus.kafka.devservices.enabled=false
+quarkus.amqp.devservices.enabled=false
 com.boozallen.aissemble.datalineage.consumer.HttpProducer/postEventHttp/Retry/maxRetries=5
 com.boozallen.aissemble.datalineage.consumer.HttpProducer/postEventHttp/Retry/delay=1

--- a/extensions/extensions-docker/aissemble-configuration-store/pom.xml
+++ b/extensions/extensions-docker/aissemble-configuration-store/pom.xml
@@ -77,13 +77,13 @@
                                             <run>
                                                 <wait>
                                                     <http>
-                                                        <url>http://localhost:8080/aissemble-properties/healthcheck</url>
+                                                        <url>http://localhost:${host.port}/aissemble-properties/healthcheck</url>
                                                         <method>GET</method>
                                                         <status>200</status>
                                                     </http>
                                                 </wait>
                                                 <ports>
-                                                    <port>8080:8080</port>
+                                                    <port>host.port:8080</port>
                                                 </ports>
                                             </run>
                                         </image>

--- a/extensions/extensions-docker/aissemble-data-lineage-http-consumer/pom.xml
+++ b/extensions/extensions-docker/aissemble-data-lineage-http-consumer/pom.xml
@@ -101,13 +101,13 @@
                                             <run>
                                                 <wait>
                                                     <http>
-                                                        <url>http://localhost:8080/q/health</url>
+                                                        <url>http://localhost:${host.port}/q/health</url>
                                                         <method>GET</method>
                                                         <status>200</status>
                                                     </http>
                                                 </wait>
                                                 <ports>
-                                                    <port>8080:8080</port>
+                                                    <port>host.port:8080</port>
                                                 </ports>
                                             </run>
                                         </image>

--- a/extensions/extensions-docker/aissemble-metadata/pom.xml
+++ b/extensions/extensions-docker/aissemble-metadata/pom.xml
@@ -78,13 +78,13 @@
                                             <run>
                                                 <wait>
                                                     <http>
-                                                        <url>http://localhost:8080/metadata/healthcheck</url>
+                                                        <url>http://localhost:${host.port}/metadata/healthcheck</url>
                                                         <method>GET</method>
                                                         <status>200</status>
                                                     </http>
                                                 </wait>
                                                 <ports>
-                                                    <port>8080:8080</port>
+                                                    <port>host.port:8080</port>
                                                 </ports>
                                                 <volumes>
                                                     <bind>

--- a/extensions/extensions-docker/aissemble-pipeline-invocation/pom.xml
+++ b/extensions/extensions-docker/aissemble-pipeline-invocation/pom.xml
@@ -97,13 +97,13 @@
                                             <run>
                                                 <wait>
                                                     <http>
-                                                        <url>http://localhost:8080/invoke-pipeline/healthcheck</url>
+                                                        <url>http://localhost:${host.port}/invoke-pipeline/healthcheck</url>
                                                         <method>GET</method>
                                                         <status>200</status>
                                                     </http>
                                                 </wait>
                                                 <ports>
-                                                    <port>8080:8080</port>
+                                                    <port>host.port:8080</port>
                                                 </ports>
                                                 <volumes>
                                                     <bind>

--- a/extensions/extensions-docker/aissemble-policy-decision-point/pom.xml
+++ b/extensions/extensions-docker/aissemble-policy-decision-point/pom.xml
@@ -77,13 +77,13 @@
                                             <run>
                                                 <wait>
                                                     <http>
-                                                        <url>http://localhost:8080/api/healthcheck</url>
+                                                        <url>http://localhost:${host.port}/api/healthcheck</url>
                                                         <method>GET</method>
                                                         <status>200</status>
                                                     </http>
                                                 </wait>
                                                 <ports>
-                                                    <port>8080:8080</port>
+                                                    <port>host.port:8080</port>
                                                 </ports>
                                             </run>
                                         </image>

--- a/extensions/extensions-docker/aissemble-spark-infrastructure/pom.xml
+++ b/extensions/extensions-docker/aissemble-spark-infrastructure/pom.xml
@@ -151,11 +151,14 @@
                                                 <wait>
                                                     <http>
                                                         <!-- History server check -->
-                                                        <url>http://localhost:18080</url>
+                                                        <url>http://localhost:${host.port}</url>
                                                     </http>
                                                     <!-- Thrift server check -->
                                                     <log>.*HiveThriftServer2 started.*</log>
                                                 </wait>
+                                                <ports>
+                                                    <port>host.port:18080</port>
+                                                </ports>
                                                 <volumes>
                                                     <bind>
                                                         <volume>${project.basedir}/src/test/resources:/tmp/test</volume>

--- a/extensions/extensions-transform/aissemble-extensions-transform-spark-python/pyproject.toml
+++ b/extensions/extensions-transform/aissemble-extensions-transform-spark-python/pyproject.toml
@@ -13,7 +13,7 @@ dynamic = ["version", "dependencies"]
 readme = "README.md"
 
 [tool.poetry.dependencies]
-krausening = ">=20"
+krausening = ">=21"
 pydantic = ">=2.8.0"
 
 pyspark = "3.5.5"

--- a/foundation/aissemble-foundation-core-python/pyproject.toml
+++ b/foundation/aissemble-foundation-core-python/pyproject.toml
@@ -20,7 +20,7 @@ readme = "README.md"
 
 [tool.poetry.dependencies]
 pydantic = ">=2.8.0"
-krausening = ">=20"
+krausening = ">=21"
 cryptography = ">=42.0.4"
 pyjwt = ">=2.3.0"
 pyjks = ">=20.0.0"

--- a/foundation/aissemble-foundation-model-training-api/pyproject.toml
+++ b/foundation/aissemble-foundation-model-training-api/pyproject.toml
@@ -19,7 +19,7 @@ uvicorn = {version = "^0.18.0", extras = ["standard"]}
 pydantic = ">=2.8.0"
 kubernetes = ">=26.1.0"
 urllib3 = "^2.5.0"
-krausening = ">=20"
+krausening = ">=21"
 
 [tool.poetry.group.dev.dependencies]
 behave = ">=1.2.6"

--- a/foundation/foundation-archetype/src/main/resources/archetype-resources/.mvn/extensions.xml
+++ b/foundation/foundation-archetype/src/main/resources/archetype-resources/.mvn/extensions.xml
@@ -2,6 +2,6 @@
     <extension>
         <groupId>org.apache.maven.extensions</groupId>
         <artifactId>maven-build-cache-extension</artifactId>
-        <version>1.1.0</version>
+        <version>1.2.0</version>
     </extension>
 </extensions>

--- a/foundation/foundation-archetype/src/main/resources/archetype-resources/.mvn/maven-build-cache-config.xml
+++ b/foundation/foundation-archetype/src/main/resources/archetype-resources/.mvn/maven-build-cache-config.xml
@@ -78,6 +78,12 @@
                         <goal>deploy</goal>
                     </goals>
                 </goalsList>
+                <!-- necessary for calculating the Python version string for use in Docker -->
+                <goalsList artifactId="build-helper-maven-plugin">
+                    <goals>
+                        <goal>regex-property</goal>
+                    </goals>
+                </goalsList>
             </goalsLists>
         </runAlways>
         <reconcile logAllProperties="true">

--- a/foundation/foundation-archetype/test-project-archetype.sh
+++ b/foundation/foundation-archetype/test-project-archetype.sh
@@ -27,7 +27,7 @@ cd target/temp
 #---
 function exit {
   if [ "$1" -ne 0 ]; then
-    rm -rf ~/.m2/build-cache/v1/com.bah.aiops
+    rm -rf ~/.m2/build-cache/v1.1/com.bah.aiops
   fi
   POSIXLY_CORRECT=1; unset exit
   exit "$1"
@@ -101,7 +101,7 @@ function runBuildAndApplyManualActions {
   outputEnd='\[WARNING\]'
 
   # $deployOutputStart match at end ensures the match line isn't captured. NF ensures blank lines aren't captured.
-  ./mvnw clean install -Dhabushu.usePyenv=false | \
+  ./mvnw -T8 clean install -Dhabushu.usePyenv=false | \
       tee >(awk "BEGIN {output=0} /$outputEnd/ {output=0} NF && output {print} /$deployOutputStart/ {output=1}">deploy.out ) | \
       tee >(awk "BEGIN {output=0} /$outputEnd/ {output=0} NF && output {print} /$helmfileOutputStart/ {output=1}">helmfile.out ) | \
       tee >(awk "BEGIN {output=0} /$outputEnd/ {output=0} NF && output {print} /$helmfileAppsOutputStart/ {output=1}">helmfile-apps.out ) \
@@ -334,12 +334,12 @@ runBuildAndApplyManualActions
 
 
 echo -e "\nINFO: Running final build to ensure success"
-./mvnw clean install -Dhabushu.usePyenv=false || { echo -e '\n\n\t**** MAVEN BUILD FAILED ****\n\n' ; exit 1; }
+./mvnw -T8 clean install -Dhabushu.usePyenv=false || { echo -e '\n\n\t**** MAVEN BUILD FAILED ****\n\n' ; exit 1; }
 
 echo -e "\nINFO: Running fermenter generation to check for left over manual actions\n"
 # NOTE: because fermenter results are cached, the build-cache will hide remaining manual actions that were missed in previous steps
 
-./mvnw clean generate-sources -Dhabushu.usePyenv=false -Dmaven.build.cache.skipCache -Dfermenter.display.message.keys=true | tee >(awk '/WARNING/ {print}' > maven-build.log) \
+./mvnw -T8 clean generate-sources -Dhabushu.usePyenv=false -Dmaven.build.cache.skipCache -Dfermenter.display.message.keys=true | tee >(awk '/WARNING/ {print}' > maven-build.log) \
     || { echo -e '\n\n\t**** MAVEN BUILD FAILED ****\n\n' ; exit 1; }
 if grep -iq 'Manual action' maven-build.log; then
   echo -e "\n\n **** ERROR: Manual action still found in build **** \n    Look at **archetype/target/temp/test-generator/maven-build.log** to see what the problem was. \n\n"

--- a/foundation/foundation-configuration-store/src/main/resources/application.properties
+++ b/foundation/foundation-configuration-store/src/main/resources/application.properties
@@ -9,4 +9,4 @@
 ###
 
 quarkus.http.port=8080
-quarkus.http.test-port=14800
+quarkus.http.test-port=0

--- a/foundation/foundation-configuration-store/src/test/resources/application.properties
+++ b/foundation/foundation-configuration-store/src/test/resources/application.properties
@@ -9,5 +9,5 @@
 ###
 
 quarkus.http.port=8080
-quarkus.http.test-port=14800
+quarkus.http.test-port=0
 quarkus.kafka.devservices.image-name=redpandadata/redpanda:v24.1.7

--- a/foundation/foundation-drift-detection/aissemble-foundation-drift-detection-client-python/pyproject.toml
+++ b/foundation/foundation-drift-detection/aissemble-foundation-drift-detection-client-python/pyproject.toml
@@ -16,7 +16,7 @@ readme = "README.md"
 [tool.poetry.dependencies]
 pydantic = ">=2.8.0"
 requests = ">=2.32.2"
-krausening = ">=20"
+krausening = ">=21"
 cryptography = ">=42.0.4"
 urllib3 = "^2.5.0"
 

--- a/foundation/foundation-drift-detection/foundation-drift-detection-service/src/main/resources/application.properties
+++ b/foundation/foundation-drift-detection/foundation-drift-detection-service/src/main/resources/application.properties
@@ -16,5 +16,5 @@
 #
 # See https://quarkus.io/guides/cdi-reference for reference.
 quarkus.arc.unremovable-types=com.boozallen.aissemble.alerting.**
-quarkus.http.test-port=14800
+quarkus.http.test-port=0
 quarkus.kafka.devservices.image-name=redpandadata/redpanda:v24.1.7

--- a/foundation/foundation-lineage/foundation-data-lineage/aissemble-foundation-data-lineage-python/pyproject.toml
+++ b/foundation/foundation-lineage/foundation-data-lineage/aissemble-foundation-data-lineage-python/pyproject.toml
@@ -16,7 +16,7 @@ include = [
 ]
 
 [tool.poetry.dependencies]
-krausening = ">=20"
+krausening = ">=21"
 kafka-python = "^2.0.2"
 # TODO: why not match the Java version? this is very old comparatively
 openlineage-python = {version = "^0.21.1"}

--- a/foundation/foundation-mda/src/main/java/com/boozallen/aiops/mda/metamodel/DictionaryModelInstanceManager.java
+++ b/foundation/foundation-mda/src/main/java/com/boozallen/aiops/mda/metamodel/DictionaryModelInstanceManager.java
@@ -24,7 +24,7 @@ import com.boozallen.aiops.mda.metamodel.element.DictionaryType;
  */
 class DictionaryModelInstanceManager extends AbstractMetamodelManager<Dictionary> {
 
-    private static final DictionaryModelInstanceManager instance = new DictionaryModelInstanceManager();
+    private static final ThreadLocal<DictionaryModelInstanceManager> instance = ThreadLocal.withInitial(DictionaryModelInstanceManager::new);
 
     private Map<String, DictionaryType> dictionaryTypesByFullyQualifiedName = new HashMap<>();
 
@@ -34,7 +34,7 @@ class DictionaryModelInstanceManager extends AbstractMetamodelManager<Dictionary
      * @return singleton
      */
     public static DictionaryModelInstanceManager getInstance() {
-        return instance;
+        return instance.get();
     }
 
     /**

--- a/foundation/foundation-mda/src/main/java/com/boozallen/aiops/mda/metamodel/PipelineModelInstanceManager.java
+++ b/foundation/foundation-mda/src/main/java/com/boozallen/aiops/mda/metamodel/PipelineModelInstanceManager.java
@@ -21,7 +21,7 @@ import com.boozallen.aiops.mda.metamodel.element.PipelineElement;
  */
 class PipelineModelInstanceManager extends AbstractMetamodelManager<Pipeline> {
 
-	private static final PipelineModelInstanceManager instance = new PipelineModelInstanceManager();
+	private static final ThreadLocal<PipelineModelInstanceManager> instance = ThreadLocal.withInitial(PipelineModelInstanceManager::new);
 
 	/**
 	 * Returns the singleton instance of this class.
@@ -29,7 +29,7 @@ class PipelineModelInstanceManager extends AbstractMetamodelManager<Pipeline> {
 	 * @return singleton
 	 */
 	public static PipelineModelInstanceManager getInstance() {
-		return instance;
+		return instance.get();
 	}
 
 	/**

--- a/foundation/foundation-mda/src/main/java/com/boozallen/aiops/mda/metamodel/RecordModelInstanceManager.java
+++ b/foundation/foundation-mda/src/main/java/com/boozallen/aiops/mda/metamodel/RecordModelInstanceManager.java
@@ -29,7 +29,7 @@ import java.util.Map;
  */
 class RecordModelInstanceManager extends AbstractMetamodelManager<Record> {
 
-    private static final RecordModelInstanceManager instance = new RecordModelInstanceManager();
+    private static final ThreadLocal<RecordModelInstanceManager> instance = ThreadLocal.withInitial(RecordModelInstanceManager::new);
 
     /**
      * Returns the singleton instance of this class.
@@ -37,7 +37,7 @@ class RecordModelInstanceManager extends AbstractMetamodelManager<Record> {
      * @return singleton
      */
     public static RecordModelInstanceManager getInstance() {
-        return instance;
+        return instance.get();
     }
 
     /**

--- a/foundation/foundation-mda/src/main/resources/templates/data-delivery-data-records/combined.pyproject.toml.vm
+++ b/foundation/foundation-mda/src/main/resources/templates/data-delivery-data-records/combined.pyproject.toml.vm
@@ -7,6 +7,7 @@ version = "1.0.0.dev"#*Version is automatically updated by Habushu*#
 description = "PySpark data records"
 authors = [{name = "Your Name", email = "<you@example.com>"}]
 requires-python = ">=3.9"
+dynamic = ["version", "dependencies"]
 
 [tool.poetry]
 include = [{path = "src/${artifactIdPythonCase}/generated/**/*.py", format = ["sdist", "wheel"]}]

--- a/foundation/foundation-mda/src/main/resources/templates/data-delivery-data-records/separate.core.pyproject.toml.vm
+++ b/foundation/foundation-mda/src/main/resources/templates/data-delivery-data-records/separate.core.pyproject.toml.vm
@@ -7,6 +7,7 @@ version = "1.0.0.dev"#*Version is automatically updated by Habushu*#
 description = "Core data record functionality"
 authors = [{name = "Your Name", email = "<you@example.com>"}]
 requires-python = ">=3.9"
+dynamic = ["version", "dependencies"]
 
 [tool.poetry]
 include = [{path = "src/${artifactIdPythonCase}/generated/**/*.py", format = ["sdist", "wheel"]}]

--- a/foundation/foundation-mda/src/main/resources/templates/data-delivery-data-records/separate.spark.pyproject.toml.vm
+++ b/foundation/foundation-mda/src/main/resources/templates/data-delivery-data-records/separate.spark.pyproject.toml.vm
@@ -7,17 +7,16 @@ version = "1.0.0.dev"#*Version is automatically updated by Habushu*#
 description = "PySpark support for data records"
 authors = [{name = "Your Name", email = "<you@example.com>"}]
 requires-python = ">=3.9"
+dynamic = ["version", "dependencies"]
 
 [tool.poetry]
 include = [{path = "src/${artifactIdPythonCase}/generated/**/*.py", format = ["sdist", "wheel"]}]
 
 [tool.poetry.dependencies]
+${pythonDataRecords} = {path = "../${pythonDataRecords}", develop = true}
 pyspark = "${versionSpark}"
 
 aissemble-extensions-data-delivery-spark-py = "${aissemblePythonVersion}"
-
-[tool.poetry.group.monorepo.dependencies]
-${pythonDataRecords} = {path = "../${pythonDataRecords}", develop = true}
 
 [tool.poetry.group.dev.dependencies]
 behave = ">=1.2.6"

--- a/foundation/foundation-mda/src/main/resources/templates/data-delivery-pyspark/pyproject.toml.vm
+++ b/foundation/foundation-mda/src/main/resources/templates/data-delivery-pyspark/pyproject.toml.vm
@@ -7,12 +7,16 @@ version = "1.0.0.dev"
 description = "${pipeline.description|'Description of package'}"
 authors = [{name = "Your Name", email = "<you@example.com>"}]
 requires-python = ">=3.9"
+dynamic = ["version", "dependencies"]
 
 [tool.poetry]
 include = [{path = "src/${artifactIdPythonCase}/generated/**/*.py", format = ["sdist", "wheel"]}]
 
 [tool.poetry.dependencies]
-krausening = ">=20"
+#if ($enableSemanticDataSupport)
+${pythonDataRecords} = {path = "../../${projectName}-shared/${pythonDataRecords}", develop = true}
+#end
+krausening = ">=21"
 pyspark = "${versionSpark}"
 jsonpickle = "^2.1.0"
 pyyaml = "^6.0"
@@ -32,11 +36,6 @@ kafka-python = "^2.0.2"
 apache-sedona = "~${versionSedona}"
 #end
 
-#if ($enableSemanticDataSupport)
-[tool.poetry.group.monorepo.dependencies]
-${pythonDataRecords} = {path = "../../${projectName}-shared/${pythonDataRecords}", develop = true}
-
-#end
 [tool.poetry.group.dev.dependencies]
 behave = ">=1.2.6"
 nose = ">=1.3.7"

--- a/foundation/foundation-mda/src/main/resources/templates/general-docker/spark-worker.docker.file.vm
+++ b/foundation/foundation-mda/src/main/resources/templates/general-docker/spark-worker.docker.file.vm
@@ -16,11 +16,8 @@ USER root
 
 #HABUSHU_FINAL_STAGE
 
-RUN chown -R spark:spark /opt/venv
-
 #else
 # If no Pyspark pipelines exist then Java based pipelines will still need this FROM statement
-
 FROM ${DOCKER_BASELINE_REPO_ID}boozallen/aissemble-spark:${VERSION_AISSEMBLE}
 #end
 

--- a/foundation/foundation-mda/src/main/resources/templates/general-mlflow/pyproject.toml.vm
+++ b/foundation/foundation-mda/src/main/resources/templates/general-mlflow/pyproject.toml.vm
@@ -7,12 +7,13 @@ version = "1.0.0.dev"
 description = "${pipeline.description|'Description of package'}"
 authors = [{name = "Your Name", email = "<you@example.com>"}]
 requires-python = ">=3.9"
+dynamic = ["version", "dependencies"]
 
 [tool.poetry]
 include = [{path = "src/${artifactIdPythonCase}/generated/**/*.py", format = ["sdist", "wheel"]}]
 
 [tool.poetry.dependencies]
-krausening = ">=20"
+krausening = ">=21"
 mlflow = ">=2.22.0"
 kafka-python = "^2.0.2"
 pandas = ">=1.5.0"

--- a/foundation/foundation-mda/src/main/resources/templates/inference/pyproject.toml.vm
+++ b/foundation/foundation-mda/src/main/resources/templates/inference/pyproject.toml.vm
@@ -7,6 +7,7 @@ version = "1.0.0.dev"
 description = "${pipeline.description|'Description of package'}"
 authors = [{name = "Your Name", email = "<you@example.com>"}]
 requires-python = ">=3.9"
+dynamic = ["version", "dependencies"]
 
 [tool.poetry]
 include = [{path = "src/${artifactIdPythonCase}/generated/**/*.py", format = ["sdist", "wheel"]}]
@@ -16,7 +17,7 @@ mlflow = ">=2.22.0"
 fastapi = ">=0.95.0"
 uvicorn = { version = "^0.18.0", extras = ["standard"]}
 grpcio = "^1.50.0"
-krausening = ">=20"
+krausening = ">=21"
 pandas = ">=1.5.0"
 
 aissemble-foundation-core-python = "${aissemblePythonVersion}"

--- a/foundation/foundation-messaging/foundation-messaging-python/aissemble-foundation-messaging-python-client/pyproject.toml
+++ b/foundation/foundation-messaging/foundation-messaging-python/aissemble-foundation-messaging-python-client/pyproject.toml
@@ -17,7 +17,7 @@ include = [
 
 [tool.poetry.dependencies]
 py4j = "0.10.9.7"
-krausening = ">=20"
+krausening = ">=21"
 
 [tool.poetry.group.dev.dependencies]
 behave = ">=1.2.6"

--- a/foundation/foundation-transform/aissemble-foundation-transform-core-python/pyproject.toml
+++ b/foundation/foundation-transform/aissemble-foundation-transform-core-python/pyproject.toml
@@ -15,7 +15,7 @@ readme = "README.md"
 [tool.poetry.dependencies]
 aissemble-foundation-core-python = {path = "../../aissemble-foundation-core-python", develop = true}
 pydantic = ">=2.8.0"
-krausening = ">=20"
+krausening = ">=21"
 cryptography = ">=42.0.4"
 
 [tool.poetry.group.dev.dependencies]

--- a/pom.xml
+++ b/pom.xml
@@ -46,9 +46,6 @@
         <module>foundation</module>
         <module>extensions</module>
         <module>test</module>
-        <!--We are relying on the sequential build from Maven; if we ever use parallel builds, we would need to
-         ensure the report aggregator depends on all other modules-->
-        <module>cucumber-report-aggregator</module>
     </modules>
 
     <scm>
@@ -266,6 +263,12 @@
         </pluginRepository>
     </pluginRepositories>
     <profiles>
+        <profile>
+            <id>create-test-report</id>
+            <modules>
+                <module>cucumber-report-aggregator</module>
+            </modules>
+        </profile>
         <profile>
             <id>integration-test</id>
             <build>

--- a/test/test-mda-models/aissemble-test-data-delivery-pyspark-model-basic/pyproject.toml
+++ b/test/test-mda-models/aissemble-test-data-delivery-pyspark-model-basic/pyproject.toml
@@ -22,7 +22,7 @@ aissemble-foundation-core-python = {path = "../../../foundation/aissemble-founda
 aissemble-extensions-data-delivery-spark-py = {path = "../../../extensions/extensions-data-delivery/aissemble-extensions-data-delivery-spark-py", develop = true}
 apache-sedona = "~1.7.1"
 kafka-python = "^2.0.2"
-krausening = ">=20"
+krausening = ">=21"
 pyspark = "3.5.5"
 jsonpickle = "^2.1.0"
 pyyaml = "^6.0"

--- a/test/test-mda-models/aissemble-test-data-delivery-pyspark-model/pyproject.toml
+++ b/test/test-mda-models/aissemble-test-data-delivery-pyspark-model/pyproject.toml
@@ -21,7 +21,7 @@ aissemble-foundation-core-python = {path = "../../../foundation/aissemble-founda
 aissemble-extensions-data-delivery-spark-py = {path = "../../../extensions/extensions-data-delivery/aissemble-extensions-data-delivery-spark-py", develop = true}
 apache-sedona = "~1.7.1"
 kafka-python = "^2.0.2"
-krausening = ">=20"
+krausening = ">=21"
 pyspark = "3.5.5"
 jsonpickle = "^2.1.0"
 pyyaml = "^6.0"

--- a/test/test-mda-models/test-machine-learning-base-model/aissemble-machine-learning-training-base/pyproject.toml
+++ b/test/test-mda-models/test-machine-learning-base-model/aissemble-machine-learning-training-base/pyproject.toml
@@ -14,7 +14,7 @@ include = [{path = "src/aissemble_machine_learning_training_base/generated/**/*.
 [tool.poetry.dependencies]
 aissemble-foundation-pdp-client-python = {path = "../../../../foundation/foundation-security/aissemble-foundation-pdp-client-python", develop = true}
 aissemble-foundation-core-python = {path = "../../../../foundation/aissemble-foundation-core-python", develop = true}
-krausening = ">=20"
+krausening = ">=21"
 mlflow = ">=2.22.0"
 kafka-python = "^2.0.2"
 pandas = ">=1.5.0"

--- a/test/test-mda-models/test-machine-learning-model/aissemble-machine-learning-inference/pyproject.toml
+++ b/test/test-mda-models/test-machine-learning-model/aissemble-machine-learning-inference/pyproject.toml
@@ -18,7 +18,7 @@ mlflow = ">=2.22.0"
 fastapi = ">=0.95.0"
 uvicorn = { version = "^0.18.0", extras = ["standard"]}
 grpcio = "^1.50.0"
-krausening = ">=20"
+krausening = ">=21"
 pandas = ">=1.5.0"
 
 [tool.poetry.group.dev.dependencies]

--- a/test/test-mda-models/test-machine-learning-model/aissemble-machine-learning-training/pyproject.toml
+++ b/test/test-mda-models/test-machine-learning-model/aissemble-machine-learning-training/pyproject.toml
@@ -19,7 +19,7 @@ aissemble-foundation-pdp-client-python = {path = "../../../../foundation/foundat
 onnxmltools = "^1.11.1"
 aissemble-foundation-core-python = {path = "../../../../foundation/aissemble-foundation-core-python", develop = true}
 aissemble-foundation-model-lineage = {path = "../../../../foundation/foundation-lineage/aissemble-foundation-model-lineage", develop = true}
-krausening = ">=20"
+krausening = ">=21"
 mlflow = ">=2.22.0"
 kafka-python = "^2.0.2"
 pandas = ">=1.5.0"


### PR DESCRIPTION
 - remove docker cache save/restore in CI
 - Add parallel build flag to CI build
 - Add extra replicas to docker k8s builder
 - Upgrade krausening, baton, and build-cache for better parallel support
 - Deconflict ITs by using dynamic ports
 - Add parallel build flag to archetype test
 - Make MDA model managers thread-safe
 - Ensure no baton migrations are needed for pyproject.toml templates
 - Remove spurious `RUN chown` in Spark worker docker template
 - Move report aggregator to separate profile to support parallel builds