### PR TITLE
[#795] set fixed helm unittest version in GH workflow

### DIFF
--- a/.github/actions/install_dependencies/action.yaml
+++ b/.github/actions/install_dependencies/action.yaml
@@ -40,7 +40,7 @@ runs:
       run: |
         echo "::group::Install Helm Unittest"
         echo "Updating helm unittest plugin to latest version..."
-        helm plugin install https://github.com/helm-unittest/helm-unittest.git
+        helm plugin install --version "1.0.1" https://github.com/helm-unittest/helm-unittest.git
         echo "::endgroup::"
     - name: Set up JDK 17
       uses: actions/setup-java@v4


### PR DESCRIPTION
Follow-on to also fix the version in the `install_dependencies` workflow file. (Didn't realize CI boot-strapped the plugin in before the Maven build ran.)