### PR TITLE
Add fork-safe pull request smoke build

### DIFF
--- a/.github/workflows/pr-smoke.yml
+++ b/.github/workflows/pr-smoke.yml
@@ -1,0 +1,45 @@
+name: PR Smoke Build
+
+on:
+  pull_request:
+    branches:
+      - dev
+    paths-ignore:
+      - "**/*.md"
+      - "docs/**"
+      - ".github/ISSUE_TEMPLATE/**"
+      - ".github/PULL_REQUEST_TEMPLATE*"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pr-smoke-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  smoke-build:
+    name: Fork-safe Maven smoke build
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Java 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+          cache: maven
+
+      - name: Make Maven wrapper executable
+        run: chmod +x ./mvnw
+
+      - name: Validate Maven project
+        run: ./mvnw -B -ntp validate -Pskip-docker
+
+      - name: Compile without tests
+        run: ./mvnw -B -ntp compile -DskipTests -Pskip-docker


### PR DESCRIPTION
Add a lightweight pull request validation workflow that runs on GitHub-hosted runners without requiring internal ARC runners, AWS cache credentials, Docker Hub credentials, PyPI tokens, or package publishing permissions.