### PR TITLE
chore: replace Bitnami image references with Soldevelo equivalents

### DIFF
--- a/extensions/extensions-helm/aissemble-mlflow-chart/values.yaml
+++ b/extensions/extensions-helm/aissemble-mlflow-chart/values.yaml
@@ -18,9 +18,9 @@ mlflow:
       category: Database
       images: |
         - name: os-shell
-          image: docker.io/bitnamilegacy/os-shell:12-debian-12-r43
+          image: docker.io/soldevelo/os-shell:12-debian-12-r2
         - name: postgres-exporter
-          image: docker.io/bitnamilegacy/postgres-exporter:0.17.1-debian-12-r6
+          image: docker.io/soldevelo/postgres-exporter:0.17.1-debian-12-r0
         - name: postgresql
           image: docker.io/bitnamilegacy/postgresql:17.4.0-debian-12-r17
   minio:
@@ -41,7 +41,7 @@ mlflow:
         - name: minio-client
           image: docker.io/bitnamilegacy/minio-client:2025.4.16-debian-12-r0
         - name: os-shell
-          image: docker.io/bitnamilegacy/os-shell:12-debian-12-r43
+          image: docker.io/soldevelo/os-shell:12-debian-12-r2
   run:
     enabled: false
   tracking:
@@ -76,4 +76,4 @@ mlflow:
       - name: mlflow
         image: docker.io/bitnamilegacy/mlflow:2.22.0-debian-12-r3
       - name: os-shell
-        image: docker.io/bitnamilegacy/os-shell:12-debian-12-r43
+        image: docker.io/soldevelo/os-shell:12-debian-12-r2

--- a/extensions/extensions-helm/extensions-helm-spark-infrastructure/aissemble-hive-metastore-service-chart/values.yaml
+++ b/extensions/extensions-helm/extensions-helm-spark-infrastructure/aissemble-hive-metastore-service-chart/values.yaml
@@ -41,7 +41,7 @@ mysql:
       - name: mysqld-exporter
         image: docker.io/bitnamilegacy/mysqld-exporter:0.15.1-debian-12-r17
       - name: os-shell
-        image: docker.io/bitnamilegacy/os-shell:12-debian-12-r22
+        image: docker.io/soldevelo/os-shell:12-debian-12-r2
 
 hive:
   dbType: "mysql"


### PR DESCRIPTION
## Why this change

Bitnami changed its container image distribution model on August 28, 2025, and public images no longer receive ongoing updates or security fixes.
[SolDevelo](https://hub.docker.com/u/soldevelo) images are free drop-in replacements built from [SolDevelo/containers](https://github.com/SolDevelo/containers), a fork of bitnami/containers that continues to provide actively maintained and publicly available images.

## Image replacements

- `bitnamilegacy/os-shell:12-debian-12-r43` → [`soldevelo/os-shell:12-debian-12-r2`](https://hub.docker.com/r/soldevelo/os-shell)
- `bitnamilegacy/postgres-exporter:0.17.1-debian-12-r6` → [`soldevelo/postgres-exporter:0.17.1-debian-12-r0`](https://hub.docker.com/r/soldevelo/postgres-exporter)
- `bitnamilegacy/os-shell:12-debian-12-r22` → [`soldevelo/os-shell:12-debian-12-r2`](https://hub.docker.com/r/soldevelo/os-shell)